### PR TITLE
add openapi_diff to travis

### DIFF
--- a/.ci/json_diff.sh
+++ b/.ci/json_diff.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 diff=$(jsondiff openapi.json local_openapi.json);
+
 if [ ! "$diff" = "{}" ]; then 
     echo -e "Generated OpenAPI spec did not match committed version. Diff:\n$diff"; 
 exit 1;

--- a/.ci/openapi_diff.sh
+++ b/.ci/openapi_diff.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Note: This returns exit code 0, if the two specs agree, otherwise exit code 1
+docker run -t -v $(pwd):/specs:ro quen2404/openapi-diff /specs/openapi.json /specs/local_openapi.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 services:
   - mongodb
+  - docker
 language: python
 python:
   - "3.6"
@@ -7,10 +8,11 @@ install:
    - pip install -e .
    - pip install -r requirements.txt
    - pip install -r requirements-optional.txt
+   - docker pull quen2404/openapi-diff
 script:
    - pytest
    - openapi-spec-validator openapi.json
      # start server to generate schema then kill it
    - timeout 2 ./run.sh; if [ $? -eq 124 ]; then return 0; else return 1; fi
      # check whether generated schema matches the committed version
-   - .ci/diff_spec.sh
+   - .ci/openapi_diff.sh


### PR DESCRIPTION
slightly more readable diff - example output:
```
$ docker run -t   -v $(pwd):/specs:ro   quen2404/openapi-diff /specs/open2.json /specs/openapi.json
==========================================================================
==                            API CHANGE LOG                            ==
==========================================================================
                               OPTiMaDe API
--------------------------------------------------------------------------
--                            What's Changed                            --
--------------------------------------------------------------------------
- GET    /structures
  Parameter:
    - Changed filter in query
  Return Type:
    - Changed 200 OK
      Media types:
        - Changed application/json
          Schema: Backward compatible
--------------------------------------------------------------------------
--                                Result                                --
--------------------------------------------------------------------------
                   API changes are backward compatible
--------------------------------------------------------------------------
```