### PR TITLE
Fix data_returned and data_available

### DIFF
--- a/optimade/server/entry_collections.py
+++ b/optimade/server/entry_collections.py
@@ -46,7 +46,7 @@ class EntryCollection(Collection):  # pylint: disable=inherit-non-class
     @abstractmethod
     def find(
         self, params: EntryListingQueryParams
-    ) -> Tuple[List[EntryResource], NonnegativeInt, bool, NonnegativeInt, set]:
+    ) -> Tuple[List[EntryResource], NonnegativeInt, bool, set]:
         """
         Fetches results and indicates if more data is available.
 
@@ -56,7 +56,7 @@ class EntryCollection(Collection):  # pylint: disable=inherit-non-class
             params (EntryListingQueryParams): entry listing URL query params
 
         Returns:
-            Tuple[List[Entry], NonnegativeInt, bool, NonnegativeInt, set]: (results, data_returned, more_data_available, data_available, fields)
+            Tuple[List[Entry], NonnegativeInt, bool, set]: (results, data_returned, more_data_available, fields)
 
         """
 
@@ -99,7 +99,7 @@ class MongoCollection(EntryCollection):
 
     def find(
         self, params: Union[EntryListingQueryParams, SingleEntryQueryParams]
-    ) -> Tuple[List[EntryResource], NonnegativeInt, bool, NonnegativeInt, set]:
+    ) -> Tuple[List[EntryResource], NonnegativeInt, bool, set]:
         criteria = self._parse_params(params)
 
         all_fields = criteria.pop("fields")
@@ -129,13 +129,7 @@ class MongoCollection(EntryCollection):
                 )
             results = results[0] if results else None
 
-        return (
-            results,
-            data_returned,
-            more_data_available,
-            self.count(),  # data_available
-            all_fields - fields,
-        )
+        return results, data_returned, more_data_available, all_fields - fields
 
     def _alias_filter(self, filter_: dict) -> dict:
         res = {}

--- a/optimade/server/entry_collections.py
+++ b/optimade/server/entry_collections.py
@@ -83,9 +83,6 @@ class MongoCollection(EntryCollection):
             version=(0, 10, 0), variant="default"
         )  # The NewMongoTransformer only supports v0.10.0 as the latest grammar
 
-        # "Cache"
-        self._data_available: int = None
-
     def __len__(self):
         return self.collection.estimated_document_count()
 
@@ -99,12 +96,6 @@ class MongoCollection(EntryCollection):
         if "filter" not in kwargs:  # "filter" is needed for count_documents()
             kwargs["filter"] = {}
         return self.collection.count_documents(**kwargs)
-
-    @property
-    def data_available(self) -> int:
-        if self._data_available is None:
-            self._data_available = self.count()
-        return self._data_available
 
     def find(
         self, params: Union[EntryListingQueryParams, SingleEntryQueryParams]
@@ -142,7 +133,7 @@ class MongoCollection(EntryCollection):
             results,
             data_returned,
             more_data_available,
-            self.data_available,
+            self.count(),  # data_available
             all_fields - fields,
         )
 

--- a/optimade/server/entry_collections.py
+++ b/optimade/server/entry_collections.py
@@ -46,7 +46,7 @@ class EntryCollection(Collection):  # pylint: disable=inherit-non-class
     @abstractmethod
     def find(
         self, params: EntryListingQueryParams
-    ) -> Tuple[List[EntryResource], bool, NonnegativeInt, set]:
+    ) -> Tuple[List[EntryResource], NonnegativeInt, bool, NonnegativeInt, set]:
         """
         Fetches results and indicates if more data is available.
 
@@ -56,7 +56,7 @@ class EntryCollection(Collection):  # pylint: disable=inherit-non-class
             params (EntryListingQueryParams): entry listing URL query params
 
         Returns:
-            Tuple[List[Entry], bool, NonnegativeInt, set]: (results, more_data_available, data_available, fields)
+            Tuple[List[Entry], NonnegativeInt, bool, NonnegativeInt, set]: (results, data_returned, more_data_available, data_available, fields)
 
         """
 
@@ -83,6 +83,9 @@ class MongoCollection(EntryCollection):
             version=(0, 10, 0), variant="default"
         )  # The NewMongoTransformer only supports v0.10.0 as the latest grammar
 
+        # "Cache"
+        self._data_available: int = None
+
     def __len__(self):
         return self.collection.estimated_document_count()
 
@@ -93,40 +96,55 @@ class MongoCollection(EntryCollection):
         for k in list(kwargs.keys()):
             if k not in ("filter", "skip", "limit", "hint", "maxTimeMS"):
                 del kwargs[k]
+        if "filter" not in kwargs:  # "filter" is needed for count_documents()
+            kwargs["filter"] = {}
         return self.collection.count_documents(**kwargs)
+
+    @property
+    def data_available(self) -> int:
+        if self._data_available is None:
+            self._data_available = self.count()
+        return self._data_available
 
     def find(
         self, params: Union[EntryListingQueryParams, SingleEntryQueryParams]
-    ) -> Tuple[List[EntryResource], bool, NonnegativeInt, set]:
+    ) -> Tuple[List[EntryResource], NonnegativeInt, bool, NonnegativeInt, set]:
         criteria = self._parse_params(params)
-        if isinstance(params, EntryListingQueryParams):
-            criteria_nolimit = criteria.copy()
-            del criteria_nolimit["limit"]
-            nresults_now = self.count(**criteria)
-            nresults_total = self.count(**criteria_nolimit)
-            more_data_available = nresults_now < nresults_total
-            data_available = nresults_total
-        else:
-            more_data_available = False
-            data_available = self.count(**criteria)
-            if data_available > 1:
-                raise HTTPException(
-                    status_code=404,
-                    detail=f"Instead of a single entry, {data_available} entries were found",
-                )
+
         all_fields = criteria.pop("fields")
         if getattr(params, "response_fields", False):
             fields = set(params.response_fields.split(","))
         else:
             fields = all_fields.copy()
+
         results = []
         for doc in self.collection.find(**criteria):
             results.append(self.resource_cls(**self.resource_mapper.map_back(doc)))
 
-        if isinstance(params, SingleEntryQueryParams):
+        if isinstance(params, EntryListingQueryParams):
+            nresults_now = len(results)
+            criteria_nolimit = criteria.copy()
+            criteria_nolimit.pop("limit", None)
+            data_returned = self.count(**criteria_nolimit)
+            more_data_available = nresults_now < data_returned
+        else:
+            # SingleEntryQueryParams, e.g., /structures/{entry_id}
+            data_returned = 1
+            more_data_available = False
+            if len(results) > 1:
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"Instead of a single entry, {len(results)} entries were found",
+                )
             results = results[0] if results else None
 
-        return results, more_data_available, data_available, all_fields - fields
+        return (
+            results,
+            data_returned,
+            more_data_available,
+            self.data_available,
+            all_fields - fields,
+        )
 
     def _alias_filter(self, filter_: dict) -> dict:
         res = {}

--- a/optimade/server/tests/test_server.py
+++ b/optimade/server/tests/test_server.py
@@ -200,171 +200,173 @@ class FilterTests(unittest.TestCase):
     def test_custom_field(self):
         request = '/structures?filter=_exmpl__mp_chemsys="Ac"'
         expected_ids = ["mpf_1"]
-        self._check_response(request, expected_ids)
+        self._check_response(request, expected_ids, len(expected_ids))
 
     def test_id(self):
         request = "/structures?filter=id=mpf_2"
         expected_ids = ["mpf_2"]
-        self._check_response(request, expected_ids)
+        self._check_response(request, expected_ids, len(expected_ids))
 
     def test_geq(self):
         request = "/structures?filter=nelements>=9"
         expected_ids = ["mpf_3819"]
-        self._check_response(request, expected_ids)
+        self._check_response(request, expected_ids, len(expected_ids))
 
     def test_gt(self):
         request = "/structures?filter=nelements>8"
         expected_ids = ["mpf_3819"]
-        self._check_response(request, expected_ids)
+        self._check_response(request, expected_ids, len(expected_ids))
 
     def test_gt_none(self):
         request = "/structures?filter=nelements>9"
         expected_ids = []
-        self._check_response(request, expected_ids)
+        self._check_response(request, expected_ids, len(expected_ids))
 
     def test_list_has(self):
         request = '/structures?filter=elements HAS "Ti"'
         expected_ids = ["mpf_3803", "mpf_3819"]
-        self._check_response(request, expected_ids)
+        self._check_response(request, expected_ids, len(expected_ids))
 
     def test_page_limit(self):
         request = '/structures?filter=elements HAS "Ac"&page_limit=2'
         expected_ids = ["mpf_1", "mpf_2"]
-        self._check_response(request, expected_ids)
+        expected_return = 6
+        self._check_response(request, expected_ids, expected_return)
 
         request = '/structures?page_limit=2&filter=elements HAS "Ac"'
         expected_ids = ["mpf_1", "mpf_2"]
-        self._check_response(request, expected_ids)
+        expected_return = 6
+        self._check_response(request, expected_ids, expected_return)
 
     @unittest.skip("Skipping HAS ALL until implemented in server code.")
     def test_list_has_all(self):
         request = '/structures?filter=elements HAS ALL "Ba","F","H","Mn","O","Re","Si"'
         expected_ids = ["mpf_3819"]
-        self._check_response(request, expected_ids)
+        self._check_response(request, expected_ids, len(expected_ids))
 
         request = '/structures?filter=elements HAS ALL "Re","Ti"'
         expected_ids = ["mpf_3819"]
-        self._check_response(request, expected_ids)
+        self._check_response(request, expected_ids, len(expected_ids))
 
     @unittest.skip("Skipping HAS ANY until implemented in server code.")
     def test_list_has_any(self):
         request = '/structures?filter=elements HAS ANY "Re","Ti"'
         expected_ids = ["mpf_3819"]
-        self._check_response(request, expected_ids)
+        self._check_response(request, expected_ids, len(expected_ids))
 
     def test_list_length_basic(self):
         request = "/structures?filter=LENGTH elements = 9"
         expected_ids = ["mpf_3819"]
-        self._check_response(request, expected_ids)
+        self._check_response(request, expected_ids, len(expected_ids))
 
     @unittest.skip("Skipping LENGTH until implemented in server code.")
     def test_list_length(self):
         request = "/structures?filter=LENGTH elements = 9"
         expected_ids = ["mpf_3819"]
-        self._check_response(request, expected_ids)
+        self._check_response(request, expected_ids, len(expected_ids))
 
         request = "/structures?filter=LENGTH elements >= 9"
         expected_ids = ["mpf_3819"]
-        self._check_response(request, expected_ids)
+        self._check_response(request, expected_ids, len(expected_ids))
 
         request = "/structures?filter=LENGTH structure_features > 0"
         expected_ids = []
-        self._check_response(request, expected_ids)
+        self._check_response(request, expected_ids, len(expected_ids))
 
     @unittest.skip("Skipping HAS ONLY until implemented in server code.")
     def test_list_has_only(self):
         request = '/structures?filter=elements HAS ONLY "Ac"'
         expected_ids = ["mpf_1"]
-        self._check_response(request, expected_ids)
+        self._check_response(request, expected_ids, len(expected_ids))
 
     @unittest.skip("Skipping correlated list query until implemented in server code.")
     def test_list_correlated(self):
         request = '/structures?filter=elements:elements_ratios HAS "Ag":"0.2"'
         expected_ids = ["mpf_259"]
-        self._check_response(request, expected_ids)
+        self._check_response(request, expected_ids, len(expected_ids))
 
     def test_is_known(self):
         request = "/structures?filter=nsites IS KNOWN AND nsites>=44"
         expected_ids = ["mpf_551", "mpf_3803", "mpf_3819"]
-        self._check_response(request, expected_ids)
+        self._check_response(request, expected_ids, len(expected_ids))
 
         request = "/structures?filter=lattice_vectors IS KNOWN AND nsites>=44"
         expected_ids = ["mpf_551", "mpf_3803", "mpf_3819"]
-        self._check_response(request, expected_ids)
+        self._check_response(request, expected_ids, len(expected_ids))
 
     def test_aliased_is_known(self):
         request = "/structures?filter=id IS KNOWN AND nsites>=44"
         expected_ids = ["mpf_551", "mpf_3803", "mpf_3819"]
-        self._check_response(request, expected_ids)
+        self._check_response(request, expected_ids, len(expected_ids))
 
         request = "/structures?filter=chemical_formula_reduced IS KNOWN AND nsites>=44"
         expected_ids = ["mpf_551", "mpf_3803", "mpf_3819"]
-        self._check_response(request, expected_ids)
+        self._check_response(request, expected_ids, len(expected_ids))
 
         request = (
             "/structures?filter=chemical_formula_descriptive IS KNOWN AND nsites>=44"
         )
         expected_ids = ["mpf_551", "mpf_3803", "mpf_3819"]
-        self._check_response(request, expected_ids)
+        self._check_response(request, expected_ids, len(expected_ids))
 
     def test_aliased_fields(self):
         request = '/structures?filter=chemical_formula_anonymous="A"'
         expected_ids = ["mpf_1", "mpf_200"]
-        self._check_response(request, expected_ids)
+        self._check_response(request, expected_ids, len(expected_ids))
 
         request = '/structures?filter=chemical_formula_anonymous CONTAINS "A2BC"'
         expected_ids = ["mpf_2", "mpf_3", "mpf_110"]
-        self._check_response(request, expected_ids)
+        self._check_response(request, expected_ids, len(expected_ids))
 
     def test_string_contains(self):
         request = '/structures?filter=chemical_formula_descriptive CONTAINS "c2Ag"'
         expected_ids = ["mpf_3", "mpf_2"]
-        self._check_response(request, expected_ids)
+        self._check_response(request, expected_ids, len(expected_ids))
 
     def test_string_start(self):
         request = (
             '/structures?filter=chemical_formula_descriptive STARTS WITH "Ag2CSNCl"'
         )
         expected_ids = ["mpf_259"]
-        self._check_response(request, expected_ids)
+        self._check_response(request, expected_ids, len(expected_ids))
 
     def test_string_end(self):
         request = '/structures?filter=chemical_formula_descriptive ENDS WITH "NClO4"'
         expected_ids = ["mpf_259"]
-        self._check_response(request, expected_ids)
+        self._check_response(request, expected_ids, len(expected_ids))
 
     def test_list_has_and(self):
         request = '/structures?filter=elements HAS "Ac" AND nelements=1'
         expected_ids = ["mpf_1"]
-        self._check_response(request, expected_ids)
+        self._check_response(request, expected_ids, len(expected_ids))
 
     def test_not_or_and_precedence(self):
         request = '/structures?filter=NOT elements HAS "Ac" AND nelements=1'
         expected_ids = ["mpf_200"]
-        self._check_response(request, expected_ids)
+        self._check_response(request, expected_ids, len(expected_ids))
 
         request = '/structures?filter=nelements=1 AND NOT elements HAS "Ac"'
         expected_ids = ["mpf_200"]
-        self._check_response(request, expected_ids)
+        self._check_response(request, expected_ids, len(expected_ids))
 
         request = '/structures?filter=NOT elements HAS "Ac" AND nelements=1 OR nsites=1'
         expected_ids = ["mpf_1", "mpf_200"]
-        self._check_response(request, expected_ids)
+        self._check_response(request, expected_ids, len(expected_ids))
 
         request = '/structures?filter=elements HAS "Ac" AND nelements>1 AND nsites=1'
         expected_ids = []
-        self._check_response(request, expected_ids)
+        self._check_response(request, expected_ids, len(expected_ids))
 
     def test_brackets(self):
         request = '/structures?filter=elements HAS "Ac" AND nelements=1 OR nsites=1'
         expected_ids = ["mpf_200", "mpf_1"]
-        self._check_response(request, expected_ids)
+        self._check_response(request, expected_ids, len(expected_ids))
 
         request = '/structures?filter=(elements HAS "Ac" AND nelements=1) OR (elements HAS "Ac" AND nsites=1)'
         expected_ids = ["mpf_1"]
-        self._check_response(request, expected_ids)
+        self._check_response(request, expected_ids, len(expected_ids))
 
-    def _check_response(self, request, expected_id):
+    def _check_response(self, request, expected_ids, expected_return):
         try:
             response = self.client.get(request)
             self.assertEqual(
@@ -372,8 +374,8 @@ class FilterTests(unittest.TestCase):
             )
             response = response.json()
             response_ids = [struct["id"] for struct in response["data"]]
-            self.assertEqual(sorted(expected_id), sorted(response_ids))
-            self.assertEqual(response["meta"]["data_returned"], len(expected_id))
+            self.assertEqual(sorted(expected_ids), sorted(response_ids))
+            self.assertEqual(response["meta"]["data_returned"], expected_return)
         except Exception as exc:
             print("Request attempted:")
             print(f"http://localhost:5000{request}")

--- a/optimade/server/utils.py
+++ b/optimade/server/utils.py
@@ -120,9 +120,7 @@ def get_entries(
     params: EntryListingQueryParams,
 ) -> EntryResponseMany:
     """Generalized /{entry} endpoint getter"""
-    results, data_returned, more_data_available, data_available, fields = collection.find(
-        params
-    )
+    results, data_returned, more_data_available, fields = collection.find(params)
 
     if more_data_available:
         parse_result = urllib.parse.urlparse(str(request.url))
@@ -142,7 +140,10 @@ def get_entries(
         links=links,
         data=results,
         meta=meta_values(
-            str(request.url), data_returned, data_available, more_data_available
+            url=str(request.url),
+            data_returned=data_returned,
+            data_available=len(collection),
+            more_data_available=more_data_available,
         ),
     )
 
@@ -155,9 +156,7 @@ def get_single_entry(
     params: SingleEntryQueryParams,
 ) -> EntryResponseOne:
     params.filter = f'id="{entry_id}"'
-    results, data_returned, more_data_available, data_available, fields = collection.find(
-        params
-    )
+    results, data_returned, more_data_available, fields = collection.find(params)
 
     if more_data_available:
         raise StarletteHTTPException(
@@ -174,7 +173,10 @@ def get_single_entry(
         links=links,
         data=results,
         meta=meta_values(
-            str(request.url), data_returned, data_available, more_data_available
+            url=str(request.url),
+            data_returned=data_returned,
+            data_available=len(collection),
+            more_data_available=more_data_available,
         ),
     )
 

--- a/optimade/server/utils.py
+++ b/optimade/server/utils.py
@@ -120,7 +120,9 @@ def get_entries(
     params: EntryListingQueryParams,
 ) -> EntryResponseMany:
     """Generalized /{entry} endpoint getter"""
-    results, more_data_available, data_available, fields = collection.find(params)
+    results, data_returned, more_data_available, data_available, fields = collection.find(
+        params
+    )
 
     if more_data_available:
         parse_result = urllib.parse.urlparse(str(request.url))
@@ -140,7 +142,7 @@ def get_entries(
         links=links,
         data=results,
         meta=meta_values(
-            str(request.url), len(results), data_available, more_data_available
+            str(request.url), data_returned, data_available, more_data_available
         ),
     )
 
@@ -153,7 +155,9 @@ def get_single_entry(
     params: SingleEntryQueryParams,
 ) -> EntryResponseOne:
     params.filter = f'id="{entry_id}"'
-    results, more_data_available, data_available, fields = collection.find(params)
+    results, data_returned, more_data_available, data_available, fields = collection.find(
+        params
+    )
 
     if more_data_available:
         raise StarletteHTTPException(
@@ -165,8 +169,6 @@ def get_single_entry(
 
     if fields and results is not None:
         results = handle_response_fields(results, fields)[0]
-
-    data_returned = 1 if results else 0
 
     return response(
         links=links,

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,4 @@
 filterwarnings =
     ignore:.*PY_SSIZE_T_CLEAN will be required for '#' formats.*:DeprecationWarning
     ignore:.*"@coroutine" decorator is deprecated since Python 3.8, use "async def" instead.*:DeprecationWarning
+    ignore:.*Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated.*:DeprecationWarning


### PR DESCRIPTION
See the OPTiMaDe spec issue [here](https://github.com/Materials-Consortia/OPTiMaDe/issues/208).

`data_returned` is defined as the total number of data that can be returned using the passed parameters.
`data_available` is defined as the total number of data available of a certain type at any time.

`data_available` is saved "lazily", i.e., when the first request has been made, and then it is stored as a property for the specific collection instance.

Tests have been slightly updated to account for the fix.
Perhaps the expected `data_returned` value should be hard-coded?