### PR TITLE
Add /links

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -50,7 +50,8 @@
             "schema": {
               "title": "Filter",
               "type": "string",
-              "description": "See [the full and latest OPTiMaDe spec](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst) for filter query syntax.\n\nExample: `chemical_formula = \"Al\" OR (prototype_formula = \"AB\" AND elements HAS Si, Al, O)`.\n"
+              "description": "See [the full and latest OPTiMaDe spec](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst) for filter query syntax.\n\nExample: `chemical_formula = \"Al\" OR (prototype_formula = \"AB\" AND elements HAS Si, Al, O)`.\n",
+              "default": ""
             },
             "name": "filter",
             "in": "query"
@@ -70,7 +71,8 @@
             "schema": {
               "title": "Email_Address",
               "type": "string",
-              "format": "email"
+              "format": "email",
+              "default": ""
             },
             "name": "email_address",
             "in": "query"
@@ -79,7 +81,8 @@
             "required": false,
             "schema": {
               "title": "Response_Fields",
-              "type": "string"
+              "type": "string",
+              "default": ""
             },
             "name": "response_fields",
             "in": "query"
@@ -88,7 +91,8 @@
             "required": false,
             "schema": {
               "title": "Sort",
-              "type": "string"
+              "type": "string",
+              "default": ""
             },
             "name": "sort",
             "in": "query"
@@ -224,7 +228,8 @@
             "schema": {
               "title": "Email_Address",
               "type": "string",
-              "format": "email"
+              "format": "email",
+              "default": ""
             },
             "name": "email_address",
             "in": "query"
@@ -233,7 +238,8 @@
             "required": false,
             "schema": {
               "title": "Response_Fields",
-              "type": "string"
+              "type": "string",
+              "default": ""
             },
             "name": "response_fields",
             "in": "query"
@@ -285,7 +291,8 @@
             "schema": {
               "title": "Filter",
               "type": "string",
-              "description": "See [the full and latest OPTiMaDe spec](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst) for filter query syntax.\n\nExample: `chemical_formula = \"Al\" OR (prototype_formula = \"AB\" AND elements HAS Si, Al, O)`.\n"
+              "description": "See [the full and latest OPTiMaDe spec](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst) for filter query syntax.\n\nExample: `chemical_formula = \"Al\" OR (prototype_formula = \"AB\" AND elements HAS Si, Al, O)`.\n",
+              "default": ""
             },
             "name": "filter",
             "in": "query"
@@ -305,7 +312,8 @@
             "schema": {
               "title": "Email_Address",
               "type": "string",
-              "format": "email"
+              "format": "email",
+              "default": ""
             },
             "name": "email_address",
             "in": "query"
@@ -314,7 +322,8 @@
             "required": false,
             "schema": {
               "title": "Response_Fields",
-              "type": "string"
+              "type": "string",
+              "default": ""
             },
             "name": "response_fields",
             "in": "query"
@@ -323,7 +332,8 @@
             "required": false,
             "schema": {
               "title": "Sort",
-              "type": "string"
+              "type": "string",
+              "default": ""
             },
             "name": "sort",
             "in": "query"
@@ -459,7 +469,8 @@
             "schema": {
               "title": "Email_Address",
               "type": "string",
-              "format": "email"
+              "format": "email",
+              "default": ""
             },
             "name": "email_address",
             "in": "query"
@@ -468,9 +479,170 @@
             "required": false,
             "schema": {
               "title": "Response_Fields",
-              "type": "string"
+              "type": "string",
+              "default": ""
             },
             "name": "response_fields",
+            "in": "query"
+          }
+        ]
+      }
+    },
+    "/links": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response_Get_Links_Links_Get",
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/LinksResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorResponse"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Links"
+        ],
+        "summary": "Get Links",
+        "operationId": "get_links_links_get",
+        "parameters": [
+          {
+            "description": "See [the full and latest OPTiMaDe spec](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst) for filter query syntax.\n\nExample: `chemical_formula = \"Al\" OR (prototype_formula = \"AB\" AND elements HAS Si, Al, O)`.\n",
+            "required": false,
+            "schema": {
+              "title": "Filter",
+              "type": "string",
+              "description": "See [the full and latest OPTiMaDe spec](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst) for filter query syntax.\n\nExample: `chemical_formula = \"Al\" OR (prototype_formula = \"AB\" AND elements HAS Si, Al, O)`.\n",
+              "default": ""
+            },
+            "name": "filter",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "title": "Response_Format",
+              "type": "string",
+              "default": "json"
+            },
+            "name": "response_format",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "title": "Email_Address",
+              "type": "string",
+              "format": "email",
+              "default": ""
+            },
+            "name": "email_address",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "title": "Response_Fields",
+              "type": "string",
+              "default": ""
+            },
+            "name": "response_fields",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "title": "Sort",
+              "type": "string",
+              "default": ""
+            },
+            "name": "sort",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "title": "Page_Limit",
+              "minimum": 0.0,
+              "type": "integer",
+              "default": 500
+            },
+            "name": "page_limit",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "title": "Page_Offset",
+              "minimum": 0.0,
+              "type": "integer",
+              "default": 0
+            },
+            "name": "page_offset",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "title": "Page_Page",
+              "minimum": 0.0,
+              "type": "integer",
+              "default": 0
+            },
+            "name": "page_page",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "title": "Page_Cursor",
+              "minimum": 0.0,
+              "type": "integer",
+              "default": 0
+            },
+            "name": "page_cursor",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "title": "Page_Above",
+              "minimum": 0.0,
+              "type": "integer",
+              "default": 0
+            },
+            "name": "page_above",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "title": "Page_Below",
+              "minimum": 0.0,
+              "type": "integer",
+              "default": 0
+            },
+            "name": "page_below",
             "in": "query"
           }
         ]
@@ -593,8 +765,25 @@
       "Attributes": {
         "title": "Attributes",
         "type": "object",
-        "properties": {},
-        "description": "Members of the attributes object (\"attributes\") represent information about the resource object in which it's defined.\nThe keys for Attributes must NOT be:\n    relationships\n    links\n    id\n    type"
+        "properties": {
+          "relationships": {
+            "title": "Relationships",
+            "description": "Not allowed key"
+          },
+          "links": {
+            "title": "Links",
+            "description": "Not allowed key"
+          },
+          "id": {
+            "title": "Id",
+            "description": "Not allowed key"
+          },
+          "type": {
+            "title": "Type",
+            "description": "Not allowed key"
+          }
+        },
+        "description": "Members of the attributes object (\"attributes\") represent information about the resource object in which it's defined.\nThe keys for Attributes MUST NOT be:\n    relationships\n    links\n    id\n    type"
       },
       "AvailableApiVersion": {
         "title": "AvailableApiVersion",
@@ -737,6 +926,27 @@
         },
         "description": "Resource objects appear in a JSON:API document to represent resources."
       },
+      "BaseResource": {
+        "title": "BaseResource",
+        "required": [
+          "id",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string",
+            "description": "Resource ID"
+          },
+          "type": {
+            "title": "Type",
+            "type": "string",
+            "description": "Resource type"
+          }
+        },
+        "description": "Minimum requirements to represent a Resource"
+      },
       "EntryInfoProperty": {
         "title": "EntryInfoProperty",
         "required": [
@@ -856,6 +1066,134 @@
           }
         },
         "description": "errors are not allowed"
+      },
+      "EntryRelationships": {
+        "title": "EntryRelationships",
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "description": "Not allowed key"
+          },
+          "type": {
+            "title": "Type",
+            "description": "Not allowed key"
+          },
+          "references": {
+            "title": "References",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ReferenceRelationship"
+              }
+            ],
+            "description": "Object containing links to relationships with entries of the `references` type."
+          },
+          "structures": {
+            "title": "Structures",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/StructureRelationship"
+              }
+            ],
+            "description": "Object containing links to relationships with entries of the `structures` type."
+          }
+        },
+        "description": "This model wraps the JSON API Relationships to include type-specific top level keys. "
+      },
+      "EntryResource": {
+        "title": "EntryResource",
+        "required": [
+          "id",
+          "type",
+          "attributes"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string",
+            "description": "An entry's ID as defined in section `Definition of Terms`_.\n- **Type**: string.\n- **Requirements/Conventions**:\n\n  - **Response**: REQUIRED in the response unless explicitly excluded.\n  - **Query**: MUST be a queryable property with support for all mandatory filter operators.\n  - See section `Definition of Terms`_.\n\n- **Examples**:\n\n  - :val:`\"db/1234567\"`\n  - :val:`\"cod/2000000\"`\n  - :val:`\"cod/2000000@1234567\"`\n  - :val:`\"nomad/L1234567890\"`\n  - :val:`\"42\"`"
+          },
+          "type": {
+            "title": "Type",
+            "type": "string",
+            "description": "The name of the type of an entry.\nAny entry MUST be able to be fetched using the `base URL <Base URL_>`_ type and ID at the url :endpoint:`<base URL>/<type>/<id>`.\n- **Type**: string.\n- **Requirements/Conventions**:\n\n  - **Response**: REQUIRED in the response unless explicitly excluded.\n  - **Query**: Support for queries on this property is OPTIONAL.\n    If supported, only a subset of string comparison operators MAY be supported.\n\n- **Requirements/Conventions**: MUST be an existing entry type.\n- **Example**: :val:`\"structures\"`"
+          },
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResourceLinks"
+              }
+            ],
+            "description": "a links object containing links related to the resource."
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Meta"
+              }
+            ],
+            "description": "a meta object containing non-standard meta-information about a resource that can not be represented as an attribute or relationship."
+          },
+          "attributes": {
+            "title": "Attributes",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EntryResourceAttributes"
+              }
+            ],
+            "description": "a dictionary, containing key-value pairs representing the entry's properties, except for type and id.\n\nDatabase-provider-specific properties need to include the database-provider-specific prefix\n(see appendix `Database-Provider-Specific Namespace Prefixes`_)."
+          },
+          "relationships": {
+            "title": "Relationships",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EntryRelationships"
+              }
+            ],
+            "description": "a dictionary containing references to other entries according to the description in section `Relationships`_\nencoded as `JSON API Relationships <https://jsonapi.org/format/1.0/#document-resource-object-relationships>`__.\nThe OPTIONAL human-readable description of the relationship MAY be provided in the :field:`description` field inside the :field:`meta` dictionary."
+          }
+        },
+        "description": "Resource objects appear in a JSON:API document to represent resources."
+      },
+      "EntryResourceAttributes": {
+        "title": "EntryResourceAttributes",
+        "required": [
+          "last_modified"
+        ],
+        "type": "object",
+        "properties": {
+          "relationships": {
+            "title": "Relationships",
+            "description": "Not allowed key"
+          },
+          "links": {
+            "title": "Links",
+            "description": "Not allowed key"
+          },
+          "id": {
+            "title": "Id",
+            "description": "Not allowed key"
+          },
+          "type": {
+            "title": "Type",
+            "description": "Not allowed key"
+          },
+          "immutable_id": {
+            "title": "Immutable_Id",
+            "type": "string",
+            "description": "The entry's immutable ID (e.g., an UUID).\nThis is important for databases having preferred IDs that point to \"the latest version\" of a record, but still offer access to older variants.\nThis ID maps to the version-specific record, in case it changes in the future.\n- **Type**: string.\n- **Requirements/Conventions**:\n\n  - **Response**: OPTIONAL in the response.\n  - **Query**: If present, MUST be a queryable property with support for all mandatory filter operators.\n\n- **Examples**:\n\n  - :val:`\"8bd3e750-b477-41a0-9b11-3a799f21b44f\"`\n  - :val:`\"fjeiwoj,54;@=%<>#32\"` (Strings that are not URL-safe are allowed.)"
+          },
+          "last_modified": {
+            "title": "Last_Modified",
+            "type": "string",
+            "description": "Date and time representing when the entry was last modified.\n- **Type**: timestamp.\n- **Requirements/Conventions**:\n\n  - **Response**: REQUIRED in the response unless explicitly excluded.\n  - **Query**: MUST be a queryable property with support for all mandatory filter operators.\n\n- **Example**:\n\n  - As part of JSON response format: :VAL:`\"2007-04-05T14:30Z\"`\n    (i.e., encoded as an `RFC 3339 Internet Date/Time Format <https://tools.ietf.org/html/rfc3339#section-5.6>`__ string.)",
+            "format": "date-time"
+          }
+        },
+        "description": "Contains key-value pairs representing the entry's properties."
       },
       "ErrorLinks": {
         "title": "ErrorLinks",
@@ -1133,6 +1471,195 @@
         },
         "description": "A link **MUST** be represented as either: a string containing the link's URL or a link object."
       },
+      "LinksResource": {
+        "title": "LinksResource",
+        "required": [
+          "id",
+          "type",
+          "attributes"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string",
+            "description": "An entry's ID as defined in section `Definition of Terms`_.\n- **Type**: string.\n- **Requirements/Conventions**:\n\n  - **Response**: REQUIRED in the response unless explicitly excluded.\n  - **Query**: MUST be a queryable property with support for all mandatory filter operators.\n  - See section `Definition of Terms`_.\n\n- **Examples**:\n\n  - :val:`\"db/1234567\"`\n  - :val:`\"cod/2000000\"`\n  - :val:`\"cod/2000000@1234567\"`\n  - :val:`\"nomad/L1234567890\"`\n  - :val:`\"42\"`"
+          },
+          "type": {
+            "title": "Type",
+            "type": "string",
+            "description": "MUST be either \"parent\", \"child\", or \"provider\". These objects are described in detail in sections Parent and Child Objects and Provider Objects."
+          },
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResourceLinks"
+              }
+            ],
+            "description": "a links object containing links related to the resource."
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Meta"
+              }
+            ],
+            "description": "a meta object containing non-standard meta-information about a resource that can not be represented as an attribute or relationship."
+          },
+          "attributes": {
+            "title": "Attributes",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LinksResourceAttributes"
+              }
+            ],
+            "description": "a dictionary containing key-value pairs representing the entry's properties."
+          },
+          "relationships": {
+            "title": "Relationships",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EntryRelationships"
+              }
+            ],
+            "description": "a dictionary containing references to other entries according to the description in section `Relationships`_\nencoded as `JSON API Relationships <https://jsonapi.org/format/1.0/#document-resource-object-relationships>`__.\nThe OPTIONAL human-readable description of the relationship MAY be provided in the :field:`description` field inside the :field:`meta` dictionary."
+          }
+        },
+        "description": "A Links endpoint resource object"
+      },
+      "LinksResourceAttributes": {
+        "title": "LinksResourceAttributes",
+        "required": [
+          "name",
+          "description"
+        ],
+        "type": "object",
+        "properties": {
+          "relationships": {
+            "title": "Relationships",
+            "description": "Not allowed key"
+          },
+          "links": {
+            "title": "Links",
+            "description": "Not allowed key"
+          },
+          "id": {
+            "title": "Id",
+            "description": "Not allowed key"
+          },
+          "type": {
+            "title": "Type",
+            "description": "Not allowed key"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string",
+            "description": "Human-readable name for the OPTiMaDe API implementation a client may provide in a list to an end-user."
+          },
+          "description": {
+            "title": "Description",
+            "type": "string",
+            "description": "Human-readable description for the OPTiMaDe API implementation a client may provide in a list to an end-user."
+          },
+          "base_url": {
+            "title": "Base_Url",
+            "anyOf": [
+              {
+                "minLength": 1,
+                "maxLength": 65536,
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Link"
+                  }
+                ]
+              }
+            ],
+            "description": "JSON API links object, pointing to the base URL for this implementation"
+          }
+        },
+        "description": "Links endpoint resource object attributes"
+      },
+      "LinksResponse": {
+        "title": "LinksResponse",
+        "required": [
+          "data",
+          "meta"
+        ],
+        "type": "object",
+        "properties": {
+          "data": {
+            "title": "Data",
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/LinksResource"
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              }
+            ]
+          },
+          "meta": {
+            "$ref": "#/components/schemas/ResponseMeta"
+          },
+          "errors": {
+            "title": "Errors",
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/optimade__models__jsonapi__Error"
+            },
+            "description": "A list of errors"
+          },
+          "included": {
+            "title": "Included",
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/EntryResource"
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              }
+            ]
+          },
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToplevelLinks"
+              }
+            ],
+            "description": "Links associated with the primary data"
+          },
+          "jsonapi": {
+            "title": "Jsonapi",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JsonApi"
+              }
+            ],
+            "description": "Information about the JSON API used"
+          }
+        },
+        "description": "errors are not allowed"
+      },
       "Meta": {
         "title": "Meta",
         "type": "object",
@@ -1227,6 +1754,50 @@
         },
         "description": "Information on the database provider of the implementation."
       },
+      "ReferenceRelationship": {
+        "title": "ReferenceRelationship",
+        "type": "object",
+        "properties": {
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RelationshipLinks"
+              }
+            ],
+            "description": "a links object containing at least one of the following: self, related"
+          },
+          "data": {
+            "title": "Data",
+            "anyOf": [
+              {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BaseResource"
+                  }
+                ]
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/BaseResource"
+                }
+              }
+            ],
+            "description": "Resource linkage"
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Meta"
+              }
+            ],
+            "description": "a meta object that contains non-standard meta-information about the relationship."
+          }
+        },
+        "description": "Representation references from the resource object in which it\u2019s defined to other resource objects."
+      },
       "ReferenceResource": {
         "title": "ReferenceResource",
         "required": [
@@ -1270,7 +1841,7 @@
             "title": "Relationships",
             "allOf": [
               {
-                "$ref": "#/components/schemas/Relationships"
+                "$ref": "#/components/schemas/EntryRelationships"
               }
             ],
             "description": "a dictionary containing references to other entries according to the description in section `Relationships`_\nencoded as `JSON API Relationships <https://jsonapi.org/format/1.0/#document-resource-object-relationships>`__.\nThe OPTIONAL human-readable description of the relationship MAY be provided in the :field:`description` field inside the :field:`meta` dictionary."
@@ -1285,6 +1856,22 @@
         ],
         "type": "object",
         "properties": {
+          "relationships": {
+            "title": "Relationships",
+            "description": "Not allowed key"
+          },
+          "links": {
+            "title": "Links",
+            "description": "Not allowed key"
+          },
+          "id": {
+            "title": "Id",
+            "description": "Not allowed key"
+          },
+          "type": {
+            "title": "Type",
+            "description": "Not allowed key"
+          },
           "immutable_id": {
             "title": "Immutable_Id",
             "type": "string",
@@ -1477,12 +2064,20 @@
           },
           "included": {
             "title": "Included",
-            "uniqueItems": true,
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Resource"
-            },
-            "description": "A list of resources that are included"
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/EntryResource"
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              }
+            ]
           },
           "links": {
             "title": "Links",
@@ -1537,12 +2132,20 @@
           },
           "included": {
             "title": "Included",
-            "uniqueItems": true,
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Resource"
-            },
-            "description": "A list of resources that are included"
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/EntryResource"
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              }
+            ]
           },
           "links": {
             "title": "Links",
@@ -1565,10 +2168,64 @@
         },
         "description": "errors are not allowed"
       },
+      "RelationshipLinks": {
+        "title": "RelationshipLinks",
+        "type": "object",
+        "properties": {
+          "self": {
+            "title": "Self",
+            "anyOf": [
+              {
+                "minLength": 1,
+                "maxLength": 65536,
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Link"
+                  }
+                ]
+              }
+            ],
+            "description": "A link to itself"
+          },
+          "related": {
+            "title": "Related",
+            "anyOf": [
+              {
+                "minLength": 1,
+                "maxLength": 65536,
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Link"
+                  }
+                ]
+              }
+            ],
+            "description": "A related resource link"
+          }
+        },
+        "description": "A resource object **MAY** contain references to other resource objects (\"relationships\").\nRelationships may be to-one or to-many. Relationships can be specified by including a member in a resource's links object."
+      },
       "Relationships": {
         "title": "Relationships",
         "type": "object",
-        "properties": {},
+        "properties": {
+          "id": {
+            "title": "Id",
+            "description": "Not allowed key"
+          },
+          "type": {
+            "title": "Type",
+            "description": "Not allowed key"
+          }
+        },
         "description": "Members of the relationships object (\"relationships\") represent references from the resource object in which it's defined to other resource objects.\nKeys MUST NOT be:\n    type\n    id"
       },
       "Resource": {
@@ -1798,6 +2455,50 @@
         },
         "description": "A list describing the species of the sites of this structure.\nSpecies can be pure chemical elements, or virtual-crystal atoms representing a statistical occupation of a given site by multiple chemical elements.\n\n- **Examples**:\n\n    - :val:`[ {\"name\": \"Ti\", \"chemical_symbols\": [\"Ti\"], \"concentration\": [1.0]} ]`: any site with this species is occupied by a Ti atom.\n    - :val:`[ {\"name\": \"Ti\", \"chemical_symbols\": [\"Ti\", \"vacancy\"], \"concentration\": [0.9, 0.1]} ]`: any site with this species is occupied by a Ti atom with 90 % probability, and has a vacancy with 10 % probability.\n    - :val:`[ {\"name\": \"BaCa\", \"chemical_symbols\": [\"vacancy\", \"Ba\", \"Ca\"], \"concentration\": [0.05, 0.45, 0.5], \"mass\": 88.5} ]`: any site with this species is occupied by a Ba atom with 45 % probability, a Ca atom with 50 % probability, and by a vacancy with 5 % probability. The mass of this site is (on average) 88.5 a.m.u.\n    - :val:`[ {\"name\": \"C12\", \"chemical_symbols\": [\"C\"], \"concentration\": [1.0], \"mass\": 12.0} ]`: any site with this species is occupied by a carbon isotope with mass 12.\n    - :val:`[ {\"name\": \"C13\", \"chemical_symbols\": [\"C\"], \"concentration\": [1.0], \"mass\": 13.0} ]`: any site with this species is occupied by a carbon isotope with mass 13."
       },
+      "StructureRelationship": {
+        "title": "StructureRelationship",
+        "type": "object",
+        "properties": {
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RelationshipLinks"
+              }
+            ],
+            "description": "a links object containing at least one of the following: self, related"
+          },
+          "data": {
+            "title": "Data",
+            "anyOf": [
+              {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BaseResource"
+                  }
+                ]
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/BaseResource"
+                }
+              }
+            ],
+            "description": "Resource linkage"
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Meta"
+              }
+            ],
+            "description": "a meta object that contains non-standard meta-information about the relationship."
+          }
+        },
+        "description": "Representation references from the resource object in which it\u2019s defined to other resource objects."
+      },
       "StructureResource": {
         "title": "StructureResource",
         "required": [
@@ -1841,7 +2542,7 @@
             "title": "Relationships",
             "allOf": [
               {
-                "$ref": "#/components/schemas/Relationships"
+                "$ref": "#/components/schemas/EntryRelationships"
               }
             ],
             "description": "a dictionary containing references to other entries according to the description in section `Relationships`_\nencoded as `JSON API Relationships <https://jsonapi.org/format/1.0/#document-resource-object-relationships>`__.\nThe OPTIONAL human-readable description of the relationship MAY be provided in the :field:`description` field inside the :field:`meta` dictionary."
@@ -1868,6 +2569,22 @@
         ],
         "type": "object",
         "properties": {
+          "relationships": {
+            "title": "Relationships",
+            "description": "Not allowed key"
+          },
+          "links": {
+            "title": "Links",
+            "description": "Not allowed key"
+          },
+          "id": {
+            "title": "Id",
+            "description": "Not allowed key"
+          },
+          "type": {
+            "title": "Type",
+            "description": "Not allowed key"
+          },
           "immutable_id": {
             "title": "Immutable_Id",
             "type": "string",
@@ -2023,12 +2740,20 @@
           },
           "included": {
             "title": "Included",
-            "uniqueItems": true,
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Resource"
-            },
-            "description": "A list of resources that are included"
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/EntryResource"
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              }
+            ]
           },
           "links": {
             "title": "Links",
@@ -2083,12 +2808,20 @@
           },
           "included": {
             "title": "Included",
-            "uniqueItems": true,
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Resource"
-            },
-            "description": "A list of resources that are included"
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/EntryResource"
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              }
+            ]
           },
           "links": {
             "title": "Links",

--- a/optimade/models/links.py
+++ b/optimade/models/links.py
@@ -27,7 +27,7 @@ class LinksResourceAttributes(Attributes):
         description="Human-readable description for the OPTiMaDe API implementation "
         "a client may provide in a list to an end-user.",
     )
-    base_url: Union[UrlStr, Link] = Schema(
+    base_url: Union[UrlStr, Link, None] = Schema(
         ...,
         description="JSON API links object, pointing to the base URL for this implementation",
     )

--- a/optimade/models/links.py
+++ b/optimade/models/links.py
@@ -1,8 +1,8 @@
-from pydantic import Schema, UrlStr, validator
+from pydantic import Schema, UrlStr, validator  # pylint: disable=no-name-in-module
 from typing import Union
 
-from .jsonapi import Link
-from .entries import EntryResourceAttributes, EntryResource
+from .jsonapi import Link, Attributes
+from .entries import EntryResource
 
 
 __all__ = (
@@ -14,7 +14,7 @@ __all__ = (
 )
 
 
-class LinksResourceAttributes(EntryResourceAttributes):
+class LinksResourceAttributes(Attributes):
     """Links endpoint resource object attributes"""
 
     name: str = Schema(
@@ -56,6 +56,10 @@ class LinksResource(EntryResource):
                 "name of Links endpoint resource MUST be either 'parent, 'child', or 'provider'"
             )
         return value
+
+    @validator("relationships")
+    def relationships_must_not_be_present(cls, value):
+        raise ValueError('"relationships" is not allowed for links resources')
 
 
 class ChildResource(LinksResource):

--- a/optimade/models/toplevel.py
+++ b/optimade/models/toplevel.py
@@ -190,11 +190,6 @@ class InfoResponse(Success):
     data: BaseInfoResource = Schema(...)
 
 
-class LinksResponse(Success):
-    meta: Optional[ResponseMeta] = Schema(...)
-    data: Union[LinksResource, Dict[str, Any], None] = Schema(...)
-
-
 class EntryResponseOne(Success):
     meta: ResponseMeta = Schema(...)
     data: Union[EntryResource, Dict[str, Any], None] = Schema(...)
@@ -205,6 +200,10 @@ class EntryResponseMany(Success):
     meta: ResponseMeta = Schema(...)
     data: Union[List[EntryResource], List[Dict[str, Any]]] = Schema(...)
     included: Optional[Union[List[EntryResource], List[Dict[str, Any]]]] = Schema(...)
+
+
+class LinksResponse(EntryResponseMany):
+    data: Union[List[LinksResource], List[Dict[str, Any]]] = Schema(...)
 
 
 class StructureResponseOne(EntryResponseOne):

--- a/optimade/models/toplevel.py
+++ b/optimade/models/toplevel.py
@@ -1,12 +1,19 @@
 from datetime import datetime
 from typing import Union, List, Optional, Dict, Any
 
-from pydantic import BaseModel, validator, UrlStr, Schema, EmailStr
+from pydantic import (  # pylint: disable=no-name-in-module
+    BaseModel,
+    validator,
+    UrlStr,
+    Schema,
+    EmailStr,
+)
 
 from .jsonapi import Link, Meta
 from .util import NonnegativeInt
 from .baseinfo import BaseInfoResource
 from .entries import EntryInfoResource, EntryResource
+from .links import LinksResource
 from .optimade_json import Error, Success, Failure, Warnings
 from .references import ReferenceResource
 from .structures import StructureResource
@@ -21,6 +28,7 @@ __all__ = (
     "ErrorResponse",
     "EntryInfoResponse",
     "InfoResponse",
+    "LinksResponse",
     "EntryResponseOne",
     "EntryResponseMany",
     "StructureResponseOne",
@@ -180,6 +188,11 @@ class EntryInfoResponse(Success):
 class InfoResponse(Success):
     meta: Optional[ResponseMeta] = Schema(...)
     data: BaseInfoResource = Schema(...)
+
+
+class LinksResponse(Success):
+    meta: Optional[ResponseMeta] = Schema(...)
+    data: Union[LinksResource, Dict[str, Any], None] = Schema(...)
 
 
 class EntryResponseOne(Success):

--- a/optimade/server/config.ini
+++ b/optimade/server/config.ini
@@ -13,5 +13,3 @@ index_base_url = http://example.com/optimade/index
 [structures]
 band_gap :
 _mp_chemsys :
-
-[references]

--- a/optimade/server/config.py
+++ b/optimade/server/config.py
@@ -66,9 +66,11 @@ class ServerConfig(Config):
 
         self.provider_fields = {}
         for endpoint in {"structures", "references"}:
-            self.provider_fields[endpoint] = {
-                field for field, _ in config[endpoint].items() if _ == ""
-            }
+            self.provider_fields[endpoint] = (
+                {field for field, _ in config[endpoint].items() if _ == ""}
+                if endpoint in config
+                else {}
+            )
 
     def load_from_json(self):
         """ Load from the file "config.json", if it exists. """

--- a/optimade/server/deps.py
+++ b/optimade/server/deps.py
@@ -13,16 +13,16 @@ class EntryListingQueryParams:
         self,
         *,
         filter: str = Query(  # pylint: disable=redefined-builtin
-            None,
+            "",
             description="""See [the full and latest OPTiMaDe spec](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst) for filter query syntax.
 
 Example: `chemical_formula = "Al" OR (prototype_formula = "AB" AND elements HAS Si, Al, O)`.
 """,
         ),
         response_format: str = Query("json"),
-        email_address: EmailStr = Query(None),
-        response_fields: str = Query(None),
-        sort: str = Query(None),
+        email_address: EmailStr = Query(""),
+        response_fields: str = Query(""),
+        sort: str = Query(""),
         page_limit: NonnegativeInt = Query(CONFIG.page_limit),
         page_offset: NonnegativeInt = Query(0),
         page_page: NonnegativeInt = Query(0),
@@ -50,8 +50,8 @@ class SingleEntryQueryParams:
         self,
         *,
         response_format: str = Query("json"),
-        email_address: EmailStr = Query(None),
-        response_fields: str = Query(None),
+        email_address: EmailStr = Query(""),
+        response_fields: str = Query(""),
     ):
         self.response_format = response_format
         self.email_address = email_address

--- a/optimade/server/entry_collections.py
+++ b/optimade/server/entry_collections.py
@@ -35,6 +35,10 @@ class EntryCollection(Collection):  # pylint: disable=inherit-non-class
     def get_attribute_fields(self) -> set:
         schema = self.resource_cls.schema()
         attributes = schema["properties"]["attributes"]
+        if "allOf" in attributes:
+            allOf = attributes.pop("allOf")
+            for dict_ in allOf:
+                attributes.update(dict_)
         if "$ref" in attributes:
             path = attributes["$ref"].split("/")[1:]
             attributes = schema.copy()
@@ -77,7 +81,7 @@ class MongoCollection(EntryCollection):
         self.transformer = NewMongoTransformer()
 
         self.provider = CONFIG.provider["prefix"]
-        self.provider_fields = CONFIG.provider_fields[resource_mapper.ENDPOINT]
+        self.provider_fields = CONFIG.provider_fields.get(resource_mapper.ENDPOINT, [])
         self.page_limit = CONFIG.page_limit
         self.parser = LarkParser(
             version=(0, 10, 0), variant="default"

--- a/optimade/server/main.py
+++ b/optimade/server/main.py
@@ -69,7 +69,6 @@ test_paths = {
 }
 if not CONFIG.use_real_mongo and (path.exists() for path in test_paths.values()):
     import bson.json_util
-    import requests
 
     def load_entries(endpoint_name: str, endpoint_collection: MongoCollection):
         print(f"loading test {endpoint_name}...")
@@ -83,13 +82,8 @@ if not CONFIG.use_real_mongo and (path.exists() for path in test_paths.values())
             print(
                 "adding providers.json to links from github.com/Materials-Consortia/OPTiMaDe"
             )
-            mat_consortia_providers = requests.get(
-                "https://raw.githubusercontent.com/Materials-Consortia/OPTiMaDe/develop/providers.json"
-            ).json()
             endpoint_collection.collection.insert_many(
-                bson.json_util.loads(
-                    bson.json_util.dumps(mat_consortia_providers.get("data", []))
-                )
+                bson.json_util.loads(bson.json_util.dumps(u.get_providers()))
             )
         print(f"done inserting test {endpoint_name}...")
 

--- a/optimade/server/mappers/__init__.py
+++ b/optimade/server/mappers/__init__.py
@@ -1,6 +1,9 @@
 # pylint: disable=undefined-variable
 from .entries import *
+from .links import *
 from .references import *
 from .structures import *
 
-__all__ = entries.__all__ + references.__all__ + structures.__all__  # noqa
+__all__ = (
+    entries.__all__ + links.__all__ + references.__all__ + structures.__all__  # noqa
+)

--- a/optimade/server/mappers/entries.py
+++ b/optimade/server/mappers/entries.py
@@ -9,6 +9,7 @@ class ResourceMapper:
 
     ENDPOINT: str = ""
     ALIASES: Tuple[Tuple[str, str]] = ()
+    TOP_LEVEL_NON_ATTRIBUTES_FIELDS: set = {"id", "type", "relationships", "links"}
 
     @classmethod
     def all_aliases(cls) -> Tuple[Tuple[str, str]]:
@@ -36,6 +37,12 @@ class ResourceMapper:
     def map_back(cls, doc: dict) -> dict:
         """Map properties from MongoDB to OPTiMaDe
 
+        Starting from a MongoDB document ``doc``, map the DB fields to the corresponding OPTiMaDe fields.
+        Then, the fields are all added to the top-level field "attributes",
+        with the exception of other top-level fields, defined in ``cls.TOPLEVEL_NON_ATTRIBUTES_FIELDS``.
+        All fields not in ``cls.TOPLEVEL_NON_ATTRIBUTES_FIELDS`` + "attributes" will be removed.
+        Finally, the ``type`` is given the value of the specified ``cls.ENDPOINT``.
+
         :param doc: A resource object in MongoDB format
         :type doc: dict
 
@@ -59,11 +66,10 @@ class ResourceMapper:
             raise Exception("Will overwrite doc field!")
         attributes = newdoc.copy()
 
-        top_level_entry_fields = {"id", "type", "relationships", "links"}
-        for k in top_level_entry_fields:
+        for k in cls.TOP_LEVEL_NON_ATTRIBUTES_FIELDS:
             attributes.pop(k, None)
         for k in list(newdoc.keys()):
-            if k not in top_level_entry_fields:
+            if k not in cls.TOP_LEVEL_NON_ATTRIBUTES_FIELDS:
                 del newdoc[k]
 
         newdoc["type"] = cls.ENDPOINT

--- a/optimade/server/mappers/links.py
+++ b/optimade/server/mappers/links.py
@@ -6,7 +6,6 @@ __all__ = ("LinksMapper",)
 class LinksMapper(ResourceMapper):
 
     ENDPOINT = "links"
-    ALIASES = (("id", "task_id"),)
 
     @classmethod
     def map_back(cls, doc: dict) -> dict:

--- a/optimade/server/mappers/links.py
+++ b/optimade/server/mappers/links.py
@@ -1,0 +1,24 @@
+from .entries import ResourceMapper
+
+__all__ = ("LinksMapper",)
+
+
+class LinksMapper(ResourceMapper):
+
+    ENDPOINT = "links"
+    ALIASES = (("id", "task_id"),)
+
+    @classmethod
+    def map_back(cls, doc: dict) -> dict:
+        """Map properties from MongoDB to OPTiMaDe
+
+        :param doc: A resource object in MongoDB format
+        :type doc: dict
+
+        :return: A resource object in OPTiMaDe format
+        :rtype: dict
+        """
+        type_ = doc["type"]
+        newdoc = super().map_back(doc)
+        newdoc["type"] = type_
+        return newdoc

--- a/optimade/server/mappers/references.py
+++ b/optimade/server/mappers/references.py
@@ -1,6 +1,5 @@
 from .entries import ResourceMapper
 
-
 __all__ = ("ReferenceMapper",)
 
 
@@ -8,38 +7,3 @@ class ReferenceMapper(ResourceMapper):
 
     ENDPOINT = "references"
     ALIASES = (("id", "task_id"),)
-
-    @classmethod
-    def map_back(cls, doc: dict) -> dict:
-        """Map properties from MongoDB to OPTiMaDe
-
-        :param doc: A resource object in MongoDB format
-        :type doc: dict
-
-        :return: A resource object in OPTiMaDe format
-        :rtype: dict
-        """
-        if "_id" in doc:
-            del doc["_id"]
-        # print(doc)
-        mapping = ((real, alias) for alias, real in cls.all_aliases())
-        newdoc = {}
-        reals = {real for alias, real in cls.all_aliases()}
-        for k in doc:
-            if k not in reals:
-                newdoc[k] = doc[k]
-        for real, alias in mapping:
-            if real in doc:
-                newdoc[alias] = doc[real]
-
-        # print(newdoc)
-        if "attributes" in newdoc:
-            raise Exception("Will overwrite doc field!")
-        newdoc["attributes"] = newdoc.copy()
-        for k in {"id", "type"}:
-            newdoc["attributes"].pop(k, None)
-        for k in list(newdoc.keys()):
-            if k not in ("id", "attributes"):
-                del newdoc[k]
-        newdoc["type"] = cls.ENDPOINT
-        return newdoc

--- a/optimade/server/mappers/references.py
+++ b/optimade/server/mappers/references.py
@@ -6,4 +6,3 @@ __all__ = ("ReferenceMapper",)
 class ReferenceMapper(ResourceMapper):
 
     ENDPOINT = "references"
-    ALIASES = (("id", "task_id"),)

--- a/optimade/server/mappers/structures.py
+++ b/optimade/server/mappers/structures.py
@@ -1,6 +1,5 @@
 from .entries import ResourceMapper
 
-
 __all__ = ("StructureMapper",)
 
 
@@ -13,41 +12,3 @@ class StructureMapper(ResourceMapper):
         ("chemical_formula_reduced", "pretty_formula"),
         ("chemical_formula_anonymous", "formula_anonymous"),
     )
-
-    @classmethod
-    def map_back(cls, doc: dict) -> dict:
-        """Map properties from MongoDB to OPTiMaDe
-
-        :param doc: A resource object in MongoDB format
-        :type doc: dict
-
-        :return: A resource object in OPTiMaDe format
-        :rtype: dict
-        """
-        if "_id" in doc:
-            del doc["_id"]
-        if "nsites" not in doc:
-            doc["nsites"] = len(doc.get("cartesian_site_positions", []))
-
-        mapping = ((real, alias) for alias, real in cls.all_aliases())
-        newdoc = {}
-        reals = {real for alias, real in cls.all_aliases()}
-        for k in doc:
-            if k not in reals:
-                newdoc[k] = doc[k]
-        for real, alias in mapping:
-            if real in doc:
-                newdoc[alias] = doc[real]
-
-        if "attributes" in newdoc:
-            raise Exception("Will overwrite doc field!")
-        attributes = newdoc.copy()
-        for k in {"id", "type", "relationships", "links"}:
-            attributes.pop(k, None)
-        for k in list(newdoc.keys()):
-            if k not in ("id", "attributes", "relationships", "links"):
-                del newdoc[k]
-        newdoc["type"] = cls.ENDPOINT
-        newdoc["attributes"] = attributes
-
-        return newdoc

--- a/optimade/server/tests/test_links.json
+++ b/optimade/server/tests/test_links.json
@@ -3,7 +3,7 @@
       "_id": {
         "$oid": "5cfb441f053b174410700d03"
       },
-      "task_id": "index",
+      "id": "index",
       "last_modified": {
         "$date": "2019-11-12T14:24:37.331Z"
       },

--- a/optimade/server/tests/test_links.json
+++ b/optimade/server/tests/test_links.json
@@ -1,0 +1,15 @@
+[
+    {
+      "_id": {
+        "$oid": "5cfb441f053b174410700d03"
+      },
+      "task_id": "index",
+      "last_modified": {
+        "$date": "2019-11-12T14:24:37.331Z"
+      },
+      "type": "parent",
+      "name": "Index meta-database",
+      "description": "Index for example's OPTiMaDe databases",
+      "base_url": "http://example.com/optimade/index"
+    }
+  ]

--- a/optimade/server/tests/test_references.json
+++ b/optimade/server/tests/test_references.json
@@ -3,7 +3,7 @@
     "_id": {
       "$oid": "5cfb441f053b174410701bec"
     },
-    "task_id": "dijkstra1968",
+    "id": "dijkstra1968",
     "last_modified": {
       "$date": "2019-11-12T14:24:37.331Z"
     },
@@ -23,7 +23,7 @@
     "_id": {
       "$oid": "5cfb441f053b174410701bed"
     },
-    "task_id": "maddox1988",
+    "id": "maddox1988",
     "last_modified": {
       "$date": "2019-11-27T14:24:37.331Z"
     },
@@ -43,7 +43,7 @@
     "_id": {
       "$oid": "5cfb441f053b174410701bea"
     },
-    "task_id": "dummy2019",
+    "id": "dummy2019",
     "last_modified": {
       "$date": "2019-11-23T14:24:37.332Z"
     },

--- a/optimade/server/utils.py
+++ b/optimade/server/utils.py
@@ -287,7 +287,7 @@ def get_providers():
     from bson.objectid import ObjectId
 
     mat_consortia_providers = requests.get(
-        "https://raw.githubusercontent.com/Materials-Consortia/OPTiMaDe/develop/providers.json"
+        "https://raw.githubusercontent.com/Materials-Consortia/OPTiMaDe/master/providers.json"
     ).json()
 
     providers_list = []
@@ -296,11 +296,10 @@ def get_providers():
         if provider["id"] == "exmpl":
             continue
 
-        provider["task_id"] = provider.pop("id")
         provider.update(provider.pop("attributes"))
 
         # Create MongoDB id
-        oid = provider["task_id"] + provider["type"]
+        oid = provider["id"] + provider["type"]
         if len(oid) < 12:
             oid = oid + "0" * (12 - len(oid))
         elif len(oid) > 12:

--- a/optimade/server/utils.py
+++ b/optimade/server/utils.py
@@ -28,6 +28,12 @@ from .entry_collections import EntryCollection
 from .deps import EntryListingQueryParams, SingleEntryQueryParams
 
 
+ENTRY_INFO_SCHEMAS = {
+    "structures": StructureResource.schema,
+    "references": ReferenceResource.schema,
+}
+
+
 def meta_values(
     url: str,
     data_returned: int,
@@ -275,7 +281,33 @@ def retrieve_queryable_properties(schema: dict, queryable_properties: list) -> d
     return properties
 
 
-ENTRY_INFO_SCHEMAS = {
-    "structures": StructureResource.schema,
-    "references": ReferenceResource.schema,
-}
+def get_providers():
+    """Retrieve providers.json from /Materials-Consortia/OPTiMaDe"""
+    import requests
+    from bson.objectid import ObjectId
+
+    mat_consortia_providers = requests.get(
+        "https://raw.githubusercontent.com/Materials-Consortia/OPTiMaDe/develop/providers.json"
+    ).json()
+
+    providers_list = []
+    for provider in mat_consortia_providers.get("data", []):
+        # Remove/skip "exmpl"
+        if provider["id"] == "exmpl":
+            continue
+
+        provider["task_id"] = provider.pop("id")
+        provider.update(provider.pop("attributes"))
+
+        # Create MongoDB id
+        oid = provider["task_id"] + provider["type"]
+        if len(oid) < 12:
+            oid = oid + "0" * (12 - len(oid))
+        elif len(oid) > 12:
+            oid = oid[:12]
+        oid = oid.encode("UTF-8")
+        provider["_id"] = {"$oid": ObjectId(oid)}
+
+        providers_list.append(provider)
+
+    return providers_list

--- a/optimade/validator/validator.py
+++ b/optimade/validator/validator.py
@@ -9,6 +9,7 @@ import requests
 import sys
 import logging
 import json
+import traceback
 
 from pydantic import ValidationError
 
@@ -140,6 +141,9 @@ def test_case(test_fn):
         try:
             result, msg = test_fn(*args, **kwargs)
         except (ResponseError, ValidationError) as exc:
+            if args[0].verbosity > 1:
+                traceback.print_exc()
+
             result = False
             msg = f"{type(exc).__name__}: {exc}"
 
@@ -370,7 +374,10 @@ class ImplementationValidator:
             raise ResponseError(
                 f"Endpoint did not obey page limit: {num_entries} entries vs {self.page_limit} limit"
             )
-        return num_entries, f"Endpoint obeyed page limit of {self.page_limit}"
+        return (
+            True,
+            f"Endpoint obeyed page limit of {self.page_limit} by returning {num_entries} entries.",
+        )
 
     @test_case
     def get_single_id_from_multi_endpoint(self, deserialized):

--- a/optimade/validator/validator.py
+++ b/optimade/validator/validator.py
@@ -12,7 +12,7 @@ import json
 
 from pydantic import ValidationError
 
-from optimade.models import InfoResponse, EntryInfoResponse
+from optimade.models import InfoResponse, EntryInfoResponse, LinksResponse
 
 from .validator_model_patches import (
     ValidatorEntryResponseOne,
@@ -33,6 +33,7 @@ RESPONSE_CLASSES = {
     "structures": ValidatorStructureResponseMany,
     "structures/": ValidatorStructureResponseOne,
     "info": InfoResponse,
+    "links": LinksResponse,
 }
 RESPONSE_CLASSES.update(
     {f"info/{entry}": EntryInfoResponse for entry in REQUIRED_ENTRY_ENDPOINTS}
@@ -294,6 +295,18 @@ class ImplementationValidator:
 
     def test_info_endpoints(self, request_str):
         """ Runs the test cases for the info endpoints. """
+        response = self.get_endpoint(request_str)
+        if response:
+            deserialized = self.deserialize_reponse(
+                response, RESPONSE_CLASSES[request_str]
+            )
+            if not deserialized:
+                return response
+            return deserialized
+        return False
+
+    def test_links_endpoint(self, request_str="links"):
+        """ Runs the test cases for the links endpoint. """
         response = self.get_endpoint(request_str)
         if response:
             deserialized = self.deserialize_reponse(


### PR DESCRIPTION
Closes #89 

Several things are happening here:
- Centralize the mapper method `map_back` in the parent class. This should provide an idea of going forward and perhaps removing the sub-classed mappers or similar.
- Add the `/links` endpoint with a pseudo `index` parent implementation and all the providers from [`providers.json`](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/providers.json).

Comments:
I am unsure on how to treat the `/links` endpoint concerning whether `/links/{entry_id}` is valid. And why is it demanded that only the `SingleEntryQueryParams` are valid query parameters for the endpoint, (see [here](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst#44links-endpoint))?
I think some of these questions should be put to the consortium and changes should be suggested to the spec.

~Missing:~
- Tests for the `/links` endpoint. (Added by @ml-evs)