### PR TITLE
int and float consistency maintained

### DIFF
--- a/optimade/converter/mongoconverter/mongo.py
+++ b/optimade/converter/mongoconverter/mongo.py
@@ -100,8 +100,7 @@ def cleanMongo(rawMongoDbQuery):
                     value = float(value)
                     rawMongoDbQuery[k] = value
                 except:
-                    f = value
-                f = value
+                    pass
         else:
             raise UnknownMongoDBQueryError("Unrecognized MongoDB Query \n {}".format(rawMongoDbQuery))
 

--- a/optimade/converter/mongoconverter/mongo.py
+++ b/optimade/converter/mongoconverter/mongo.py
@@ -93,7 +93,6 @@ def cleanMongo(rawMongoDbQuery):
             cleanMongo(value)
         elif(type(value) == str):
             try:
-                # TODO: convert to int if possible
                 value = int(value)
                 rawMongoDbQuery[k] = value
             except:

--- a/optimade/converter/mongoconverter/mongo.py
+++ b/optimade/converter/mongoconverter/mongo.py
@@ -93,9 +93,15 @@ def cleanMongo(rawMongoDbQuery):
             cleanMongo(value)
         elif(type(value) == str):
             try:
-                value = float(value)
-                rawMongoDbQuery[k] = float(value)
+                # TODO: convert to int if possible
+                value = int(value)
+                rawMongoDbQuery[k] = value
             except:
+                try:
+                    value = float(value)
+                    rawMongoDbQuery[k] = value
+                except:
+                    f = value
                 f = value
         else:
             raise UnknownMongoDBQueryError("Unrecognized MongoDB Query \n {}".format(rawMongoDbQuery))


### PR DESCRIPTION
The problem originally was that the numbers will always become a float because i had to convert everything to a string in order for the pql library. 

Now if user entered a float, it will be a float in the output query, if user entered int, it will be int in the output query
ex:
$ mongoconverter "filter=a<1.0"
{'a': {'$lt': 1.0}}
$ mongoconverter "filter=a<1"
{'a': {'$lt': 1}}
$ mongoconverter "filter=a<-1"
{'a': {'$lt': -1}}
$ mongoconverter "filter=a<-1.0"
{'a': {'$lt': -1.0}}