### PR TITLE
Index meta-database

### DIFF
--- a/.ci/index_openapi_diff.sh
+++ b/.ci/index_openapi_diff.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Note: This returns exit code 0, if the two specs agree, otherwise exit code 1
+docker run -t -v $(pwd):/specs:ro quen2404/openapi-diff /specs/index_openapi.json /specs/local_index_openapi.json

--- a/.ci/json_diff.sh
+++ b/.ci/json_diff.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 diff=$(jsondiff openapi.json local_openapi.json);
+index_diff=$(jsondiff index_openapi.json local_index_openapi.json);
 
-if [ ! "$diff" = "{}" ]; then
-    echo -e "Generated OpenAPI spec did not match committed version.\nRun 'invoke update_openapijson' and re-commit.\nDiff:\n$diff";
+if [ ! "$diff" = "{}" ]; then 
+    echo -e "Generated OpenAPI spec for test server did not match committed version.\nRun 'invoke update_openapijson' and re-commit.\nDiff:\n$diff"; 
+exit 1;
+fi
+
+if [ ! "$index_diff" = "{}" ]; then 
+    echo -e "Generated OpenAPI spec for Index meta-database did not match committed version. Diff:\n$index_diff"; 
 exit 1;
 fi

--- a/.ci/json_diff.sh
+++ b/.ci/json_diff.sh
@@ -5,12 +5,12 @@ python -c "from optimade.server.main_index import app, update_schema; update_sch
 diff=$(jsondiff openapi.json local_openapi.json);
 index_diff=$(jsondiff index_openapi.json local_index_openapi.json);
 
-if [ ! "$diff" = "{}" ]; then 
-    echo -e "Generated OpenAPI spec for test server did not match committed version.\nRun 'invoke update_openapijson' and re-commit.\nDiff:\n$diff"; 
+if [ ! "$diff" = "{}" ]; then
+    echo -e "Generated OpenAPI spec for test server did not match committed version.\nRun 'invoke update_openapijson' and re-commit.\nDiff:\n$diff";
 exit 1;
 fi
 
-if [ ! "$index_diff" = "{}" ]; then 
-    echo -e "Generated OpenAPI spec for Index meta-database did not match committed version. Diff:\n$index_diff"; 
+if [ ! "$index_diff" = "{}" ]; then
+    echo -e "Generated OpenAPI spec for Index meta-database did not match committed version.\nRun 'invoke update_openapijson' and re-commit.\nDiff:\n$index_diff";
 exit 1;
 fi

--- a/.ci/json_diff.sh
+++ b/.ci/json_diff.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+python -c "from optimade.server.main import app, update_schema; update_schema(app)"
+python -c "from optimade.server.main_index import app, update_schema; update_schema(app)"
+
 diff=$(jsondiff openapi.json local_openapi.json);
 index_diff=$(jsondiff index_openapi.json local_index_openapi.json);
 

--- a/.github/workflows/deps_lint.yml
+++ b/.github/workflows/deps_lint.yml
@@ -47,7 +47,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -U setuptools
-        pip install pre-commit
+        pip install .[dev]
 
     - name: Run pre-commit
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,4 @@ venv.bak/
 Untitled.ipynb
 local_openapi.json
 local_index_openapi.json
+server.cfg

--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,4 @@ venv.bak/
 
 Untitled.ipynb
 local_openapi.json
+local_index_openapi.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,25 @@
-repos:
-- repo: https://github.com/ambv/black
-  rev: stable
-  hooks:
-  - id: black
+default_language_version:
+  python: python3.7
 
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v2.3.0
-  hooks:
-  - id: trailing-whitespace
-    exclude: README.md
-  - id: check-yaml
-  - id: check-json
+repos:
+  - repo: https://github.com/ambv/black
+    rev: stable
+    hooks:
+    - id: black
+      name: Blacken
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+    - id: trailing-whitespace
+      exclude: README.md
+    - id: check-yaml
+    - id: check-json
+
+  - repo: local
+    hooks:
+    - id: json-diff
+      name: OpenAPI diff
+      description: Check for differences in openapi.json and index_openapi.json with local versions.
+      entry: ./.ci/json_diff.sh
+      language: system

--- a/index_openapi.json
+++ b/index_openapi.json
@@ -1,0 +1,2081 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "OPTiMaDe API - Index meta-database",
+    "version": "0.10.0",
+    "description": "The [Open Databases Integration for Materials Design (OPTiMaDe) consortium](http://http://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.\nThis is the \"special\" index meta-database."
+  },
+  "paths": {
+    "/index/optimade/info": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response_Get_Info_Index_Optimade_Info_Get",
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/IndexInfoResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorResponse"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Info"
+        ],
+        "summary": "Get Info",
+        "operationId": "get_info_index_optimade_info_get"
+      }
+    },
+    "/index/optimade/links": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response_Get_Links_Index_Optimade_Links_Get",
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/LinksResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorResponse"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Links"
+        ],
+        "summary": "Get Links",
+        "operationId": "get_links_index_optimade_links_get",
+        "parameters": [
+          {
+            "description": "See [the full and latest OPTiMaDe spec](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst) for filter query syntax.\n\nExample: `chemical_formula = \"Al\" OR (prototype_formula = \"AB\" AND elements HAS Si, Al, O)`.\n",
+            "required": false,
+            "schema": {
+              "title": "Filter",
+              "type": "string",
+              "description": "See [the full and latest OPTiMaDe spec](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst) for filter query syntax.\n\nExample: `chemical_formula = \"Al\" OR (prototype_formula = \"AB\" AND elements HAS Si, Al, O)`.\n",
+              "default": ""
+            },
+            "name": "filter",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "title": "Response_Format",
+              "type": "string",
+              "default": "json"
+            },
+            "name": "response_format",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "title": "Email_Address",
+              "type": "string",
+              "format": "email",
+              "default": ""
+            },
+            "name": "email_address",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "title": "Response_Fields",
+              "type": "string",
+              "default": ""
+            },
+            "name": "response_fields",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "title": "Sort",
+              "type": "string",
+              "default": ""
+            },
+            "name": "sort",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "title": "Page_Limit",
+              "minimum": 0.0,
+              "type": "integer",
+              "default": 500
+            },
+            "name": "page_limit",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "title": "Page_Offset",
+              "minimum": 0.0,
+              "type": "integer",
+              "default": 0
+            },
+            "name": "page_offset",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "title": "Page_Page",
+              "minimum": 0.0,
+              "type": "integer",
+              "default": 0
+            },
+            "name": "page_page",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "title": "Page_Cursor",
+              "minimum": 0.0,
+              "type": "integer",
+              "default": 0
+            },
+            "name": "page_cursor",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "title": "Page_Above",
+              "minimum": 0.0,
+              "type": "integer",
+              "default": 0
+            },
+            "name": "page_above",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "title": "Page_Below",
+              "minimum": 0.0,
+              "type": "integer",
+              "default": 0
+            },
+            "name": "page_below",
+            "in": "query"
+          }
+        ]
+      }
+    },
+    "/index/optimade/v0.10.0/info": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response_Get_Info_Index_Optimade_V0.10.0_Info_Get",
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/IndexInfoResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorResponse"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Info"
+        ],
+        "summary": "Get Info",
+        "operationId": "get_info_index_optimade_v0.10.0_info_get"
+      }
+    },
+    "/index/optimade/v0.10.0/links": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response_Get_Links_Index_Optimade_V0.10.0_Links_Get",
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/LinksResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorResponse"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Links"
+        ],
+        "summary": "Get Links",
+        "operationId": "get_links_index_optimade_v0.10.0_links_get",
+        "parameters": [
+          {
+            "description": "See [the full and latest OPTiMaDe spec](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst) for filter query syntax.\n\nExample: `chemical_formula = \"Al\" OR (prototype_formula = \"AB\" AND elements HAS Si, Al, O)`.\n",
+            "required": false,
+            "schema": {
+              "title": "Filter",
+              "type": "string",
+              "description": "See [the full and latest OPTiMaDe spec](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst) for filter query syntax.\n\nExample: `chemical_formula = \"Al\" OR (prototype_formula = \"AB\" AND elements HAS Si, Al, O)`.\n",
+              "default": ""
+            },
+            "name": "filter",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "title": "Response_Format",
+              "type": "string",
+              "default": "json"
+            },
+            "name": "response_format",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "title": "Email_Address",
+              "type": "string",
+              "format": "email",
+              "default": ""
+            },
+            "name": "email_address",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "title": "Response_Fields",
+              "type": "string",
+              "default": ""
+            },
+            "name": "response_fields",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "title": "Sort",
+              "type": "string",
+              "default": ""
+            },
+            "name": "sort",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "title": "Page_Limit",
+              "minimum": 0.0,
+              "type": "integer",
+              "default": 500
+            },
+            "name": "page_limit",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "title": "Page_Offset",
+              "minimum": 0.0,
+              "type": "integer",
+              "default": 0
+            },
+            "name": "page_offset",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "title": "Page_Page",
+              "minimum": 0.0,
+              "type": "integer",
+              "default": 0
+            },
+            "name": "page_page",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "title": "Page_Cursor",
+              "minimum": 0.0,
+              "type": "integer",
+              "default": 0
+            },
+            "name": "page_cursor",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "title": "Page_Above",
+              "minimum": 0.0,
+              "type": "integer",
+              "default": 0
+            },
+            "name": "page_above",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "title": "Page_Below",
+              "minimum": 0.0,
+              "type": "integer",
+              "default": 0
+            },
+            "name": "page_below",
+            "in": "query"
+          }
+        ]
+      }
+    },
+    "/index/optimade/v0.10/info": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response_Get_Info_Index_Optimade_V0.10_Info_Get",
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/IndexInfoResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorResponse"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Info"
+        ],
+        "summary": "Get Info",
+        "operationId": "get_info_index_optimade_v0.10_info_get"
+      }
+    },
+    "/index/optimade/v0.10/links": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response_Get_Links_Index_Optimade_V0.10_Links_Get",
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/LinksResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorResponse"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Links"
+        ],
+        "summary": "Get Links",
+        "operationId": "get_links_index_optimade_v0.10_links_get",
+        "parameters": [
+          {
+            "description": "See [the full and latest OPTiMaDe spec](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst) for filter query syntax.\n\nExample: `chemical_formula = \"Al\" OR (prototype_formula = \"AB\" AND elements HAS Si, Al, O)`.\n",
+            "required": false,
+            "schema": {
+              "title": "Filter",
+              "type": "string",
+              "description": "See [the full and latest OPTiMaDe spec](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst) for filter query syntax.\n\nExample: `chemical_formula = \"Al\" OR (prototype_formula = \"AB\" AND elements HAS Si, Al, O)`.\n",
+              "default": ""
+            },
+            "name": "filter",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "title": "Response_Format",
+              "type": "string",
+              "default": "json"
+            },
+            "name": "response_format",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "title": "Email_Address",
+              "type": "string",
+              "format": "email",
+              "default": ""
+            },
+            "name": "email_address",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "title": "Response_Fields",
+              "type": "string",
+              "default": ""
+            },
+            "name": "response_fields",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "title": "Sort",
+              "type": "string",
+              "default": ""
+            },
+            "name": "sort",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "title": "Page_Limit",
+              "minimum": 0.0,
+              "type": "integer",
+              "default": 500
+            },
+            "name": "page_limit",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "title": "Page_Offset",
+              "minimum": 0.0,
+              "type": "integer",
+              "default": 0
+            },
+            "name": "page_offset",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "title": "Page_Page",
+              "minimum": 0.0,
+              "type": "integer",
+              "default": 0
+            },
+            "name": "page_page",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "title": "Page_Cursor",
+              "minimum": 0.0,
+              "type": "integer",
+              "default": 0
+            },
+            "name": "page_cursor",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "title": "Page_Above",
+              "minimum": 0.0,
+              "type": "integer",
+              "default": 0
+            },
+            "name": "page_above",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "title": "Page_Below",
+              "minimum": 0.0,
+              "type": "integer",
+              "default": 0
+            },
+            "name": "page_below",
+            "in": "query"
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Attributes": {
+        "title": "Attributes",
+        "type": "object",
+        "properties": {
+          "relationships": {
+            "title": "Relationships",
+            "description": "Not allowed key"
+          },
+          "links": {
+            "title": "Links",
+            "description": "Not allowed key"
+          },
+          "id": {
+            "title": "Id",
+            "description": "Not allowed key"
+          },
+          "type": {
+            "title": "Type",
+            "description": "Not allowed key"
+          }
+        },
+        "description": "Members of the attributes object (\"attributes\") represent information about the resource object in which it's defined.\nThe keys for Attributes MUST NOT be:\n    relationships\n    links\n    id\n    type"
+      },
+      "AvailableApiVersion": {
+        "title": "AvailableApiVersion",
+        "required": [
+          "url",
+          "version"
+        ],
+        "type": "object",
+        "properties": {
+          "url": {
+            "title": "Url",
+            "maxLength": 65536,
+            "minLength": 1,
+            "type": "string",
+            "description": "a string specifying a base URL that MUST adhere to the rules in section Base URL",
+            "format": "uri"
+          },
+          "version": {
+            "title": "Version",
+            "type": "string",
+            "description": "a string containing the full version number of the API served at that base URL. The version number string MUST NOT be prefixed by, e.g., 'v'."
+          }
+        },
+        "description": "A JSON object containing information about an available API version"
+      },
+      "BaseResource": {
+        "title": "BaseResource",
+        "required": [
+          "id",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string",
+            "description": "Resource ID"
+          },
+          "type": {
+            "title": "Type",
+            "type": "string",
+            "description": "Resource type"
+          }
+        },
+        "description": "Minimum requirements to represent a Resource"
+      },
+      "EntryRelationships": {
+        "title": "EntryRelationships",
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "description": "Not allowed key"
+          },
+          "type": {
+            "title": "Type",
+            "description": "Not allowed key"
+          },
+          "references": {
+            "title": "References",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ReferenceRelationship"
+              }
+            ],
+            "description": "Object containing links to relationships with entries of the `references` type."
+          },
+          "structures": {
+            "title": "Structures",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/StructureRelationship"
+              }
+            ],
+            "description": "Object containing links to relationships with entries of the `structures` type."
+          }
+        },
+        "description": "This model wraps the JSON API Relationships to include type-specific top level keys. "
+      },
+      "EntryResource": {
+        "title": "EntryResource",
+        "required": [
+          "id",
+          "type",
+          "attributes"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string",
+            "description": "An entry's ID as defined in section `Definition of Terms`_.\n- **Type**: string.\n- **Requirements/Conventions**:\n\n  - **Response**: REQUIRED in the response unless explicitly excluded.\n  - **Query**: MUST be a queryable property with support for all mandatory filter operators.\n  - See section `Definition of Terms`_.\n\n- **Examples**:\n\n  - :val:`\"db/1234567\"`\n  - :val:`\"cod/2000000\"`\n  - :val:`\"cod/2000000@1234567\"`\n  - :val:`\"nomad/L1234567890\"`\n  - :val:`\"42\"`"
+          },
+          "type": {
+            "title": "Type",
+            "type": "string",
+            "description": "The name of the type of an entry.\nAny entry MUST be able to be fetched using the `base URL <Base URL_>`_ type and ID at the url :endpoint:`<base URL>/<type>/<id>`.\n- **Type**: string.\n- **Requirements/Conventions**:\n\n  - **Response**: REQUIRED in the response unless explicitly excluded.\n  - **Query**: Support for queries on this property is OPTIONAL.\n    If supported, only a subset of string comparison operators MAY be supported.\n\n- **Requirements/Conventions**: MUST be an existing entry type.\n- **Example**: :val:`\"structures\"`"
+          },
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResourceLinks"
+              }
+            ],
+            "description": "a links object containing links related to the resource."
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Meta"
+              }
+            ],
+            "description": "a meta object containing non-standard meta-information about a resource that can not be represented as an attribute or relationship."
+          },
+          "attributes": {
+            "title": "Attributes",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EntryResourceAttributes"
+              }
+            ],
+            "description": "a dictionary, containing key-value pairs representing the entry's properties, except for type and id.\n\nDatabase-provider-specific properties need to include the database-provider-specific prefix\n(see appendix `Database-Provider-Specific Namespace Prefixes`_)."
+          },
+          "relationships": {
+            "title": "Relationships",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EntryRelationships"
+              }
+            ],
+            "description": "a dictionary containing references to other entries according to the description in section `Relationships`_\nencoded as `JSON API Relationships <https://jsonapi.org/format/1.0/#document-resource-object-relationships>`__.\nThe OPTIONAL human-readable description of the relationship MAY be provided in the :field:`description` field inside the :field:`meta` dictionary."
+          }
+        },
+        "description": "Resource objects appear in a JSON:API document to represent resources."
+      },
+      "EntryResourceAttributes": {
+        "title": "EntryResourceAttributes",
+        "required": [
+          "last_modified"
+        ],
+        "type": "object",
+        "properties": {
+          "relationships": {
+            "title": "Relationships",
+            "description": "Not allowed key"
+          },
+          "links": {
+            "title": "Links",
+            "description": "Not allowed key"
+          },
+          "id": {
+            "title": "Id",
+            "description": "Not allowed key"
+          },
+          "type": {
+            "title": "Type",
+            "description": "Not allowed key"
+          },
+          "immutable_id": {
+            "title": "Immutable_Id",
+            "type": "string",
+            "description": "The entry's immutable ID (e.g., an UUID).\nThis is important for databases having preferred IDs that point to \"the latest version\" of a record, but still offer access to older variants.\nThis ID maps to the version-specific record, in case it changes in the future.\n- **Type**: string.\n- **Requirements/Conventions**:\n\n  - **Response**: OPTIONAL in the response.\n  - **Query**: If present, MUST be a queryable property with support for all mandatory filter operators.\n\n- **Examples**:\n\n  - :val:`\"8bd3e750-b477-41a0-9b11-3a799f21b44f\"`\n  - :val:`\"fjeiwoj,54;@=%<>#32\"` (Strings that are not URL-safe are allowed.)"
+          },
+          "last_modified": {
+            "title": "Last_Modified",
+            "type": "string",
+            "description": "Date and time representing when the entry was last modified.\n- **Type**: timestamp.\n- **Requirements/Conventions**:\n\n  - **Response**: REQUIRED in the response unless explicitly excluded.\n  - **Query**: MUST be a queryable property with support for all mandatory filter operators.\n\n- **Example**:\n\n  - As part of JSON response format: :VAL:`\"2007-04-05T14:30Z\"`\n    (i.e., encoded as an `RFC 3339 Internet Date/Time Format <https://tools.ietf.org/html/rfc3339#section-5.6>`__ string.)",
+            "format": "date-time"
+          }
+        },
+        "description": "Contains key-value pairs representing the entry's properties."
+      },
+      "ErrorLinks": {
+        "title": "ErrorLinks",
+        "type": "object",
+        "properties": {
+          "about": {
+            "title": "About",
+            "anyOf": [
+              {
+                "minLength": 1,
+                "maxLength": 65536,
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Link"
+                  }
+                ]
+              }
+            ],
+            "description": "A link that leads to further details about this particular occurrence of the problem."
+          }
+        },
+        "description": "A Links object specific to Error objects"
+      },
+      "ErrorResponse": {
+        "title": "ErrorResponse",
+        "required": [
+          "errors"
+        ],
+        "type": "object",
+        "properties": {
+          "data": {
+            "title": "Data",
+            "anyOf": [
+              {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Resource"
+                  }
+                ]
+              },
+              {
+                "type": "array",
+                "uniqueItems": true,
+                "items": {
+                  "$ref": "#/components/schemas/Resource"
+                }
+              }
+            ],
+            "description": "Outputted Data"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/ResponseMeta"
+          },
+          "errors": {
+            "title": "Errors",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/optimade__models__optimade_json__Error"
+            }
+          },
+          "included": {
+            "title": "Included",
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Resource"
+            },
+            "description": "A list of resources that are included"
+          },
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToplevelLinks"
+              }
+            ],
+            "description": "Links associated with the primary data"
+          },
+          "jsonapi": {
+            "title": "Jsonapi",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JsonApi"
+              }
+            ],
+            "description": "Information about the JSON API used"
+          }
+        },
+        "description": "errors MUST be present and data MUST be skipped"
+      },
+      "ErrorSource": {
+        "title": "ErrorSource",
+        "type": "object",
+        "properties": {
+          "pointer": {
+            "title": "Pointer",
+            "type": "string",
+            "description": "a JSON Pointer [RFC6901] to the associated entity in the request document [e.g. \"/data\" for a primary data object, or \"/data/attributes/title\" for a specific attribute]."
+          },
+          "parameter": {
+            "title": "Parameter",
+            "type": "string",
+            "description": "a string indicating which URI query parameter caused the error."
+          }
+        },
+        "description": "an object containing references to the source of the error"
+      },
+      "HTTPValidationError": {
+        "title": "HTTPValidationError",
+        "type": "object",
+        "properties": {
+          "detail": {
+            "title": "Detail",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            }
+          }
+        }
+      },
+      "Implementation": {
+        "title": "Implementation",
+        "type": "object",
+        "properties": {
+          "name": {
+            "title": "Name",
+            "type": "string",
+            "description": "name of the implementation"
+          },
+          "version": {
+            "title": "Version",
+            "type": "string",
+            "description": "version string of the current implementation"
+          },
+          "source_url": {
+            "title": "Source_Url",
+            "maxLength": 65536,
+            "minLength": 1,
+            "type": "string",
+            "description": "URL of the implementation source, either downloadable archive or version control system",
+            "format": "uri"
+          },
+          "maintainer": {
+            "title": "Maintainer",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ImplementationMaintainer"
+              }
+            ],
+            "description": "A dictionary providing details about the maintainer of the implementation."
+          }
+        },
+        "description": "Information on the server implementation"
+      },
+      "ImplementationMaintainer": {
+        "title": "ImplementationMaintainer",
+        "required": [
+          "email"
+        ],
+        "type": "object",
+        "properties": {
+          "email": {
+            "title": "Email",
+            "type": "string",
+            "description": "the maintainer's email address",
+            "format": "email"
+          }
+        },
+        "description": "Details about the maintainer of the implementation"
+      },
+      "IndexInfoAttributes": {
+        "title": "IndexInfoAttributes",
+        "required": [
+          "api_version",
+          "available_api_versions",
+          "available_endpoints",
+          "entry_types_by_format"
+        ],
+        "type": "object",
+        "properties": {
+          "api_version": {
+            "title": "Api_Version",
+            "type": "string",
+            "description": "Presently used version of the OPTiMaDe API"
+          },
+          "available_api_versions": {
+            "title": "Available_Api_Versions",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AvailableApiVersion"
+            },
+            "description": "A list of dictionaries of available API versions at other base URLs"
+          },
+          "formats": {
+            "title": "Formats",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of available output formats.",
+            "default": [
+              "json"
+            ]
+          },
+          "available_endpoints": {
+            "title": "Available_Endpoints",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of available endpoints (i.e., the string to be appended to the base URL)."
+          },
+          "entry_types_by_format": {
+            "title": "Entry_Types_By_Format",
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "description": "Available entry endpoints as a function of output formats."
+          },
+          "is_index": {
+            "title": "Is_Index",
+            "type": "boolean",
+            "description": "If true, this is an index meta-database base URL (see section Index Meta-Database). If this member is not provided, the client MUST assume this is not an index meta-database base URL (i.e., the default is for is_index to be false)."
+          }
+        },
+        "description": "Attributes for Base URL Info endpoint for an Index Meta-Database"
+      },
+      "IndexInfoResource": {
+        "title": "IndexInfoResource",
+        "required": [
+          "attributes",
+          "relationships"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "type": {
+            "title": "Type",
+            "type": "string"
+          },
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResourceLinks"
+              }
+            ],
+            "description": "a links object containing links related to the resource."
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Meta"
+              }
+            ],
+            "description": "a meta object containing non-standard meta-information about a resource that can not be represented as an attribute or relationship."
+          },
+          "attributes": {
+            "$ref": "#/components/schemas/IndexInfoAttributes"
+          },
+          "relationships": {
+            "title": "Relationships",
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/IndexRelationship"
+            },
+            "description": "Reference to the child identifier object under the links endpoint that the provider has chosen as their 'default' OPTiMaDe API database. A client SHOULD present this database as the first choice when an end-user chooses this provider."
+          }
+        },
+        "description": "Index Meta-Database Base URL Info enpoint resource"
+      },
+      "IndexInfoResponse": {
+        "title": "IndexInfoResponse",
+        "required": [
+          "data"
+        ],
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/IndexInfoResource"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/ResponseMeta"
+          },
+          "errors": {
+            "title": "Errors",
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/optimade__models__jsonapi__Error"
+            },
+            "description": "A list of errors"
+          },
+          "included": {
+            "title": "Included",
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Resource"
+            },
+            "description": "A list of resources that are included"
+          },
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToplevelLinks"
+              }
+            ],
+            "description": "Links associated with the primary data"
+          },
+          "jsonapi": {
+            "title": "Jsonapi",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JsonApi"
+              }
+            ],
+            "description": "Information about the JSON API used"
+          }
+        },
+        "description": "errors are not allowed"
+      },
+      "IndexRelationship": {
+        "title": "IndexRelationship",
+        "type": "object",
+        "properties": {
+          "data": {
+            "title": "Data",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RelatedChildResource"
+              }
+            ],
+            "description": "JSON API resource linkage. It MUST be either null or contain a single child identifier object with the fields:"
+          }
+        },
+        "description": "Index Meta-Database relationship"
+      },
+      "JsonApi": {
+        "title": "JsonApi",
+        "required": [
+          "version"
+        ],
+        "type": "object",
+        "properties": {
+          "version": {
+            "title": "Version",
+            "type": "string",
+            "description": "Version of the json API used"
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Meta"
+              }
+            ],
+            "description": "Non-standard meta information"
+          }
+        },
+        "description": "An object describing the server's implementation"
+      },
+      "Link": {
+        "title": "Link",
+        "required": [
+          "href"
+        ],
+        "type": "object",
+        "properties": {
+          "href": {
+            "title": "Href",
+            "maxLength": 65536,
+            "minLength": 1,
+            "type": "string",
+            "description": "a string containing the link\u2019s URL.",
+            "format": "uri"
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Meta"
+              }
+            ],
+            "description": "a meta object containing non-standard meta-information about the link."
+          }
+        },
+        "description": "A link **MUST** be represented as either: a string containing the link's URL or a link object."
+      },
+      "LinksResource": {
+        "title": "LinksResource",
+        "required": [
+          "id",
+          "type",
+          "attributes"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string",
+            "description": "An entry's ID as defined in section `Definition of Terms`_.\n- **Type**: string.\n- **Requirements/Conventions**:\n\n  - **Response**: REQUIRED in the response unless explicitly excluded.\n  - **Query**: MUST be a queryable property with support for all mandatory filter operators.\n  - See section `Definition of Terms`_.\n\n- **Examples**:\n\n  - :val:`\"db/1234567\"`\n  - :val:`\"cod/2000000\"`\n  - :val:`\"cod/2000000@1234567\"`\n  - :val:`\"nomad/L1234567890\"`\n  - :val:`\"42\"`"
+          },
+          "type": {
+            "title": "Type",
+            "type": "string",
+            "description": "MUST be either \"parent\", \"child\", or \"provider\". These objects are described in detail in sections Parent and Child Objects and Provider Objects."
+          },
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResourceLinks"
+              }
+            ],
+            "description": "a links object containing links related to the resource."
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Meta"
+              }
+            ],
+            "description": "a meta object containing non-standard meta-information about a resource that can not be represented as an attribute or relationship."
+          },
+          "attributes": {
+            "title": "Attributes",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LinksResourceAttributes"
+              }
+            ],
+            "description": "a dictionary containing key-value pairs representing the entry's properties."
+          },
+          "relationships": {
+            "title": "Relationships",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EntryRelationships"
+              }
+            ],
+            "description": "a dictionary containing references to other entries according to the description in section `Relationships`_\nencoded as `JSON API Relationships <https://jsonapi.org/format/1.0/#document-resource-object-relationships>`__.\nThe OPTIONAL human-readable description of the relationship MAY be provided in the :field:`description` field inside the :field:`meta` dictionary."
+          }
+        },
+        "description": "A Links endpoint resource object"
+      },
+      "LinksResourceAttributes": {
+        "title": "LinksResourceAttributes",
+        "required": [
+          "name",
+          "description"
+        ],
+        "type": "object",
+        "properties": {
+          "relationships": {
+            "title": "Relationships",
+            "description": "Not allowed key"
+          },
+          "links": {
+            "title": "Links",
+            "description": "Not allowed key"
+          },
+          "id": {
+            "title": "Id",
+            "description": "Not allowed key"
+          },
+          "type": {
+            "title": "Type",
+            "description": "Not allowed key"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string",
+            "description": "Human-readable name for the OPTiMaDe API implementation a client may provide in a list to an end-user."
+          },
+          "description": {
+            "title": "Description",
+            "type": "string",
+            "description": "Human-readable description for the OPTiMaDe API implementation a client may provide in a list to an end-user."
+          },
+          "base_url": {
+            "title": "Base_Url",
+            "anyOf": [
+              {
+                "minLength": 1,
+                "maxLength": 65536,
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Link"
+                  }
+                ]
+              }
+            ],
+            "description": "JSON API links object, pointing to the base URL for this implementation"
+          }
+        },
+        "description": "Links endpoint resource object attributes"
+      },
+      "LinksResponse": {
+        "title": "LinksResponse",
+        "required": [
+          "data",
+          "meta"
+        ],
+        "type": "object",
+        "properties": {
+          "data": {
+            "title": "Data",
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/LinksResource"
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              }
+            ]
+          },
+          "meta": {
+            "$ref": "#/components/schemas/ResponseMeta"
+          },
+          "errors": {
+            "title": "Errors",
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/optimade__models__jsonapi__Error"
+            },
+            "description": "A list of errors"
+          },
+          "included": {
+            "title": "Included",
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/EntryResource"
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              }
+            ]
+          },
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToplevelLinks"
+              }
+            ],
+            "description": "Links associated with the primary data"
+          },
+          "jsonapi": {
+            "title": "Jsonapi",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JsonApi"
+              }
+            ],
+            "description": "Information about the JSON API used"
+          }
+        },
+        "description": "errors are not allowed"
+      },
+      "Meta": {
+        "title": "Meta",
+        "type": "object",
+        "properties": {},
+        "description": "Non-standard meta-information that can not be represented as an attribute or relationship."
+      },
+      "Provider": {
+        "title": "Provider",
+        "required": [
+          "name",
+          "description",
+          "prefix"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "title": "Name",
+            "type": "string",
+            "description": "a short name for the database provider"
+          },
+          "description": {
+            "title": "Description",
+            "type": "string",
+            "description": "a longer description of the database provider"
+          },
+          "prefix": {
+            "title": "Prefix",
+            "type": "string",
+            "description": "database-provider-specific prefix as found in Appendix 1."
+          },
+          "homepage": {
+            "title": "Homepage",
+            "anyOf": [
+              {
+                "minLength": 1,
+                "maxLength": 65536,
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Link"
+                  }
+                ]
+              }
+            ],
+            "description": "a [JSON API links object](http://jsonapi.org/format/1.0#document-links) pointing to homepage of the database provider, either directly as a string, or as a link object."
+          },
+          "index_base_url": {
+            "title": "Index_Base_Url",
+            "anyOf": [
+              {
+                "minLength": 1,
+                "maxLength": 65536,
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Link"
+                  }
+                ]
+              }
+            ],
+            "description": "a [JSON API links object](http://jsonapi.org/format/1.0#document-links) pointing to the base URL for the `index` meta-database as specified in Appendix 1, either directly as a string, or as a link object."
+          }
+        },
+        "description": "Information on the database provider of the implementation."
+      },
+      "ReferenceRelationship": {
+        "title": "ReferenceRelationship",
+        "type": "object",
+        "properties": {
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RelationshipLinks"
+              }
+            ],
+            "description": "a links object containing at least one of the following: self, related"
+          },
+          "data": {
+            "title": "Data",
+            "anyOf": [
+              {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BaseResource"
+                  }
+                ]
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/BaseResource"
+                }
+              }
+            ],
+            "description": "Resource linkage"
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Meta"
+              }
+            ],
+            "description": "a meta object that contains non-standard meta-information about the relationship."
+          }
+        },
+        "description": "Representation references from the resource object in which it\u2019s defined to other resource objects."
+      },
+      "RelatedChildResource": {
+        "title": "RelatedChildResource",
+        "required": [
+          "id"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string",
+            "description": "Resource ID"
+          },
+          "type": {
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "description": "Keep only type and id of a ChildResource"
+      },
+      "RelationshipLinks": {
+        "title": "RelationshipLinks",
+        "type": "object",
+        "properties": {
+          "self": {
+            "title": "Self",
+            "anyOf": [
+              {
+                "minLength": 1,
+                "maxLength": 65536,
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Link"
+                  }
+                ]
+              }
+            ],
+            "description": "A link to itself"
+          },
+          "related": {
+            "title": "Related",
+            "anyOf": [
+              {
+                "minLength": 1,
+                "maxLength": 65536,
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Link"
+                  }
+                ]
+              }
+            ],
+            "description": "A related resource link"
+          }
+        },
+        "description": "A resource object **MAY** contain references to other resource objects (\"relationships\").\nRelationships may be to-one or to-many. Relationships can be specified by including a member in a resource's links object."
+      },
+      "Relationships": {
+        "title": "Relationships",
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "description": "Not allowed key"
+          },
+          "type": {
+            "title": "Type",
+            "description": "Not allowed key"
+          }
+        },
+        "description": "Members of the relationships object (\"relationships\") represent references from the resource object in which it's defined to other resource objects.\nKeys MUST NOT be:\n    type\n    id"
+      },
+      "Resource": {
+        "title": "Resource",
+        "required": [
+          "id",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string",
+            "description": "Resource ID"
+          },
+          "type": {
+            "title": "Type",
+            "type": "string",
+            "description": "Resource type"
+          },
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResourceLinks"
+              }
+            ],
+            "description": "a links object containing links related to the resource."
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Meta"
+              }
+            ],
+            "description": "a meta object containing non-standard meta-information about a resource that can not be represented as an attribute or relationship."
+          },
+          "attributes": {
+            "title": "Attributes",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Attributes"
+              }
+            ],
+            "description": "an attributes object representing some of the resource\u2019s data."
+          },
+          "relationships": {
+            "title": "Relationships",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Relationships"
+              }
+            ],
+            "description": "a relationships object describing relationships between the resource and other JSON:API resources."
+          }
+        },
+        "description": "Resource objects appear in a JSON:API document to represent resources."
+      },
+      "ResourceLinks": {
+        "title": "ResourceLinks",
+        "type": "object",
+        "properties": {
+          "self": {
+            "title": "Self",
+            "anyOf": [
+              {
+                "minLength": 1,
+                "maxLength": 65536,
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Link"
+                  }
+                ]
+              }
+            ],
+            "description": "A link that identifies the resource represented by the resource object."
+          }
+        },
+        "description": "A Resource Links object"
+      },
+      "ResponseMeta": {
+        "title": "ResponseMeta",
+        "required": [
+          "query",
+          "api_version",
+          "time_stamp",
+          "data_returned",
+          "more_data_available",
+          "provider"
+        ],
+        "type": "object",
+        "properties": {
+          "query": {
+            "title": "Query",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResponseMetaQuery"
+              }
+            ],
+            "description": "information on the query that was requested"
+          },
+          "api_version": {
+            "title": "Api_Version",
+            "type": "string",
+            "description": "a string containing the version of the API implementation, e.g. v0.9.5"
+          },
+          "time_stamp": {
+            "title": "Time_Stamp",
+            "type": "string",
+            "description": "a string containing the date and time at which the query was exexcuted",
+            "format": "date-time"
+          },
+          "data_returned": {
+            "title": "Data_Returned",
+            "minimum": 0.0,
+            "type": "integer",
+            "description": "an integer containing the number of data objects returned for the query."
+          },
+          "more_data_available": {
+            "title": "More_Data_Available",
+            "type": "boolean",
+            "description": "`false` if all data has been returned, and `true` if not."
+          },
+          "provider": {
+            "title": "Provider",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Provider"
+              }
+            ],
+            "description": "information on the database provider of the implementation."
+          },
+          "data_available": {
+            "title": "Data_Available",
+            "type": "integer",
+            "description": "an integer containing the total number of data objects available in the database"
+          },
+          "last_id": {
+            "title": "Last_Id",
+            "type": "string",
+            "description": "a string containing the last ID returned"
+          },
+          "response_message": {
+            "title": "Response_Message",
+            "type": "string",
+            "description": "response string from the server"
+          },
+          "implementation": {
+            "title": "Implementation",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Implementation"
+              }
+            ],
+            "description": "a dictionary describing the server implementation"
+          },
+          "warnings": {
+            "title": "Warnings",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Warnings"
+            },
+            "description": "List of warning resource objects representing non-critical errors or warnings. A warning resource object is defined similarly to a JSON API error object, but MUST also include the field type, which MUST have the value \"warning\". The field detail MUST be present and SHOULD contain a non-critical message, e.g., reporting unrecognized search attributes or deprecated features. The field status, representing a HTTP response status code, MUST NOT be present for a warning resource object. This is an exclusive field for error resource objects."
+          }
+        },
+        "description": "A [JSON API meta member](https://jsonapi.org/format/1.0#document-meta)\nthat contains JSON API meta objects of non-standard\nmeta-information.\n\nOPTIONAL additional information global to the query that is not\nspecified in this document, MUST start with a\ndatabase-provider-specific prefix."
+      },
+      "ResponseMetaQuery": {
+        "title": "ResponseMetaQuery",
+        "required": [
+          "representation"
+        ],
+        "type": "object",
+        "properties": {
+          "representation": {
+            "title": "Representation",
+            "type": "string",
+            "description": "a string with the part of the URL that follows the base URL."
+          }
+        },
+        "description": "Information on the query that was requested. "
+      },
+      "StructureRelationship": {
+        "title": "StructureRelationship",
+        "type": "object",
+        "properties": {
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RelationshipLinks"
+              }
+            ],
+            "description": "a links object containing at least one of the following: self, related"
+          },
+          "data": {
+            "title": "Data",
+            "anyOf": [
+              {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BaseResource"
+                  }
+                ]
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/BaseResource"
+                }
+              }
+            ],
+            "description": "Resource linkage"
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Meta"
+              }
+            ],
+            "description": "a meta object that contains non-standard meta-information about the relationship."
+          }
+        },
+        "description": "Representation references from the resource object in which it\u2019s defined to other resource objects."
+      },
+      "ToplevelLinks": {
+        "title": "ToplevelLinks",
+        "type": "object",
+        "properties": {
+          "self": {
+            "title": "Self",
+            "anyOf": [
+              {
+                "minLength": 1,
+                "maxLength": 65536,
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Link"
+                  }
+                ]
+              }
+            ],
+            "description": "A link to itself"
+          },
+          "related": {
+            "title": "Related",
+            "anyOf": [
+              {
+                "minLength": 1,
+                "maxLength": 65536,
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Link"
+                  }
+                ]
+              }
+            ],
+            "description": "A related resource link"
+          },
+          "first": {
+            "title": "First",
+            "maxLength": 65536,
+            "minLength": 1,
+            "type": "string",
+            "description": "The first page of data",
+            "format": "uri"
+          },
+          "last": {
+            "title": "Last",
+            "maxLength": 65536,
+            "minLength": 1,
+            "type": "string",
+            "description": "The last page of data",
+            "format": "uri"
+          },
+          "prev": {
+            "title": "Prev",
+            "maxLength": 65536,
+            "minLength": 1,
+            "type": "string",
+            "description": "The previous page of data",
+            "format": "uri"
+          },
+          "next": {
+            "title": "Next",
+            "maxLength": 65536,
+            "minLength": 1,
+            "type": "string",
+            "description": "The next page of data",
+            "format": "uri"
+          }
+        },
+        "description": "A set of Links objects, possibly including pagination"
+      },
+      "ValidationError": {
+        "title": "ValidationError",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "loc": {
+            "title": "Location",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "msg": {
+            "title": "Message",
+            "type": "string"
+          },
+          "type": {
+            "title": "Error Type",
+            "type": "string"
+          }
+        }
+      },
+      "Warnings": {
+        "title": "Warnings",
+        "required": [
+          "detail"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string",
+            "description": "A unique identifier for this particular occurrence of the problem."
+          },
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorLinks"
+              }
+            ],
+            "description": "A links object storing about"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string",
+            "description": "the HTTP status code applicable to this problem, expressed as a string value."
+          },
+          "code": {
+            "title": "Code",
+            "type": "string",
+            "description": "an application-specific error code, expressed as a string value."
+          },
+          "title": {
+            "title": "Title",
+            "type": "string",
+            "description": "A short, human-readable summary of the problem. It **SHOULD NOT** change from occurrence to occurrence of the problem, except for purposes of localization."
+          },
+          "detail": {
+            "title": "Detail",
+            "type": "string",
+            "description": "A human-readable explanation specific to this occurrence of the problem."
+          },
+          "source": {
+            "title": "Source",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorSource"
+              }
+            ],
+            "description": "An object containing references to the source of the error"
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Meta"
+              }
+            ],
+            "description": "a meta object containing non-standard meta-information about the error."
+          },
+          "type": {
+            "title": "Type",
+            "type": "string",
+            "description": "Warnings must be of type \"warning\""
+          }
+        },
+        "description": "OPTiMaDe-specific warning class based on OPTiMaDe-specific JSON API Error.\nFrom the specification:\n\n    A warning resource object is defined similarly to a JSON API\n    error object, but MUST also include the field type, which MUST\n    have the value \"warning\". The field detail MUST be present and\n    SHOULD contain a non-critical message, e.g., reporting\n    unrecognized search attributes or deprecated features.\n\nNote: Must be named \"Warnings\", since \"Warning\" is a built-in Python class."
+      },
+      "optimade__models__jsonapi__Error": {
+        "title": "Error",
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string",
+            "description": "A unique identifier for this particular occurrence of the problem."
+          },
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorLinks"
+              }
+            ],
+            "description": "A links object storing about"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string",
+            "description": "the HTTP status code applicable to this problem, expressed as a string value."
+          },
+          "code": {
+            "title": "Code",
+            "type": "string",
+            "description": "an application-specific error code, expressed as a string value."
+          },
+          "title": {
+            "title": "Title",
+            "type": "string",
+            "description": "A short, human-readable summary of the problem. It **SHOULD NOT** change from occurrence to occurrence of the problem, except for purposes of localization."
+          },
+          "detail": {
+            "title": "Detail",
+            "type": "string",
+            "description": "A human-readable explanation specific to this occurrence of the problem."
+          },
+          "source": {
+            "title": "Source",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorSource"
+              }
+            ],
+            "description": "An object containing references to the source of the error"
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Meta"
+              }
+            ],
+            "description": "a meta object containing non-standard meta-information about the error."
+          }
+        },
+        "description": "An error response"
+      },
+      "optimade__models__optimade_json__Error": {
+        "title": "Error",
+        "required": [
+          "detail"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string",
+            "description": "A unique identifier for this particular occurrence of the problem."
+          },
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorLinks"
+              }
+            ],
+            "description": "A links object storing about"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string",
+            "description": "the HTTP status code applicable to this problem, expressed as a string value."
+          },
+          "code": {
+            "title": "Code",
+            "type": "string",
+            "description": "an application-specific error code, expressed as a string value."
+          },
+          "title": {
+            "title": "Title",
+            "type": "string",
+            "description": "A short, human-readable summary of the problem. It **SHOULD NOT** change from occurrence to occurrence of the problem, except for purposes of localization."
+          },
+          "detail": {
+            "title": "Detail",
+            "type": "string",
+            "description": "A human-readable explanation specific to this occurrence of the problem."
+          },
+          "source": {
+            "title": "Source",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorSource"
+              }
+            ],
+            "description": "An object containing references to the source of the error"
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Meta"
+              }
+            ],
+            "description": "a meta object containing non-standard meta-information about the error."
+          }
+        },
+        "description": "detail MUST be present"
+      }
+    }
+  }
+}

--- a/optimade/models/baseinfo.py
+++ b/optimade/models/baseinfo.py
@@ -48,17 +48,17 @@ class BaseInfoAttributes(BaseModel):
         "(i.e., the default is for is_index to be false).",
     )
 
-    @validator("entry_types_by_format", whole=True)
-    def formats_and_endpoints_must_be_valid(cls, v, values):
-        for format_, endpoints in v.items():
-            if format_ not in values["formats"]:
-                raise ValueError(f"'{format_}' must be listed in formats to be valid")
-            for endpoint in endpoints:
-                if endpoint not in values["available_endpoints"]:
-                    raise ValueError(
-                        f"'{endpoint}' must be listed in available_endpoints to be valid"
-                    )
-        return v
+    # @validator("entry_types_by_format", whole=True, check_fields=False)
+    # def formats_and_endpoints_must_be_valid(cls, v, values):
+    #     for format_, endpoints in v.items():
+    #         if format_ not in values["formats"]:
+    #             raise ValueError(f"'{format_}' must be listed in formats to be valid")
+    #         for endpoint in endpoints:
+    #             if endpoint not in values["available_endpoints"]:
+    #                 raise ValueError(
+    #                     f"'{endpoint}' must be listed in available_endpoints to be valid"
+    #                 )
+    #     return v
 
 
 class BaseInfoResource(Resource):

--- a/optimade/models/toplevel.py
+++ b/optimade/models/toplevel.py
@@ -13,6 +13,7 @@ from .jsonapi import Link, Meta
 from .utils import NonnegativeInt
 from .baseinfo import BaseInfoResource
 from .entries import EntryInfoResource, EntryResource
+from .index_metadb import IndexInfoResource
 from .links import LinksResource
 from .optimade_json import Error, Success, Failure, Warnings
 from .references import ReferenceResource
@@ -27,6 +28,7 @@ __all__ = (
     "ResponseMeta",
     "ErrorResponse",
     "EntryInfoResponse",
+    "IndexInfoResponse",
     "InfoResponse",
     "LinksResponse",
     "EntryResponseOne",
@@ -178,6 +180,11 @@ class ResponseMeta(Meta):
 class ErrorResponse(Failure):
     meta: Optional[ResponseMeta] = Schema(...)
     errors: List[Error] = Schema(...)
+
+
+class IndexInfoResponse(Success):
+    meta: Optional[ResponseMeta] = Schema(...)
+    data: IndexInfoResource = Schema(...)
 
 
 class EntryInfoResponse(Success):

--- a/optimade/server/config.ini
+++ b/optimade/server/config.ini
@@ -8,13 +8,14 @@ STRUCTURES_COLLECTION = structures
 [IMPLEMENTATION]
 PAGE_LIMIT = 500
 VERSION = 0.10.0
+DEFAULT_DB = test_server
 
 [PROVIDER]
 prefix = _exmpl_
 name = Example provider
 description = Provider used for examples, not to be assigned to a real database
 homepage = http://example.com
-index_base_url = http://example.com/index/optimade
+index_base_url = http://localhost:5001/index/optimade
 
 [structures]
 band_gap :

--- a/optimade/server/config.py
+++ b/optimade/server/config.py
@@ -29,11 +29,7 @@ class Config:
         if not server_cfg.exists():
             import shutil
 
-            server_cfg_template = (
-                Path(__file__)
-                .resolve()
-                .parent.parent.parent.joinpath("server_template.cfg")
-            )
+            server_cfg_template = server_cfg.parent.joinpath("server_template.cfg")
             shutil.copyfile(server_cfg_template, server_cfg)
 
     def _load_server_config(self, server_cfg: Path):

--- a/optimade/server/config.py
+++ b/optimade/server/config.py
@@ -41,6 +41,7 @@ class ServerConfig(Config):
 
     page_limit = 500
     version = "0.10.0"
+    default_db = "test_server"
 
     provider = {
         "prefix": "_exmpl_",
@@ -69,6 +70,7 @@ class ServerConfig(Config):
             "IMPLEMENTATION", "PAGE_LIMIT", fallback=self.page_limit
         )
         self.version = config.get("IMPLEMENTATION", "VERSION", fallback=self.version)
+        self.default_db = config.get("IMPLEMENTATION", "DEFAULT_DB", fallback=self.default_db)
 
         if "PROVIDER" in config.sections():
             self.provider = dict(config["PROVIDER"])
@@ -110,6 +112,7 @@ class ServerConfig(Config):
 
         self.page_limit = int(config.get("page_limit", self.page_limit))
         self.version = config.get("version", self.version)
+        self.default_db = config.get("default_db", self.default_db)
 
         self.provider = config.get("provider", self.provider)
         self.provider_fields = set(config.get("provider_fields", self.provider_fields))

--- a/optimade/server/config.py
+++ b/optimade/server/config.py
@@ -53,6 +53,18 @@ class Config:
         _path = server.get(SECTION, SERVER_CONFIG_PATH, fallback=str(self._path))
         self._path = server_cfg.parent.joinpath(_path).resolve()
 
+        if not self._path.exists():
+            raise ValueError(
+                f'Cannot resolve {self._path}. Check the config-file exists. Note, "~" is not allowed.'
+            )
+
+        if not self.index_links_path.exists():
+            from warnings import warn
+
+            warn(
+                f'Cannot resolve {self.index_links_path}. Check the index_links.json file exists. Note, "~" is not allowed.'
+            )
+
     def _get_load_func(self, format_name) -> Any:
         return getattr(self, f"load_from_{format_name}")
 

--- a/optimade/server/config.py
+++ b/optimade/server/config.py
@@ -1,5 +1,5 @@
 import json
-from typing import Dict, Set
+from typing import Dict, Set, Any
 from configparser import ConfigParser
 from pathlib import Path
 
@@ -7,13 +7,53 @@ from pathlib import Path
 class Config:
     """Base class for loading config files and its parameters"""
 
-    ftype = "ini"
+    index_links_path: Path = Path("./optimade/server/index_links.json")
+    _path: Path = Path("./optimade/server/config.ini")
 
-    def __init__(self, ftype: str = None):
-        ftype = self.ftype if ftype is None else ftype
+    def __init__(self, server_cfg: Path = None):
+        server = (
+            Path(__file__).resolve().parent.parent.parent.joinpath("server.cfg")
+            if server_cfg is None
+            else server_cfg
+        )
+
+        self._create_server_config(server)
+        self._load_server_config(server)
+
+        ftype = self._path.suffix[1:]  # Remove initial "."
         self.load(ftype)
 
-    def _get_load_func(self, format_name):
+    @staticmethod
+    def _create_server_config(server_cfg: Path):
+        """Create 'server.cfg' in top-package dir from 'server_template.cfg' if it does not exist"""
+        if not server_cfg.exists():
+            import shutil
+
+            server_cfg_template = (
+                Path(__file__)
+                .resolve()
+                .parent.parent.parent.joinpath("server_template.cfg")
+            )
+            shutil.copyfile(server_cfg_template, server_cfg)
+
+    def _load_server_config(self, server_cfg: Path):
+        """Load cfg-file determining paths to server config files"""
+        SECTION = "optimadeconfig"
+        INDEX_LINKS_PATH = "INDEX_LINKS"
+        SERVER_CONFIG_PATH = "CONFIG"
+
+        server = ConfigParser()
+        server.read(server_cfg)
+
+        index_links_path = server.get(
+            SECTION, INDEX_LINKS_PATH, fallback=str(self.index_links_path)
+        )
+        self.index_links_path = server_cfg.parent.joinpath(index_links_path).resolve()
+
+        _path = server.get(SECTION, SERVER_CONFIG_PATH, fallback=str(self._path))
+        self._path = server_cfg.parent.joinpath(_path).resolve()
+
+    def _get_load_func(self, format_name) -> Any:
         return getattr(self, f"load_from_{format_name}")
 
     def load(self, ftype: str = None):
@@ -51,13 +91,12 @@ class ServerConfig(Config):
         "index_base_url": "http://example.com/optimade/index",
     }
     provider_fields: Dict[str, Set] = {}
-    _path = Path(__file__).resolve().parent
 
     def load_from_ini(self):
         """ Load from the file "config.ini", if it exists. """
 
         config = ConfigParser()
-        config.read(self._path.joinpath("config.ini"))
+        config.read(self._path)
 
         self.use_real_mongo = config.getboolean(
             "BACKEND", "USE_REAL_MONGO", fallback=self.use_real_mongo
@@ -70,7 +109,9 @@ class ServerConfig(Config):
             "IMPLEMENTATION", "PAGE_LIMIT", fallback=self.page_limit
         )
         self.version = config.get("IMPLEMENTATION", "VERSION", fallback=self.version)
-        self.default_db = config.get("IMPLEMENTATION", "DEFAULT_DB", fallback=self.default_db)
+        self.default_db = config.get(
+            "IMPLEMENTATION", "DEFAULT_DB", fallback=self.default_db
+        )
 
         if "PROVIDER" in config.sections():
             self.provider = dict(config["PROVIDER"])
@@ -80,7 +121,7 @@ class ServerConfig(Config):
             self.provider_fields[endpoint] = (
                 {field for field, _ in config[endpoint].items() if _ == ""}
                 if endpoint in config
-                else {}
+                else set()
             )
 
             # MONGO collections
@@ -97,7 +138,7 @@ class ServerConfig(Config):
     def load_from_json(self):
         """ Load from the file "config.json", if it exists. """
 
-        with open(self._path.joinpath("config.json"), "r") as f:
+        with open(self._path, "r") as f:
             config = json.load(f)
 
         self.use_real_mongo = bool(config.get("use_real_mongo", self.use_real_mongo))

--- a/optimade/server/index_links.json
+++ b/optimade/server/index_links.json
@@ -3,7 +3,7 @@
     "_id": {
       "$oid": "746573745f73657276657263"
     },
-    "task_id": "test_server",
+    "id": "test_server",
     "type": "child",
     "name": "OPTiMaDe API",
     "description": "The [Open Databases Integration for Materials Design (OPTiMaDe) consortium](http://http://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.",

--- a/optimade/server/index_links.json
+++ b/optimade/server/index_links.json
@@ -1,0 +1,12 @@
+[
+  {
+    "_id": {
+      "$oid": "746573745f73657276657263"
+    },
+    "task_id": "test_server",
+    "type": "child",
+    "name": "OPTiMaDe API",
+    "description": "The [Open Databases Integration for Materials Design (OPTiMaDe) consortium](http://http://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.",
+    "base_url": "http://localhost:5000/optimade"
+  }
+]

--- a/optimade/server/main_index.py
+++ b/optimade/server/main_index.py
@@ -1,0 +1,80 @@
+import json
+from pathlib import Path
+
+from pydantic import ValidationError
+from fastapi import FastAPI
+from fastapi.exceptions import RequestValidationError
+from starlette.exceptions import HTTPException as StarletteHTTPException
+
+from .config import CONFIG
+from .routers import index_info, links
+
+import optimade.server.exception_handlers as exc_handlers
+
+
+app = FastAPI(
+    title="OPTiMaDe API - Index meta-database",
+    description=(
+        "The [Open Databases Integration for Materials Design (OPTiMaDe) consortium]"
+        "(http://http://www.optimade.org/) aims to make materials databases interoperational "
+        "by developing a common REST API.\n"
+        'This is the "special" index meta-database.'
+    ),
+    version=CONFIG.version,
+    docs_url="/index/optimade/extensions/docs",
+    redoc_url="/index/optimade/extensions/redoc",
+    openapi_url="/index/optimade/extensions/openapi.json",
+)
+
+
+index_links_path = Path(__file__).resolve().parent.joinpath("index_links.json")
+if not CONFIG.use_real_mongo and index_links_path.exists():
+    import bson.json_util
+    from .routers.links import links_coll
+
+    print("loading index links...")
+    with open(index_links_path) as f:
+        data = json.load(f)
+        print("inserting index links into collection...")
+        links_coll.collection.insert_many(
+            bson.json_util.loads(bson.json_util.dumps(data))
+        )
+    print("done inserting index links...")
+
+
+app.add_exception_handler(StarletteHTTPException, exc_handlers.http_exception_handler)
+app.add_exception_handler(
+    RequestValidationError, exc_handlers.request_validation_exception_handler
+)
+app.add_exception_handler(ValidationError, exc_handlers.validation_exception_handler)
+app.add_exception_handler(Exception, exc_handlers.general_exception_handler)
+
+
+# Create the following prefixes:
+#   /optimade
+#   /optimade/vMajor (but only if Major >= 1)
+#   /optimade/vMajor.Minor
+#   /optimade/vMajor.Minor.Patch
+valid_prefixes = ["/index/optimade"]
+version = [int(_) for _ in app.version.split(".")]
+while version:
+    if version[0] or len(version) >= 2:
+        valid_prefixes.append(
+            "/index/optimade/v{}".format(".".join([str(_) for _ in version]))
+        )
+    version.pop(-1)
+
+for prefix in valid_prefixes:
+    app.include_router(index_info.router, prefix=prefix)
+    app.include_router(links.router, prefix=prefix)
+
+
+def update_schema(app):
+    """Update OpenAPI schema in file 'local_index_openapi.json'"""
+    with open("local_index_openapi.json", "w") as f:
+        json.dump(app.openapi(), f, indent=2)
+
+
+@app.on_event("startup")
+async def startup_event():
+    update_schema(app)

--- a/optimade/server/main_index.py
+++ b/optimade/server/main_index.py
@@ -1,5 +1,4 @@
 import json
-from pathlib import Path
 
 from pydantic import ValidationError
 from fastapi import FastAPI

--- a/optimade/server/main_index.py
+++ b/optimade/server/main_index.py
@@ -27,13 +27,12 @@ app = FastAPI(
 )
 
 
-index_links_path = Path(__file__).resolve().parent.joinpath("index_links.json")
-if not CONFIG.use_real_mongo and index_links_path.exists():
+if not CONFIG.use_real_mongo and CONFIG.index_links_path.exists():
     import bson.json_util
     from .routers.links import links_coll
 
     print("loading index links...")
-    with open(index_links_path) as f:
+    with open(CONFIG.index_links_path) as f:
         data = json.load(f)
         print("inserting index links into collection...")
         links_coll.collection.insert_many(

--- a/optimade/server/routers/index_info.py
+++ b/optimade/server/routers/index_info.py
@@ -22,13 +22,15 @@ router = APIRouter()
 @router.get(
     "/info",
     response_model=Union[IndexInfoResponse, ErrorResponse],
-    response_model_skip_defaults=False,
+    response_model_exclude_unset=True,
     tags=["Info"],
 )
 def get_info(request: Request):
     return IndexInfoResponse(
         meta=meta_values(str(request.url), 1, 1, more_data_available=False),
         data=IndexInfoResource(
+            id=IndexInfoResource.schema()["properties"]["id"]["const"],
+            type=IndexInfoResource.schema()["properties"]["type"]["const"],
             attributes=IndexInfoAttributes(
                 api_version=f"v{CONFIG.version}",
                 available_api_versions=[
@@ -37,8 +39,9 @@ def get_info(request: Request):
                         "version": f"{CONFIG.version}",
                     }
                 ],
-                entry_types_by_format={"json": ["links"]},
+                formats=["json"],
                 available_endpoints=["info", "links"],
+                entry_types_by_format={"json": []},
                 is_index=True,
             ),
             relationships={

--- a/optimade/server/routers/index_info.py
+++ b/optimade/server/routers/index_info.py
@@ -1,0 +1,50 @@
+from typing import Union
+
+from fastapi import APIRouter
+from starlette.requests import Request
+
+from optimade.models import (
+    ErrorResponse,
+    IndexInfoResponse,
+    IndexInfoAttributes,
+    IndexInfoResource,
+    IndexRelationship,
+)
+
+from optimade.server.config import CONFIG
+
+from .utils import meta_values
+
+
+router = APIRouter()
+
+
+@router.get(
+    "/info",
+    response_model=Union[IndexInfoResponse, ErrorResponse],
+    response_model_skip_defaults=False,
+    tags=["Info"],
+)
+def get_info(request: Request):
+    return IndexInfoResponse(
+        meta=meta_values(str(request.url), 1, 1, more_data_available=False),
+        data=IndexInfoResource(
+            attributes=IndexInfoAttributes(
+                api_version=f"v{CONFIG.version}",
+                available_api_versions=[
+                    {
+                        "url": f"{CONFIG.provider['index_base_url']}/v{CONFIG.version}/",
+                        "version": f"{CONFIG.version}",
+                    }
+                ],
+                entry_types_by_format={"json": ["links"]},
+                available_endpoints=["info", "links"],
+                is_index=True,
+            ),
+            relationships={
+                "default": IndexRelationship(
+                    data={"type": "child", "id": CONFIG.default_db}
+                )
+            },
+        ),
+    )

--- a/optimade/server/routers/info.py
+++ b/optimade/server/routers/info.py
@@ -48,8 +48,9 @@ def get_info(request: Request):
                     }
                 ],
                 formats=["json"],
-                available_endpoints=["info"] + list(ENTRY_INFO_SCHEMAS.keys()),
+                available_endpoints=["info", "links"] + list(ENTRY_INFO_SCHEMAS.keys()),
                 entry_types_by_format={"json": list(ENTRY_INFO_SCHEMAS.keys())},
+                is_index=False,
             ),
         ),
     )

--- a/optimade/server/routers/utils.py
+++ b/optimade/server/routers/utils.py
@@ -43,7 +43,7 @@ def meta_values(
         query=ResponseMetaQuery(
             representation=f"{parse_result.path}?{parse_result.query}"
         ),
-        api_version="v0.10",
+        api_version=f"v{CONFIG.version}",
         time_stamp=datetime.utcnow(),
         data_returned=data_returned,
         more_data_available=more_data_available,

--- a/optimade/server/tests/test_index_server.py
+++ b/optimade/server/tests/test_index_server.py
@@ -1,0 +1,102 @@
+# pylint: disable=no-member,wrong-import-position
+import unittest
+import abc
+
+from starlette.testclient import TestClient
+
+from optimade.validator import ImplementationValidator
+
+from optimade.models import IndexInfoResponse, LinksResponse
+
+from optimade.server.main_index import app
+from optimade.server.routers import index_info, links
+
+# We need to remove the /optimade prefixes in order to have the tests run correctly.
+app.include_router(index_info.router)
+app.include_router(links.router)
+# need to explicitly set base_url, as the default "http://testserver"
+# does not validate as pydantic UrlStr model
+CLIENT = TestClient(app, base_url="http://example.org/index/optimade")
+
+
+class IndexEndpointTests(abc.ABC):
+    """ Abstract base class for common tests between endpoints. """
+
+    request_str = None
+    response_cls = None
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.client = CLIENT
+
+        self.response = self.client.get(self.request_str)
+        self.json_response = self.response.json()
+        self.assertEqual(
+            self.response.status_code,
+            200,
+            msg=f"Request failed: {self.response.json()}",
+        )
+
+    def test_meta_response(self):
+        self.assertTrue("meta" in self.json_response)
+        meta_required_keys = [
+            "query",
+            "api_version",
+            "time_stamp",
+            "data_returned",
+            "more_data_available",
+            "provider",
+        ]
+
+        self.check_keys(meta_required_keys, self.json_response["meta"])
+
+    def test_serialize_response(self):
+        self.assertTrue(
+            self.response_cls is not None, msg="Response class unset for this endpoint"
+        )
+        self.response_cls(**self.json_response)  # pylint: disable=not-callable
+
+    def check_keys(self, keys, response_subset):
+        for key in keys:
+            self.assertTrue(
+                key in response_subset,
+                msg="{} missing from response {}".format(key, response_subset),
+            )
+
+
+class IndexInfoEndpointTests(IndexEndpointTests, unittest.TestCase):
+
+    request_str = "/info"
+    response_cls = IndexInfoResponse
+
+    def test_info_endpoint_attributes(self):
+        self.assertTrue("data" in self.json_response)
+        self.assertEqual(self.json_response["data"]["type"], "info")
+        self.assertEqual(self.json_response["data"]["id"], "/")
+        self.assertTrue("attributes" in self.json_response["data"])
+        attributes = [
+            "api_version",
+            "available_api_versions",
+            "formats",
+            "entry_types_by_format",
+            "available_endpoints",
+            "is_index",
+        ]
+        self.check_keys(attributes, self.json_response["data"]["attributes"])
+        self.assertTrue("relationships" in self.json_response["data"])
+        relationships = ["default"]
+        self.check_keys(relationships, self.json_response["data"]["relationships"])
+        self.assertTrue(len(self.json_response["data"]["relationships"]["default"]), 1)
+
+
+class LinksEndpointTests(IndexEndpointTests, unittest.TestCase):
+    request_str = "/links"
+    response_cls = LinksResponse
+
+
+class ServerTestWithValidator(unittest.TestCase):
+    def test_with_validator(self):
+        validator = ImplementationValidator(client=CLIENT, index=True)
+        validator.main()
+        self.assertTrue(validator.valid)

--- a/optimade/server/tests/test_links.json
+++ b/optimade/server/tests/test_links.json
@@ -1,15 +1,12 @@
 [
-    {
-      "_id": {
-        "$oid": "5cfb441f053b174410700d03"
-      },
-      "id": "index",
-      "last_modified": {
-        "$date": "2019-11-12T14:24:37.331Z"
-      },
-      "type": "parent",
-      "name": "Index meta-database",
-      "description": "Index for example's OPTiMaDe databases",
-      "base_url": "http://example.com/optimade/index"
-    }
-  ]
+  {
+    "_id": {
+      "$oid": "696e646578706172656e7430"
+    },
+    "task_id": "index",
+    "type": "parent",
+    "name": "Index meta-database",
+    "description": "Index for example's OPTiMaDe databases",
+    "base_url": "http://localhost:5001/index/optimade"
+  }
+]

--- a/optimade/server/tests/test_links.json
+++ b/optimade/server/tests/test_links.json
@@ -3,7 +3,7 @@
     "_id": {
       "$oid": "696e646578706172656e7430"
     },
-    "task_id": "index",
+    "id": "index",
     "type": "parent",
     "name": "Index meta-database",
     "description": "Index for example's OPTiMaDe databases",

--- a/optimade/server/tests/test_server.py
+++ b/optimade/server/tests/test_server.py
@@ -14,13 +14,15 @@ from optimade.models import (
     StructureResponseOne,
     EntryInfoResponse,
     InfoResponse,
+    LinksResponse,
 )
 
 from optimade.server.main import app
-from optimade.server.routers import info, references, structures
+from optimade.server.routers import info, links, references, structures
 
 # We need to remove the /optimade prefixes in order to have the tests run correctly.
 app.include_router(info.router)
+app.include_router(links.router)
 app.include_router(references.router)
 app.include_router(structures.router)
 # need to explicitly set base_url, as the default "http://testserver"
@@ -108,6 +110,11 @@ class InfoStructuresEndpointTests(EndpointTests, unittest.TestCase):
 class InfoReferencesEndpointTests(EndpointTests, unittest.TestCase):
     request_str = "/info/references"
     response_cls = EntryInfoResponse
+
+
+class LinksEndpointTests(EndpointTests, unittest.TestCase):
+    request_str = "/links"
+    response_cls = LinksResponse
 
 
 class ReferencesEndpointTests(EndpointTests, unittest.TestCase):

--- a/optimade/validator/__init__.py
+++ b/optimade/validator/__init__.py
@@ -1,5 +1,4 @@
 """ This module contains the ImplementationValidator class and corresponding command line tools. """
-# pylint: disable=line-too-long
 
 from .validator import ImplementationValidator
 
@@ -46,7 +45,15 @@ def validate():
         "-a",
         type=str,
         help=(
-            """Validate the request URL with the provided type, rather than scanning the entire implementation e.g. optimade_validator `http://example.com/optimade/structures/0 --as_type structures`"""
+            "Validate the request URL with the provided type, rather than scanning the entire implementation e.g. "
+            "optimade_validator `http://example.com/optimade/structures/0 --as_type structures`"
+        ),
+    )
+    parser.add_argument(
+        "--index",
+        action="store_true",
+        help=(
+            "Flag for whether the specified OPTiMaDe implementation is an Index meta-database or not. [default=False]"
         ),
     )
 
@@ -56,16 +63,20 @@ def validate():
         "info",
         "info/references",
         "info/structures",
+        "links",
         "references",
         "reference",
         "structures",
         "structure",
     ]
     if args["as_type"] is not None and args["as_type"] not in valid_types:
-        sys.exit("{args['as_type']} is not a valid type, must be one of {valid_types}")
+        sys.exit(f"{args['as_type']} is not a valid type, must be one of {valid_types}")
 
     validator = ImplementationValidator(
-        base_url=args["base_url"], verbosity=args["verbosity"], as_type=args["as_type"]
+        base_url=args["base_url"],
+        verbosity=args["verbosity"],
+        as_type=args["as_type"],
+        index=args["index"],
     )
 
     try:

--- a/optimade/validator/validator_model_patches.py
+++ b/optimade/validator/validator_model_patches.py
@@ -5,7 +5,7 @@ validation responses.
 
 """
 
-from typing import List, Optional, List, Dict, Any
+from typing import List, Optional, Dict, Any
 
 from pydantic import Schema
 
@@ -13,9 +13,15 @@ from optimade.models.optimade_json import Success
 from optimade.models import (
     ResponseMeta,
     EntryResource,
-    StructureResource,
+    LinksResource,
     ReferenceResource,
+    StructureResource,
 )
+
+
+class ValidatorLinksResponse(Success):
+    meta: ResponseMeta = Schema(...)
+    data: List[LinksResource] = Schema(...)
 
 
 class ValidatorEntryResponseOne(Success):
@@ -30,17 +36,17 @@ class ValidatorEntryResponseMany(Success):
     included: Optional[List[Dict[str, Any]]] = Schema(...)
 
 
-class ValidatorStructureResponseOne(ValidatorEntryResponseOne):
-    data: StructureResource = Schema(...)
-
-
-class ValidatorStructureResponseMany(ValidatorEntryResponseMany):
-    data: List[StructureResource] = Schema(...)
-
-
 class ValidatorReferenceResponseOne(ValidatorEntryResponseOne):
     data: ReferenceResource = Schema(...)
 
 
 class ValidatorReferenceResponseMany(ValidatorEntryResponseMany):
     data: List[ReferenceResource] = Schema(...)
+
+
+class ValidatorStructureResponseOne(ValidatorEntryResponseOne):
+    data: StructureResource = Schema(...)
+
+
+class ValidatorStructureResponseMany(ValidatorEntryResponseMany):
+    data: List[StructureResource] = Schema(...)

--- a/run.sh
+++ b/run.sh
@@ -1,2 +1,11 @@
 #!/bin/bash
-uvicorn optimade.server.main:app --reload --port 5000
+if [ "$1" == "index" ]
+then
+    MAIN="main_index"
+    PORT=5001
+else
+    MAIN="main"
+    PORT=5000
+fi
+
+uvicorn optimade.server.$MAIN:app --reload --port $PORT

--- a/server_template.cfg
+++ b/server_template.cfg
@@ -1,0 +1,3 @@
+[optimadeconfig]
+CONFIG = ./optimade/server/config.ini
+INDEX_LINKS = ./optimade/server/index_links.json

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [pycodestyle]
-ignore = E501,W503
+ignore = E501, W503

--- a/tasks.py
+++ b/tasks.py
@@ -38,3 +38,4 @@ def setver(_, patch=False, new_ver=""):
 @task
 def update_openapijson(c):
     c.run("cp local_openapi.json openapi.json")
+    c.run("cp local_index_openapi.json index_openapi.json")


### PR DESCRIPTION
Closes #100

Easily implement an OPTiMaDe [Index meta-database](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst#index-meta-database) using this repository.

## Start

Start the index meta-database by writing:

```shell
/path/to/optimade-python-tools$ ./run.sh index
```

This runs an `uvicorn` server at `http://localhost:5001/index/optimade`, making it possible to open a new terminal and also run the "standard" OPTiMaDe server (at `http://localhost:5000/optimade`).

## Setup

The file `/optimade/server/index_links_json` can be modified to list all known OPTiMaDe implementations by a provider to be listed under the index meta-database's `/links` endpoint.

**EDIT**: By request from @ltalirz, I have added support for a `server.cfg` file in the top-package directory.
This is also added to `.gitignore`, so if anyone forks the repository and wished to contribute back some updates, the file will not be overwritten. Instead, a `server_template.cfg` file exists that should _never_ be changed in forks, but used as a template for their own `server.cfg` file. This is due to the fact that if a `server.cfg` file is indeed not found, one will be created as a copy of `server_template.cfg`. This is needed for tests etc.

The point of `server.cfg` is to relay paths to server configuration files. So it currently has the paths for the `config.ini` or `config.json` file and the `index_links.json` file. ~Note that the paths at this point MUST be relative, with respect to the location of `server.cfg`. This may be updated, with a check if the paths given in `server.cfg` are absolute or not, before setting them in `CONFIG`.~
The paths can be relative, but MUST be so from the location of `server.cfg`. They may also be absolute. They may, however, _never_ include "~", since the `Path`-class cannot resolve this.

## Missing
- [x] Make tests for the index meta-database.
- [x] Add OpenAPI validation for index meta-database.
- [x] Add comparison of the created `local_index_openapi.json` with the file `index_openapi.json`.