### PR TITLE
Bump to v0.3.3

### DIFF
--- a/.github/workflows/requirements.txt
+++ b/.github/workflows/requirements.txt
@@ -1,9 +1,9 @@
 lark-parser==0.8.1
-fastapi==0.46.0
+fastapi==0.47.1
 pydantic==1.3
 email_validator==1.0.5
 requests==2.22.0
-uvicorn==0.11.1
+uvicorn==0.11.2
 pymongo==3.10.1
 mongomock==3.18.0
 django==2.2.9

--- a/optimade/__init__.py
+++ b/optimade/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "0.3.2"
+__version__ = "0.3.3"
 __api_version__ = "0.10.1"

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ all_deps = dev_deps + django_deps + elastic_deps
 
 setup(
     name="optimade",
-    version="0.3.2",
+    version="0.3.3",
     url="https://github.com/Materials-Consortia/optimade-python-tools",
     license="MIT",
     author="OPTiMaDe Development Team",
@@ -45,7 +45,7 @@ setup(
     python_requires=">=3.6",
     install_requires=[
         "lark-parser~=0.8.1",
-        "fastapi~=0.46",
+        "fastapi~=0.47",
         "pydantic~=1.3",
         "email_validator",
         "requests",


### PR DESCRIPTION
Also bump FastAPI requirement to ~=0.47

Changes:
- Fixes for OPTiMaDe validator.
- Better error handling for the OPTiMaDe validator concerning error responses.