### PR TITLE
Add explicit idna dependency

### DIFF
--- a/.github/workflows/requirements.txt
+++ b/.github/workflows/requirements.txt
@@ -9,3 +9,4 @@ mongomock==3.19.0
 django==2.2.10
 elasticsearch-dsl==6.4.0
 Jinja2==2.11.1
+idna==2.8

--- a/.github/workflows/requirements_eager.txt
+++ b/.github/workflows/requirements_eager.txt
@@ -8,3 +8,4 @@ mongomock
 django
 elasticsearch_dsl
 Jinja2
+idna

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
         "pydantic~=1.4",
         "email_validator",
         "requests",
+        "idna<2.9",  # Set to avoid problems with requests
     ],
     extras_require={
         "all": all_deps,


### PR DESCRIPTION
Fixes #188 

This solves the issue by having this repo depend directly on `idna<2.9`.