### PR TITLE
Extend OpenAPI/spec description

### DIFF
--- a/openapi/index_openapi.json
+++ b/openapi/index_openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.2",
   "info": {
     "title": "OPTiMaDe API - Index meta-database",
-    "description": "The [Open Databases Integration for Materials Design (OPTiMaDe) consortium](http://http://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.\nThis is the \"special\" index meta-database.",
+    "description": "The [Open Databases Integration for Materials Design (OPTiMaDe) consortium](https://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.\nThis is the \"special\" index meta-database.\n\nThis specification is generated using [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools/tree/v0.3.3) v0.3.3.",
     "version": "0.10.1"
   },
   "paths": {

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.2",
   "info": {
     "title": "OPTiMaDe API",
-    "description": "The [Open Databases Integration for Materials Design (OPTiMaDe) consortium](http://http://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.",
+    "description": "The [Open Databases Integration for Materials Design (OPTiMaDe) consortium](https://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.\n\nThis specification is generated using [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools/tree/v0.3.3) v0.3.3.",
     "version": "0.10.1"
   },
   "paths": {

--- a/optimade/server/main.py
+++ b/optimade/server/main.py
@@ -1,3 +1,4 @@
+# pylint: disable=line-too-long
 import os
 import json
 from pathlib import Path
@@ -14,16 +15,16 @@ from .config import CONFIG
 from .routers import info, links, references, structures
 from .routers.utils import get_providers
 
-from optimade import __api_version__
+from optimade import __api_version__, __version__
 import optimade.server.exception_handlers as exc_handlers
 
 
 app = FastAPI(
     title="OPTiMaDe API",
     description=(
-        "The [Open Databases Integration for Materials Design (OPTiMaDe) consortium]"
-        "(http://http://www.optimade.org/) aims to make materials databases interoperational "
-        "by developing a common REST API."
+        f"""The [Open Databases Integration for Materials Design (OPTiMaDe) consortium](https://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.
+
+This specification is generated using [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools/tree/v{__version__}) v{__version__}."""
     ),
     version=__api_version__,
     docs_url="/optimade/extensions/docs",

--- a/optimade/server/main_index.py
+++ b/optimade/server/main_index.py
@@ -1,3 +1,4 @@
+# pylint: disable=line-too-long
 import os
 import json
 from pathlib import Path
@@ -12,17 +13,17 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 from .config import CONFIG
 from .routers import index_info, links
 
-from optimade import __api_version__
+from optimade import __api_version__, __version__
 import optimade.server.exception_handlers as exc_handlers
 
 
 app = FastAPI(
     title="OPTiMaDe API - Index meta-database",
     description=(
-        "The [Open Databases Integration for Materials Design (OPTiMaDe) consortium]"
-        "(http://http://www.optimade.org/) aims to make materials databases interoperational "
-        "by developing a common REST API.\n"
-        'This is the "special" index meta-database.'
+        f"""The [Open Databases Integration for Materials Design (OPTiMaDe) consortium](https://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.
+This is the "special" index meta-database.
+
+This specification is generated using [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools/tree/v{__version__}) v{__version__}."""
     ),
     version=__api_version__,
     docs_url="/index/optimade/extensions/docs",


### PR DESCRIPTION
This adds a notion of the spec's source material to the description.
The extension comes from a suggestion to the PR Materials-Consortia/OPTiMaDe#242