### PR TITLE
Minor change to fallback server.cfg

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
-recursive-include optimade/server/ *.ini *.cfg *.json
+recursive-include optimade/server/ *.ini *.json
 recursive-include optimade/server/data *
 recursive-include optimade/grammar *.g

--- a/optimade/server/server_template.cfg
+++ b/optimade/server/server_template.cfg
@@ -1,3 +1,3 @@
 [optimadeconfig]
-CONFIG = ./optimade/server/config.ini
-INDEX_LINKS = ./optimade/server/index_links.json
+CONFIG = ./config.ini
+INDEX_LINKS = ./index_links.json

--- a/optimade/server/server_template.cfg
+++ b/optimade/server/server_template.cfg
@@ -1,3 +1,0 @@
-[optimadeconfig]
-CONFIG = ./config.ini
-INDEX_LINKS = ./index_links.json


### PR DESCRIPTION
As outlined in a comment in (https://github.com/Materials-Consortia/optimade-python-tools/pull/119#discussion_r364809582), this PR modifies the construction of `server.cfg` if it's missing. Instead of using `server_template.cfg`, the created `server.cfg` uses the absolute paths of the default values for `index_links` and `config`.