### PR TITLE
Bump to v0.5.0

### DIFF
--- a/openapi/index_openapi.json
+++ b/openapi/index_openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.2",
   "info": {
     "title": "OPTiMaDe API - Index meta-database",
-    "description": "The [Open Databases Integration for Materials Design (OPTiMaDe) consortium](https://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.\nThis is the \"special\" index meta-database.\n\nThis specification is generated using [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools/tree/v0.4.0) v0.4.0.",
+    "description": "The [Open Databases Integration for Materials Design (OPTiMaDe) consortium](https://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.\nThis is the \"special\" index meta-database.\n\nThis specification is generated using [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools/tree/v0.5.0) v0.5.0.",
     "version": "0.10.1"
   },
   "paths": {

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.2",
   "info": {
     "title": "OPTiMaDe API",
-    "description": "The [Open Databases Integration for Materials Design (OPTiMaDe) consortium](https://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.\n\nThis specification is generated using [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools/tree/v0.4.0) v0.4.0.",
+    "description": "The [Open Databases Integration for Materials Design (OPTiMaDe) consortium](https://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.\n\nThis specification is generated using [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools/tree/v0.5.0) v0.5.0.",
     "version": "0.10.1"
   },
   "paths": {

--- a/optimade/__init__.py
+++ b/optimade/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 __api_version__ = "0.10.1"

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ all_deps = dev_deps + django_deps + elastic_deps
 
 setup(
     name="optimade",
-    version="0.4.0",
+    version="0.5.0",
     url="https://github.com/Materials-Consortia/optimade-python-tools",
     license="MIT",
     author="OPTiMaDe Development Team",


### PR DESCRIPTION
Since the API is changed (very slightly), we should actually up the major version, however, since the package/repository is still under development - and we are not extremely compliant with SemVer, I think it's okay to bump "just" the minor version instead.

Changes:
- Possibility for Docker deployment for both the index meta-database server as well as the regular server (#140, @ltalirz, @CasperWA)
- Test building and starting Docker images with GitHub Actions CI (#140, @CasperWA, @ml-evs, @ltalirz)
- Remove `/index` from the index meta-database's base URL (#140, @ltalirz, @CasperWA)
- `include` query parameter (#163, @CasperWA)
- Rename `optimade/server/deps.py` to `optimade/server/query_params.py` (#163, @CasperWA)
- Human-readable landing page for versioned base URLs, as well as for `/optimade` (#172, @ml-evs)
- Move mapper aliases to config file and out of mapper classes (#175, @ml-evs)

Bug fixes:
- Properly build versioned base URLs (#178, @CasperWA)