### PR TITLE
Update requirements

### DIFF
--- a/.github/workflows/deps_lint.yml
+++ b/.github/workflows/deps_lint.yml
@@ -93,7 +93,7 @@ jobs:
       fail-fast: false
       max-parallel: 2
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v1
@@ -130,7 +130,7 @@ jobs:
       fail-fast: false
       max-parallel: 2
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v1
@@ -158,7 +158,7 @@ jobs:
   #     fail-fast: false
   #     max-parallel: 2
   #     matrix:
-  #       python-version: [3.7, 3.8]
+  #       python-version: [3.6, 3.7, 3.8]
 
   #   steps:
   #   - uses: actions/checkout@v1

--- a/.github/workflows/requirements.txt
+++ b/.github/workflows/requirements.txt
@@ -1,10 +1,10 @@
 lark-parser==0.7.8
-fastapi==0.44.0
-pydantic==1.2
+fastapi==0.46.0
+pydantic==1.3
 email_validator==1.0.5
 requests==2.22.0
-uvicorn==0.10
-pymongo==3.8
-mongomock==3.16
-django==2.2.8
+uvicorn==0.11.1
+pymongo==3.10.1
+mongomock==3.18.0
+django==2.2.9
 elasticsearch_dsl==6.4.0

--- a/optimade/__init__.py
+++ b/optimade/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 __api_version__ = "0.10.1"

--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,12 @@ from setuptools import setup, find_packages
 module_dir = Path(__file__).resolve().parent
 
 # Dependencies
-mongo_deps = ["pymongo~=3.8", "mongomock~=3.16"]
+mongo_deps = ["pymongo~=3.10", "mongomock~=3.18"]
 server_deps = ["uvicorn"] + mongo_deps
 django_deps = ["django~=2.2,>=2.2.8"]
 elastic_deps = ["elasticsearch_dsl~=6.4"]
 testing_deps = [
-    "pytest~=3.6",
+    "pytest~=3.10",
     "pytest-cov",
     "codecov",
     "openapi-spec-validator",
@@ -20,7 +20,7 @@ all_deps = dev_deps + django_deps + elastic_deps
 
 setup(
     name="optimade",
-    version="0.3.0",
+    version="0.3.1",
     url="https://github.com/Materials-Consortia/optimade-python-tools",
     license="MIT",
     author="OPTiMaDe Development Team",
@@ -34,17 +34,19 @@ setup(
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Intended Audience :: Developers",
         "Topic :: Database",
         "Topic :: Database :: Database Engines/Servers",
         "Topic :: Database :: Front-Ends",
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.6",
     install_requires=[
         "lark-parser~=0.7.8",
-        "fastapi~=0.44",
-        "pydantic~=1.2",
+        "fastapi~=0.46",
+        "pydantic~=1.3",
         "email_validator",
         "requests",
     ],

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ module_dir = Path(__file__).resolve().parent
 # Dependencies
 mongo_deps = ["pymongo~=3.10", "mongomock~=3.18"]
 server_deps = ["uvicorn"] + mongo_deps
-django_deps = ["django~=2.2,>=2.2.8"]
+django_deps = ["django~=2.2,>=2.2.9"]
 elastic_deps = ["elasticsearch_dsl~=6.4"]
 testing_deps = [
     "pytest~=3.10",


### PR DESCRIPTION
Make available for installs on Py3.6 environments.

Since this makes it installable for "older" Py3 versions, I have upped the patch version, i.e., new version v0.3.1.

Added minimum Django requirement to be v2.2.9 for security reasons.