### PR TITLE
Update OpenAPI tags

### DIFF
--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -38,9 +38,7 @@
     "/optimade/info/{entry}": {
       "get": {
         "tags": [
-          "Info",
-          "Structure",
-          "Reference"
+          "Info"
         ],
         "summary": "Get Entry Info",
         "operationId": "get_entry_info_optimade_info__entry__get",
@@ -250,7 +248,7 @@
     "/optimade/references": {
       "get": {
         "tags": [
-          "Reference"
+          "References"
         ],
         "summary": "Get References",
         "operationId": "get_references_optimade_references_get",
@@ -410,7 +408,7 @@
     "/optimade/references/{entry_id}": {
       "get": {
         "tags": [
-          "Reference"
+          "References"
         ],
         "summary": "Get Single Reference",
         "operationId": "get_single_reference_optimade_references__entry_id__get",
@@ -491,7 +489,7 @@
     "/optimade/structures": {
       "get": {
         "tags": [
-          "Structure"
+          "Structures"
         ],
         "summary": "Get Structures",
         "operationId": "get_structures_optimade_structures_get",
@@ -651,7 +649,7 @@
     "/optimade/structures/{entry_id}": {
       "get": {
         "tags": [
-          "Structure"
+          "Structures"
         ],
         "summary": "Get Single Structure",
         "operationId": "get_single_structure_optimade_structures__entry_id__get",
@@ -761,9 +759,7 @@
     "/optimade/v0.10.0/info/{entry}": {
       "get": {
         "tags": [
-          "Info",
-          "Structure",
-          "Reference"
+          "Info"
         ],
         "summary": "Get Entry Info",
         "operationId": "get_entry_info_optimade_v0.10.0_info__entry__get",
@@ -973,7 +969,7 @@
     "/optimade/v0.10.0/references": {
       "get": {
         "tags": [
-          "Reference"
+          "References"
         ],
         "summary": "Get References",
         "operationId": "get_references_optimade_v0.10.0_references_get",
@@ -1133,7 +1129,7 @@
     "/optimade/v0.10.0/references/{entry_id}": {
       "get": {
         "tags": [
-          "Reference"
+          "References"
         ],
         "summary": "Get Single Reference",
         "operationId": "get_single_reference_optimade_v0.10.0_references__entry_id__get",
@@ -1214,7 +1210,7 @@
     "/optimade/v0.10.0/structures": {
       "get": {
         "tags": [
-          "Structure"
+          "Structures"
         ],
         "summary": "Get Structures",
         "operationId": "get_structures_optimade_v0.10.0_structures_get",
@@ -1374,7 +1370,7 @@
     "/optimade/v0.10.0/structures/{entry_id}": {
       "get": {
         "tags": [
-          "Structure"
+          "Structures"
         ],
         "summary": "Get Single Structure",
         "operationId": "get_single_structure_optimade_v0.10.0_structures__entry_id__get",
@@ -1484,9 +1480,7 @@
     "/optimade/v0.10/info/{entry}": {
       "get": {
         "tags": [
-          "Info",
-          "Structure",
-          "Reference"
+          "Info"
         ],
         "summary": "Get Entry Info",
         "operationId": "get_entry_info_optimade_v0.10_info__entry__get",
@@ -1696,7 +1690,7 @@
     "/optimade/v0.10/references": {
       "get": {
         "tags": [
-          "Reference"
+          "References"
         ],
         "summary": "Get References",
         "operationId": "get_references_optimade_v0.10_references_get",
@@ -1856,7 +1850,7 @@
     "/optimade/v0.10/references/{entry_id}": {
       "get": {
         "tags": [
-          "Reference"
+          "References"
         ],
         "summary": "Get Single Reference",
         "operationId": "get_single_reference_optimade_v0.10_references__entry_id__get",
@@ -1937,7 +1931,7 @@
     "/optimade/v0.10/structures": {
       "get": {
         "tags": [
-          "Structure"
+          "Structures"
         ],
         "summary": "Get Structures",
         "operationId": "get_structures_optimade_v0.10_structures_get",
@@ -2097,7 +2091,7 @@
     "/optimade/v0.10/structures/{entry_id}": {
       "get": {
         "tags": [
-          "Structure"
+          "Structures"
         ],
         "summary": "Get Single Structure",
         "operationId": "get_single_structure_optimade_v0.10_structures__entry_id__get",

--- a/optimade/server/routers/info.py
+++ b/optimade/server/routers/info.py
@@ -60,7 +60,7 @@ def get_info(request: Request):
     "/info/{entry}",
     response_model=Union[EntryInfoResponse, ErrorResponse],
     response_model_exclude_unset=True,
-    tags=["Info", "Structure", "Reference"],
+    tags=["Info"],
 )
 def get_entry_info(request: Request, entry: str):
     from optimade.models import EntryInfoResource

--- a/optimade/server/routers/references.py
+++ b/optimade/server/routers/references.py
@@ -30,7 +30,7 @@ references_coll = MongoCollection(
     "/references",
     response_model=Union[ReferenceResponseMany, ErrorResponse],
     response_model_exclude_unset=True,
-    tags=["Reference"],
+    tags=["References"],
 )
 def get_references(request: Request, params: EntryListingQueryParams = Depends()):
     return get_entries(
@@ -45,7 +45,7 @@ def get_references(request: Request, params: EntryListingQueryParams = Depends()
     "/references/{entry_id:path}",
     response_model=Union[ReferenceResponseOne, ErrorResponse],
     response_model_exclude_unset=True,
-    tags=["Reference"],
+    tags=["References"],
 )
 def get_single_reference(
     request: Request, entry_id: str, params: SingleEntryQueryParams = Depends()

--- a/optimade/server/routers/structures.py
+++ b/optimade/server/routers/structures.py
@@ -29,7 +29,7 @@ structures_coll = MongoCollection(
     "/structures",
     response_model=Union[StructureResponseMany, ErrorResponse],
     response_model_exclude_unset=True,
-    tags=["Structure"],
+    tags=["Structures"],
 )
 def get_structures(request: Request, params: EntryListingQueryParams = Depends()):
     return get_entries(
@@ -44,7 +44,7 @@ def get_structures(request: Request, params: EntryListingQueryParams = Depends()
     "/structures/{entry_id:path}",
     response_model=Union[StructureResponseOne, ErrorResponse],
     response_model_exclude_unset=True,
-    tags=["Structure"],
+    tags=["Structures"],
 )
 def get_single_structure(
     request: Request, entry_id: str, params: SingleEntryQueryParams = Depends()


### PR DESCRIPTION
Fixes #120 

Remove entry endpoints from all `/info` endpoints.
Make all tags plural.