### PR TITLE
Automatically publish version tags to PyPI via GH Actions

### DIFF
--- a/.ci/assert_version.py
+++ b/.ci/assert_version.py
@@ -1,0 +1,24 @@
+import os
+
+try:
+    from optimade import __version__
+except ImportError:
+    raise ImportError(
+        "optimade needs to be installed prior to running 'assert_version.py'"
+    )
+
+package_version = f"v{__version__}"
+
+tag_version = os.getenv("TAG_VERSION")
+tag_version = tag_version[len("refs/tags/") :]
+
+if tag_version == package_version:
+    print(f"The versions match: tag:'{tag_version}' == package:'{package_version}'")
+    exit(0)
+
+print(
+    f"""The current package version '{package_version}' does not equal the tag version '{tag_version}'.
+Update package version by \"invoke setver --new-ver='{tag_version[1:]}'\" and re-commit.
+Please remove the tag from both GitHub and your local repository and try again!"""
+)
+exit(1)

--- a/.ci/json_diff.sh
+++ b/.ci/json_diff.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 diff=$(jsondiff openapi.json local_openapi.json);
 
-if [ ! "$diff" = "{}" ]; then 
-    echo -e "Generated OpenAPI spec did not match committed version.\nRun 'invoke update_openapijson' and re-commit.\nDiff:\n$diff"; 
+if [ ! "$diff" = "{}" ]; then
+    echo -e "Generated OpenAPI spec did not match committed version.\nRun 'invoke update_openapijson' and re-commit.\nDiff:\n$diff";
 exit 1;
 fi

--- a/.ci/json_diff.sh
+++ b/.ci/json_diff.sh
@@ -2,6 +2,6 @@
 diff=$(jsondiff openapi.json local_openapi.json);
 
 if [ ! "$diff" = "{}" ]; then 
-    echo -e "Generated OpenAPI spec did not match committed version. Diff:\n$diff"; 
+    echo -e "Generated OpenAPI spec did not match committed version.\nRun 'invoke update_openapijson' and re-commit.\nDiff:\n$diff"; 
 exit 1;
 fi

--- a/.github/workflows/deps_lint.yml
+++ b/.github/workflows/deps_lint.yml
@@ -92,7 +92,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
-    - name: Set up Python ${{ matrix.python-version }} 
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
@@ -129,7 +129,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
-    - name: Set up Python ${{ matrix.python-version }} 
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
@@ -157,7 +157,7 @@ jobs:
   #   steps:
   #   - uses: actions/checkout@v1
 
-  #   - name: Set up Python ${{ matrix.python-version }} 
+  #   - name: Set up Python ${{ matrix.python-version }}
   #     uses: actions/setup-python@v1
   #     with:
   #       python-version: ${{ matrix.python-version }}

--- a/.github/workflows/publish-on-pypi.yml
+++ b/.github/workflows/publish-on-pypi.yml
@@ -1,0 +1,42 @@
+name: Publish on PyPI
+
+on:
+  push:
+    tags:
+      # No alpha, beta or release candidate releases are allowed
+      - v[0-9]+.[0-9]+.[0-9]+
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    if: github.repository == 'Materials-Consortia/optimade-python-tools' && startsWith(github.ref, 'refs/tags/v')
+
+    steps:
+    - name: Set up Python 3.7 
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+
+    - name: Upgrade setuptools
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install --upgrade setuptools
+
+    - name: Checkout repository
+      uses: actions/checkout@v1
+
+    - name: Build source distribution
+      run: python ./setup.py sdist
+
+    # - name: Publish package to TestPyPI
+    #   uses: pypa/gh-action-pypi-publish@master
+    #   with:
+    #     user: __token__
+    #     password: ${{ secrets.test_pypi_password }}
+    #     repository_url: https://test.pypi.org/legacy/
+
+    - name: Publish package to PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.pypi_password }}

--- a/.github/workflows/publish-on-pypi.yml
+++ b/.github/workflows/publish-on-pypi.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'Materials-Consortia/optimade-python-tools' && startsWith(github.ref, 'refs/tags/v')
 
+    steps:
     - name: Checkout repository
       uses: actions/checkout@v1
 
-    steps:
-    - name: Set up Python 3.7 
+    - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:
         python-version: 3.7

--- a/.github/workflows/publish-on-pypi.yml
+++ b/.github/workflows/publish-on-pypi.yml
@@ -3,13 +3,16 @@ name: Publish on PyPI
 on:
   push:
     tags:
-      # No alpha, beta or release candidate releases are allowed
-      - v[0-9]+.[0-9]+.[0-9]+
+      # After vMajor.Minor.Patch _anything_ is allowed (without "/") !
+      - v[0-9]+.[0-9]+.[0-9]+*
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     if: github.repository == 'Materials-Consortia/optimade-python-tools' && startsWith(github.ref, 'refs/tags/v')
+
+    - name: Checkout repository
+      uses: actions/checkout@v1
 
     steps:
     - name: Set up Python 3.7 
@@ -17,23 +20,27 @@ jobs:
       with:
         python-version: 3.7
 
-    - name: Upgrade setuptools
+    - name: Upgrade setuptools and install package
       run: |
         python -m pip install --upgrade pip
         python -m pip install --upgrade setuptools
+        python -m pip install -e .
 
-    - name: Checkout repository
-      uses: actions/checkout@v1
+    - name: Assert package version
+      env:
+        TAG_VERSION: ${{ github.ref }}
+      run: python ./.ci/assert_version.py
 
     - name: Build source distribution
       run: python ./setup.py sdist
 
-    # - name: Publish package to TestPyPI
-    #   uses: pypa/gh-action-pypi-publish@master
-    #   with:
-    #     user: __token__
-    #     password: ${{ secrets.test_pypi_password }}
-    #     repository_url: https://test.pypi.org/legacy/
+    # This tests that publication to PyPI is possible, before properly publishing
+    - name: Publish package to TestPyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.test_pypi_password }}
+        repository_url: https://test.pypi.org/legacy/
 
     - name: Publish package to PyPI
       uses: pypa/gh-action-pypi-publish@master

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,13 @@
 repos:
-  - repo: https://github.com/ambv/black
-    rev: stable
-    hooks:
-    - id: black
-default_language_version:
-  python: python3.7
+- repo: https://github.com/ambv/black
+  rev: stable
+  hooks:
+  - id: black
+
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v2.3.0
+  hooks:
+  - id: trailing-whitespace
+    exclude: README.md
+  - id: check-yaml
+  - id: check-json

--- a/optimade/grammar/v0.10.0.elastic.lark
+++ b/optimade/grammar/v0.10.0.elastic.lark
@@ -1,4 +1,4 @@
-// optimade v0.10.0 grammar spec in lark grammar format, 
+// optimade v0.10.0 grammar spec in lark grammar format,
 // written to work with the elasticsearch filtertransformer
 
 start: or_expr

--- a/optimade/grammar/v0.9.6.lark
+++ b/optimade/grammar/v0.9.6.lark
@@ -2,10 +2,10 @@
 
 start: KEYWORD expression
 KEYWORD: "filter=" | "filter ="
-expression: [expression CONJUNCTION] term 
+expression: [expression CONJUNCTION] term
 term: [term CONJUNCTION] atom | "(" [term CONJUNCTION] term
 
-atom: [NOT] comparison 
+atom: [NOT] comparison
 
 comparison: VALUE OPERATOR VALUE [")"] | VALUE OPERATOR "'" (combined)* "'"
 OPERATOR: /<=?|>=?|!?=/

--- a/optimade/grammar/v0.9.7.lark
+++ b/optimade/grammar/v0.9.7.lark
@@ -5,7 +5,7 @@ start: expression
 expression: [expression CONJUNCTION] term
 term: [term CONJUNCTION] atom | "(" [term CONJUNCTION] term ")"
 
-atom: [NOT] comparison 
+atom: [NOT] comparison
 
 comparison: VALUE OPERATOR VALUE | VALUE OPERATOR "'" combined "'"
 

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,7 @@
-import os
-
+from pathlib import Path
 from setuptools import setup, find_packages
 
-module_dir = os.path.dirname(os.path.abspath(__file__))
+module_dir = Path(__file__).resolve().parent
 
 # Dependencies
 mongo_deps = ["pymongo~=3.8", "mongomock~=3.16"]
@@ -27,7 +26,7 @@ setup(
     author="OPTiMaDe Development Team",
     author_email="dev@optimade.org",
     description="Tools for implementing and consuming OPTiMaDe APIs.",
-    long_description=open(os.path.join(module_dir, "README.md")).read(),
+    long_description=open(module_dir.joinpath("README.md")).read(),
     long_description_content_type="text/markdown",
     keywords="optimade jsonapi materials",
     include_package_data=True,

--- a/tasks.py
+++ b/tasks.py
@@ -6,9 +6,11 @@ from optimade import __version__
 
 
 @task
-def setver(c, patch=False, new_ver=""):
+def setver(_, patch=False, new_ver=""):
     if (not patch and not new_ver) or (patch and new_ver):
-        raise Exception("Either use --patch or specify e.g. --full='x.y.z.")
+        raise Exception(
+            "Either use --patch or specify e.g. --new-ver='Major.Minor.Patch(a|b|rc)?[0-9]+'"
+        )
     if patch:
         v = [int(x) for x in __version__.split(".")]
         v[2] += 1
@@ -20,6 +22,7 @@ def setver(c, patch=False, new_ver=""):
         ]
     with open("optimade/__init__.py", "w") as f:
         f.write("\n".join(lines))
+        f.write("\n")
 
     with open("setup.py", "r") as f:
         lines = [
@@ -28,6 +31,7 @@ def setver(c, patch=False, new_ver=""):
         ]
     with open("setup.py", "w") as f:
         f.write("\n".join(lines))
+        f.write("\n")
     print("Bumped version to {}".format(new_ver))
 
 


### PR DESCRIPTION
~This is blocked until #92 has been merged and needs to be rebased. Currently, only the last four commits are related to this PR.~

Introduce a new workflow for publishing on PyPI via GitHub Actions.
The workflow steps:
- Run for pushes on tags (no matter if on `master` branch or not).
  - Run _only_ if repository is 'Materials-Consortia/optimade-python-tools'
  - Run for tags of 'v[0-9]+.[0-9]+.[0-9]+*
    The last * makes it possible to tag alpha, beta, and release candidate versions. Basically it means the workflow will run with anything after the initial part of the tag name has been verified.
- Checkout repository, install Python 3.7, and update `setuptools` and install `optimade` with base dependencies (`pip install -e .`).
- Assert package version equals tag name, i.e., "v" + `__version__` matches the pushed tag name.
  - If this does not fail, print a helpful message. Most importantly one MUST remove the newly created tag from GitHub and the local repository.
- Build source distribution.
- Upload/publish to TestPyPI.
  - This is to check that uploading to PyPI works and that the version does not already exist on PyPI, since this will make the upload fail.
- Finally, upload/publish to PyPI.