### PR TITLE
Added JSON diff test

### DIFF
--- a/.ci/diff_spec.sh
+++ b/.ci/diff_spec.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+diff=$(jsondiff openapi.json local_openapi.json);
+if [ ! "$diff" = "{}" ]; then 
+    echo -e "Generated OpenAPI spec did not match committed version. Diff:\n$diff"; 
+exit 1;
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,6 @@ script:
    - pytest
    - openapi-spec-validator openapi.json
      # start server to generate schema then kill it
-   - timeout 0.5 ./run.sh
+   - timeout 2 ./run.sh; if [ $? -eq 124 ] then; return 0; else return 1; fi
      # check whether generated schema matches the committed version
-   - diff=$(jsondiff openapi.json local_openapi.json); \
-     if [ ! "$diff" = "{}" ]; then \
-        echo "Generate OpenAPI spec did not match committed version. Diff:\n $diff"; \
-        return 1; \
-     fi
+   - ./diff_spec.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,18 @@ services:
 language: python
 python:
   - "3.6"
-script:
+install:
    - pip install -e .
    - pip install -r requirements.txt
    - pip install -r requirements-optional.txt
+script:
    - pytest
    - openapi-spec-validator openapi.json
+     # start server to generate schema then kill it
+   - timeout 0.5 ./run.sh
+     # check whether generated schema matches the committed version
+   - diff=$(jsondiff openapi.json local_openapi.json); \
+     if [ ! "$diff" = "{}" ]; then \
+        echo "Generate OpenAPI spec did not match committed version. Diff:\n $diff"; \
+        return 1; \
+     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,6 @@ script:
    - pytest
    - openapi-spec-validator openapi.json
      # start server to generate schema then kill it
-   - timeout 2 ./run.sh; if [ $? -eq 124 ] then; return 0; else return 1; fi
+   - timeout 2 ./run.sh; if [ $? -eq 124 ]; then return 0; else return 1; fi
      # check whether generated schema matches the committed version
-   - ./diff_spec.sh
+   - .ci/diff_spec.sh

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,4 +1,6 @@
+# Extra packages required to test the tools
 invoke==1.0.0
 openapi-spec-validator==0.2.7
 twine==1.11.0
 pytest==4.0.0
+jsondiff==1.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+# Extra packages required to install and use the tools
 fastapi[all]==0.28.0
 lark-parser==0.5.6
 mongogrant==0.2.2

--- a/setup.py
+++ b/setup.py
@@ -23,10 +23,14 @@ setup(
         "mongomock>=3.16",
         "fastapi[all]",
     ],
-    extras_require = {
+    extras_require={
         "task_running": ["invoke", "twine"],
     },
-    tests_require=["pytest>=3.6", "openapi-spec-validator"],
+    tests_require=[
+        "pytest>=3.6",
+        "openapi-spec-validator",
+        "jsondiff"
+    ],
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Programming Language :: Python :: 3',


### PR DESCRIPTION
To enforce consistency between Python generated and committed OpenAPI JSON, if the json diff is not null (i.e. "{}"), the CI will fail.