### PR TITLE
Fix root_validator issues with optional fields and made meta optional

### DIFF
--- a/openapi/index_openapi.json
+++ b/openapi/index_openapi.json
@@ -1279,8 +1279,7 @@
       "LinksResponse": {
         "title": "LinksResponse",
         "required": [
-          "data",
-          "meta"
+          "data"
         ],
         "type": "object",
         "properties": {

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -3007,8 +3007,7 @@
       "LinksResponse": {
         "title": "LinksResponse",
         "required": [
-          "data",
-          "meta"
+          "data"
         ],
         "type": "object",
         "properties": {
@@ -3431,8 +3430,7 @@
       "ReferenceResponseMany": {
         "title": "ReferenceResponseMany",
         "required": [
-          "data",
-          "meta"
+          "data"
         ],
         "type": "object",
         "properties": {
@@ -3506,8 +3504,7 @@
       "ReferenceResponseOne": {
         "title": "ReferenceResponseOne",
         "required": [
-          "data",
-          "meta"
+          "data"
         ],
         "type": "object",
         "properties": {
@@ -4083,8 +4080,7 @@
       "StructureResponseMany": {
         "title": "StructureResponseMany",
         "required": [
-          "data",
-          "meta"
+          "data"
         ],
         "type": "object",
         "properties": {
@@ -4158,8 +4154,7 @@
       "StructureResponseOne": {
         "title": "StructureResponseOne",
         "required": [
-          "data",
-          "meta"
+          "data"
         ],
         "type": "object",
         "properties": {

--- a/optimade/models/jsonapi.py
+++ b/optimade/models/jsonapi.py
@@ -136,7 +136,7 @@ class RelationshipLinks(BaseModel):
         None, description="A related resource link"
     )
 
-    @root_validator
+    @root_validator(pre=True)
     def either_self_or_related_must_be_specified(cls, values):
         for value in values.values():
             if value is not None:
@@ -163,7 +163,7 @@ class Relationship(BaseModel):
         description="a meta object that contains non-standard meta-information about the relationship.",
     )
 
-    @root_validator
+    @root_validator(pre=True)
     def at_least_one_relationship_key_must_be_set(cls, values):
         for value in values.values():
             if value is not None:
@@ -268,13 +268,10 @@ class Response(BaseModel):
         None, description="Information about the JSON API used"
     )
 
-    @root_validator
+    @root_validator(pre=True)
     def either_data_meta_or_errors_must_be_set(cls, values):
         required_fields = ("data", "meta", "errors")
-        for field in required_fields:
-            if values.get(field, None) is not None:
-                break
-        else:
+        if not any(values.get(field) for field in required_fields):
             raise ValueError(
                 f"Either of {required_fields} must be specified in the top-level response"
             )

--- a/optimade/models/jsonapi.py
+++ b/optimade/models/jsonapi.py
@@ -273,6 +273,6 @@ class Response(BaseModel):
         required_fields = ("data", "meta", "errors")
         if not any(values.get(field) for field in required_fields):
             raise ValueError(
-                f"Either of {required_fields} must be specified in the top-level response"
+                f"One of {required_fields} must be specified in the top-level response"
             )
         return values

--- a/optimade/models/jsonapi.py
+++ b/optimade/models/jsonapi.py
@@ -273,6 +273,6 @@ class Response(BaseModel):
         required_fields = ("data", "meta", "errors")
         if not any(values.get(field) for field in required_fields):
             raise ValueError(
-                f"One of {required_fields} must be specified in the top-level response"
+                f"Minimum one of {required_fields} MUST be specified in the top-level response"
             )
         return values

--- a/optimade/models/jsonapi.py
+++ b/optimade/models/jsonapi.py
@@ -273,6 +273,6 @@ class Response(BaseModel):
         required_fields = ("data", "meta", "errors")
         if not any(values.get(field) for field in required_fields):
             raise ValueError(
-                f"Minimum one of {required_fields} MUST be specified in the top-level response"
+                f"At least one of {required_fields} MUST be specified in the top-level response"
             )
         return values

--- a/optimade/models/optimade_json.py
+++ b/optimade/models/optimade_json.py
@@ -65,7 +65,7 @@ class Success(jsonapi.Response):
         required_fields = ("data", "meta")
         if not any(values.get(field) for field in required_fields):
             raise ValueError(
-                f"Either of {required_fields} MUST be specified in the top-level response"
+                f"Minimum one of {required_fields} MUST be specified in the top-level response"
             )
 
         # errors MUST be skipped

--- a/optimade/models/optimade_json.py
+++ b/optimade/models/optimade_json.py
@@ -59,14 +59,11 @@ class Success(jsonapi.Response):
         None, description="Links associated with the primary data"
     )
 
-    @root_validator
+    @root_validator(pre=True)
     def either_data_meta_or_errors_must_be_set(cls, values):
         """Overwriting the existing validation function"""
         required_fields = ("data", "meta")
-        for field in required_fields:
-            if values.get(field, None) is not None:
-                break
-        else:
+        if not any(values.get(field) for field in required_fields):
             raise ValueError(
                 f"Either of {required_fields} must be specified in the top-level response"
             )

--- a/optimade/models/optimade_json.py
+++ b/optimade/models/optimade_json.py
@@ -65,7 +65,7 @@ class Success(jsonapi.Response):
         required_fields = ("data", "meta")
         if not any(values.get(field) for field in required_fields):
             raise ValueError(
-                f"Either of {required_fields} must be specified in the top-level response"
+                f"Either of {required_fields} MUST be specified in the top-level response"
             )
 
         # errors MUST be skipped

--- a/optimade/models/optimade_json.py
+++ b/optimade/models/optimade_json.py
@@ -65,7 +65,7 @@ class Success(jsonapi.Response):
         required_fields = ("data", "meta")
         if not any(values.get(field) for field in required_fields):
             raise ValueError(
-                f"Minimum one of {required_fields} MUST be specified in the top-level response"
+                f"At least one of {required_fields} MUST be specified in the top-level response"
             )
 
         # errors MUST be skipped

--- a/optimade/models/toplevel.py
+++ b/optimade/models/toplevel.py
@@ -187,13 +187,13 @@ class InfoResponse(Success):
 
 
 class EntryResponseOne(Success):
-    meta: ResponseMeta = Field(...)
+    meta: Optional[ResponseMeta] = Field(None)
     data: Union[EntryResource, Dict[str, Any], None] = Field(...)
     included: Optional[Union[List[EntryResource], List[Dict[str, Any]]]] = Field(None)
 
 
 class EntryResponseMany(Success):
-    meta: ResponseMeta = Field(...)
+    meta: Optional[ResponseMeta] = Field(None)
     data: Union[List[EntryResource], List[Dict[str, Any]]] = Field(...)
     included: Optional[Union[List[EntryResource], List[Dict[str, Any]]]] = Field(None)
 


### PR DESCRIPTION
After some fiddling, it seems like all that needed to be done was set `pre=True` in the remaining root validators, otherwise "data" seems to get validated first and popped from the response dict? (unsure)

I've also had to make `meta` optional for `EntryResponseOne` and `EntryResponseMany`, which changes the openapi spec. I'm not sure how I feel about this...