### PR TITLE
Bump to v0.3.4

### DIFF
--- a/.github/workflows/requirements.txt
+++ b/.github/workflows/requirements.txt
@@ -1,10 +1,10 @@
 lark-parser==0.8.1
-fastapi==0.47.1
-pydantic==1.3
+fastapi==0.48.0
+pydantic==1.4
 email_validator==1.0.5
 requests==2.22.0
 uvicorn==0.11.2
 pymongo==3.10.1
-mongomock==3.18.0
-django==2.2.9
-elasticsearch_dsl==6.4.0
+mongomock==3.19.0
+django==2.2.10
+elasticsearch-dsl==6.4.0

--- a/openapi/index_openapi.json
+++ b/openapi/index_openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.2",
   "info": {
     "title": "OPTiMaDe API - Index meta-database",
-    "description": "The [Open Databases Integration for Materials Design (OPTiMaDe) consortium](https://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.\nThis is the \"special\" index meta-database.\n\nThis specification is generated using [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools/tree/v0.3.3) v0.3.3.",
+    "description": "The [Open Databases Integration for Materials Design (OPTiMaDe) consortium](https://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.\nThis is the \"special\" index meta-database.\n\nThis specification is generated using [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools/tree/v0.3.4) v0.3.4.",
     "version": "0.10.1"
   },
   "paths": {

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.2",
   "info": {
     "title": "OPTiMaDe API",
-    "description": "The [Open Databases Integration for Materials Design (OPTiMaDe) consortium](https://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.\n\nThis specification is generated using [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools/tree/v0.3.3) v0.3.3.",
+    "description": "The [Open Databases Integration for Materials Design (OPTiMaDe) consortium](https://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.\n\nThis specification is generated using [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools/tree/v0.3.4) v0.3.4.",
     "version": "0.10.1"
   },
   "paths": {

--- a/optimade/__init__.py
+++ b/optimade/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "0.3.3"
+__version__ = "0.3.4"
 __api_version__ = "0.10.1"

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ all_deps = dev_deps + django_deps + elastic_deps
 
 setup(
     name="optimade",
-    version="0.3.3",
+    version="0.3.4",
     url="https://github.com/Materials-Consortia/optimade-python-tools",
     license="MIT",
     author="OPTiMaDe Development Team",

--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,10 @@ from setuptools import setup, find_packages
 module_dir = Path(__file__).resolve().parent
 
 # Dependencies
-mongo_deps = ["pymongo~=3.10", "mongomock~=3.18"]
+mongo_deps = ["pymongo~=3.10", "mongomock~=3.19"]
 server_deps = ["uvicorn"] + mongo_deps
 django_deps = ["django~=2.2,>=2.2.9"]
-elastic_deps = ["elasticsearch_dsl~=6.4"]
+elastic_deps = ["elasticsearch-dsl~=6.4"]
 testing_deps = [
     "pytest~=3.10",
     "pytest-cov",
@@ -45,8 +45,8 @@ setup(
     python_requires=">=3.6",
     install_requires=[
         "lark-parser~=0.8.1",
-        "fastapi~=0.47",
-        "pydantic~=1.3",
+        "fastapi~=0.48",
+        "pydantic~=1.4",
         "email_validator",
         "requests",
     ],


### PR DESCRIPTION
Changes:
- Add description about `optimade-python-tools` version in OpenAPI spec (#151, @CasperWA)
- Make it possible to use a non-local MongoDB database (supplying a URI in the config file) (#150, @shyamd)
- Update base URLs. Remove `/optimade`, required base URL is now `/optimade/vMAJOR`, the optional base URLs, including MINOR and PATCH versions in the URL, are still created.
  The OpenAPI spec now _only_ shows endpoints for a single base URL (`/optimade/vMAJOR`) (#155, @CasperWA)
  Redirect heroku app link to new base URL (#157, @ml-evs)
- Move installation instructions from `README.md` and `CONTRIBUTING.md` to `INSTALL.md` (#156, @ml-evs)
- Bump some dependency / requirement versions (#158, @CasperWA)