### PR TITLE
Some minor fixes

### DIFF
--- a/optimade/filtertransformers/tests/test_transformer.py
+++ b/optimade/filtertransformers/tests/test_transformer.py
@@ -2,7 +2,7 @@ import itertools
 from unittest import TestCase
 import uuid
 
-from pymongo import MongoClient
+from mongomock import MongoClient
 
 from optimade.filterparser import LarkParser
 from optimade.filtertransformers.mongo import MongoTransformer

--- a/optimade/server/models/structures.py
+++ b/optimade/server/models/structures.py
@@ -260,7 +260,7 @@ the elements in this list each refer to the direction of the corresponding entry
 """,
     )
 
-    lattice_types: Optional[List[conlist(len_eq=3)]] = Schema(
+    lattice_vectors: Optional[List[conlist(len_eq=3)]] = Schema(
         ...,
         description="""List of three lattice vectors in Cartesian coordinates,
 in ångströms (Å).


### PR DESCRIPTION
- Fixed a typo in our version of the schema for the field name `lattice_types` -> `lattice_vectors`.
- Switched the final test that needed a mongo server running to `mongomock` (I assume this is what we want @dwinston ) 