### PR TITLE
Make mapper aliases configurable

### DIFF
--- a/optimade/server/config.ini
+++ b/optimade/server/config.ini
@@ -26,3 +26,9 @@ index_base_url = http://localhost:5001/optimade
 [structures]
 band_gap :
 _mp_chemsys :
+
+[structures.aliases]
+id = task_id
+chemical_formula_descriptive = pretty_formula
+chemical_formula_reduced = pretty_formula
+chemical_formula_anonymous = formula_anonymous

--- a/optimade/server/config.py
+++ b/optimade/server/config.py
@@ -171,9 +171,9 @@ class ServerConfig(Config):
 
         self.aliases = {}
         for endpoint in {"links", "references", "structures"}:
-            if f"{endpoint}.aliases" in config.sections():
+            if f"{endpoint}.aliases" in config:
                 section = config[f"{endpoint}.aliases"]
-                self.aliases[endpoint] = tuple((key, section[key]) for key in section)
+                self.aliases[endpoint] = tuple(section.items())
 
         self.provider_fields = {}
         for endpoint in {"links", "references", "structures"}:
@@ -244,9 +244,7 @@ class ServerConfig(Config):
             for endpoint in {"links", "references", "structures"}:
                 if endpoint in config["aliases"]:
                     section = config["aliases"][endpoint]
-                    self.aliases[endpoint] = tuple(
-                        (key, section[key]) for key in section
-                    )
+                    self.aliases[endpoint] = tuple(section.items())
 
 
 CONFIG = ServerConfig()

--- a/optimade/server/config.py
+++ b/optimade/server/config.py
@@ -239,5 +239,14 @@ class ServerConfig(Config):
                 set(config.get("provider_fields", {}).get(endpoint, []))
             )
 
+        self.aliases = {}
+        if "aliases" in config:
+            for endpoint in {"links", "references", "structures"}:
+                if endpoint in config["aliases"]:
+                    section = config["aliases"][endpoint]
+                    self.aliases[endpoint] = tuple(
+                        (key, section[key]) for key in section
+                    )
+
 
 CONFIG = ServerConfig()

--- a/optimade/server/config.py
+++ b/optimade/server/config.py
@@ -169,6 +169,12 @@ class ServerConfig(Config):
         else:
             self.provider = self._DEFAULTS("provider")
 
+        self.aliases = {}
+        for endpoint in {"links", "references", "structures"}:
+            if f"{endpoint}.aliases" in config.sections():
+                section = config[f"{endpoint}.aliases"]
+                self.aliases[endpoint] = tuple((key, section[key]) for key in section)
+
         self.provider_fields = {}
         for endpoint in {"links", "references", "structures"}:
             self.provider_fields[endpoint] = (

--- a/optimade/server/mappers/entries.py
+++ b/optimade/server/mappers/entries.py
@@ -19,6 +19,7 @@ class ResourceMapper:
                 (CONFIG.provider["prefix"] + field, field)
                 for field in CONFIG.provider_fields.get(cls.ENDPOINT, [])
             )
+            + CONFIG.aliases.get(cls.ENDPOINT, ())
             + cls.ALIASES
         )
 

--- a/optimade/server/mappers/structures.py
+++ b/optimade/server/mappers/structures.py
@@ -6,9 +6,3 @@ __all__ = ("StructureMapper",)
 class StructureMapper(ResourceMapper):
 
     ENDPOINT = "structures"
-    ALIASES = (
-        ("id", "task_id"),
-        ("chemical_formula_descriptive", "pretty_formula"),
-        ("chemical_formula_reduced", "pretty_formula"),
-        ("chemical_formula_anonymous", "formula_anonymous"),
-    )

--- a/tests/server/config_test.ini
+++ b/tests/server/config_test.ini
@@ -24,3 +24,9 @@ index_base_url = http://localhost:5001/optimade
 [structures]
 band_gap :
 _mp_chemsys :
+
+[structures.aliases]
+id = task_id
+chemical_formula_descriptive = pretty_formula
+chemical_formula_reduced = pretty_formula
+chemical_formula_anonymous = formula_anonymous

--- a/tests/server/config_test.json
+++ b/tests/server/config_test.json
@@ -23,5 +23,13 @@
             "band_gap",
             "_mp_chemsys"
         ]
+    },
+    "aliases": {
+        "structures": {
+            "id": "task_id",
+            "chemical_formula_descriptive": "pretty_formula",
+            "chemical_formula_reduced": "pretty_formula",
+            "chemical_formula_anonymous": "formula_anonymous"
+        }
     }
 }


### PR DESCRIPTION
This PR removes the default StructureMapper aliases and moves them to the default `config.ini`. They were previously quite annoying as you had to use these pseudo-MP field names if you didn't want to patch the our library yourself (i.e. if you were both creating and consuming your database using the optimade models).

- Added `<endpoint>.aliases` sections to config file, with blank defaults, similar to `provider fields`.
- `ResourceMapper` now pulls aliases from three places: the defined `ALIASES` class data, any config section `config.aliases[ENDPOINT]` and the config provider fields.

We should probably write some docs on how to use the aliasing features.