### PR TITLE
Add "debug mode"

### DIFF
--- a/optimade/server/config.py
+++ b/optimade/server/config.py
@@ -20,7 +20,7 @@ class Config:
     _path: Path = Path(__file__).parent.joinpath("config.ini")
 
     def __init__(self, server_cfg: Path = None):
-        self._debug = os.getenv("DEBUG") == "1"
+        self._debug = os.getenv("OPTIMADE_DEBUG") == "1"
         self._server = (
             Path().resolve().joinpath("server.cfg")
             if server_cfg is None

--- a/optimade/server/config.py
+++ b/optimade/server/config.py
@@ -95,8 +95,8 @@ class Config:
         return self._debug
 
     @debug.setter
-    def debug(self, _):
-        raise AttributeError("debug cannot be set")
+    def debug(self, value: bool):
+        self._debug = value
 
 
 class ServerConfig(Config):

--- a/optimade/server/config.py
+++ b/optimade/server/config.py
@@ -1,3 +1,4 @@
+import os
 import json
 from typing import Any
 from configparser import ConfigParser
@@ -19,6 +20,7 @@ class Config:
     _path: Path = Path(__file__).parent.joinpath("config.ini")
 
     def __init__(self, server_cfg: Path = None):
+        self._debug = os.getenv("DEBUG") == "1"
         self._server = (
             Path().resolve().joinpath("server.cfg")
             if server_cfg is None
@@ -87,6 +89,14 @@ class Config:
             )
         else:
             f()
+
+    @property
+    def debug(self):
+        return self._debug
+
+    @debug.setter
+    def debug(self, _):
+        raise AttributeError("debug cannot be set")
 
 
 class ServerConfig(Config):

--- a/optimade/server/exception_handlers.py
+++ b/optimade/server/exception_handlers.py
@@ -21,10 +21,13 @@ def general_exception(
     status_code: int = 500,  # A status_code in `exc` will take precedence
     errors: List[OptimadeError] = None,
 ) -> JSONResponse:
-    tb = "".join(
-        traceback.format_exception(etype=type(exc), value=exc, tb=exc.__traceback__)
-    )
-    print(tb)
+    debug_info = {}
+    if CONFIG.debug:
+        tb = "".join(
+            traceback.format_exception(etype=type(exc), value=exc, tb=exc.__traceback__)
+        )
+        print(tb)
+        debug_info[f"{CONFIG.provider['prefix']}traceback"] = tb
 
     try:
         http_response_code = exc.status_code
@@ -48,7 +51,7 @@ def general_exception(
                 data_returned=0,
                 data_available=0,
                 more_data_available=False,
-                **{CONFIG.provider["prefix"] + "traceback": tb},
+                **debug_info,
             ),
             errors=errors,
         )

--- a/optimade/server/main.py
+++ b/optimade/server/main.py
@@ -19,8 +19,8 @@ from optimade import __api_version__, __version__
 import optimade.server.exception_handlers as exc_handlers
 
 
-if CONFIG.debug:
-    print("DEBUG MODE")  # pragma: no cover
+if CONFIG.debug:  # pragma: no cover
+    print("DEBUG MODE")
 
 
 app = FastAPI(

--- a/optimade/server/main.py
+++ b/optimade/server/main.py
@@ -18,6 +18,7 @@ from .routers.utils import get_providers, BASE_URL_PREFIXES
 from optimade import __api_version__, __version__
 import optimade.server.exception_handlers as exc_handlers
 
+
 if CONFIG.debug:
     print("DEBUG MODE")
 

--- a/optimade/server/main.py
+++ b/optimade/server/main.py
@@ -18,6 +18,9 @@ from .routers.utils import get_providers, BASE_URL_PREFIXES
 from optimade import __api_version__, __version__
 import optimade.server.exception_handlers as exc_handlers
 
+if CONFIG.debug:
+    print("DEBUG MODE")
+
 
 app = FastAPI(
     title="OPTiMaDe API",

--- a/optimade/server/main.py
+++ b/optimade/server/main.py
@@ -20,7 +20,7 @@ import optimade.server.exception_handlers as exc_handlers
 
 
 if CONFIG.debug:
-    print("DEBUG MODE")
+    print("DEBUG MODE")  # pragma: no cover
 
 
 app = FastAPI(

--- a/optimade/server/main_index.py
+++ b/optimade/server/main_index.py
@@ -17,6 +17,9 @@ from .routers.utils import BASE_URL_PREFIXES
 from optimade import __api_version__, __version__
 import optimade.server.exception_handlers as exc_handlers
 
+if CONFIG.debug:
+    print("DEBUG MODE")
+
 
 app = FastAPI(
     title="OPTiMaDe API - Index meta-database",

--- a/optimade/server/main_index.py
+++ b/optimade/server/main_index.py
@@ -18,8 +18,8 @@ from optimade import __api_version__, __version__
 import optimade.server.exception_handlers as exc_handlers
 
 
-if CONFIG.debug:
-    print("DEBUG MODE")  # pragma: no cover
+if CONFIG.debug:  # pragma: no cover
+    print("DEBUG MODE")
 
 
 app = FastAPI(

--- a/optimade/server/main_index.py
+++ b/optimade/server/main_index.py
@@ -17,6 +17,7 @@ from .routers.utils import BASE_URL_PREFIXES
 from optimade import __api_version__, __version__
 import optimade.server.exception_handlers as exc_handlers
 
+
 if CONFIG.debug:
     print("DEBUG MODE")
 

--- a/optimade/server/main_index.py
+++ b/optimade/server/main_index.py
@@ -19,7 +19,7 @@ import optimade.server.exception_handlers as exc_handlers
 
 
 if CONFIG.debug:
-    print("DEBUG MODE")
+    print("DEBUG MODE")  # pragma: no cover
 
 
 app = FastAPI(

--- a/run.sh
+++ b/run.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
-set -ex
+
+if [ "$1" == "debug" ]; then
+    export DEBUG=1
+fi
 
 if [ "$1" == "index" ]; then
     MAIN="main_index"
     PORT=5001
+    if [ "$2" == "debug" ]; then
+        export DEBUG=1
+    fi
 else
     if [ "${MAIN}" == "main_index" ]; then
         PORT=5001

--- a/run.sh
+++ b/run.sh
@@ -1,14 +1,17 @@
 #!/bin/bash
 
+LOG_LEVEL=info
 if [ "$1" == "debug" ]; then
-    export DEBUG=1
+    export OPTIMADE_DEBUG=1
+    LOG_LEVEL=debug
 fi
 
 if [ "$1" == "index" ]; then
     MAIN="main_index"
     PORT=5001
     if [ "$2" == "debug" ]; then
-        export DEBUG=1
+        export OPTIMADE_DEBUG=1
+        LOG_LEVEL=debug
     fi
 else
     if [ "${MAIN}" == "main_index" ]; then
@@ -19,4 +22,4 @@ else
     fi
 fi
 
-uvicorn optimade.server.$MAIN:app --reload --port $PORT
+uvicorn optimade.server.$MAIN:app --reload --port $PORT --log-level $LOG_LEVEL

--- a/tests/server/test_config.py
+++ b/tests/server/test_config.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from optimade.server.config import ServerConfig, CONFIG
 
-from .utils import SetClient, get_regular_client, get_index_client
+from .utils import SetClient
 
 
 class LoadFromIniTest(unittest.TestCase):
@@ -64,6 +64,9 @@ class TestDebugOff(SetClient, unittest.TestCase):
 
         TODO: This should be moved to a separate test file that tests the exception handlers.
         """
+        if CONFIG.debug:
+            CONFIG.debug = False
+
         response = self.client.get("/non/existent/path")
         self.assertEqual(
             response.status_code,
@@ -87,6 +90,9 @@ class IndexTestDebugOff(SetClient, unittest.TestCase):
 
         TODO: This should be moved to a separate test file that tests the exception handlers.
         """
+        if CONFIG.debug:
+            CONFIG.debug = False
+
         response = self.client.get("/non/existent/path")
         self.assertEqual(
             response.status_code,
@@ -101,17 +107,17 @@ class IndexTestDebugOff(SetClient, unittest.TestCase):
         self.assertNotIn(f"{CONFIG.provider['prefix']}traceback", response["meta"])
 
 
-class TestDebugOn(unittest.TestCase):
-    def __init__(self, methodName: str = "runTest"):
-        super().__init__(methodName=methodName)
-        os.environ["DEBUG"] = "1"
-        self.client = get_regular_client()
+class TestDebugOn(SetClient, unittest.TestCase):
+
+    server = "regular"
 
     def test_debug_is_respected_when_off(self):
         """Make sure traceback is toggleable according to debug mode - here OFF
 
         TODO: This should be moved to a separate test file that tests the exception handlers.
         """
+        CONFIG.debug = True
+
         response = self.client.get("/non/existent/path")
         self.assertEqual(
             response.status_code,
@@ -123,20 +129,20 @@ class TestDebugOn(unittest.TestCase):
         self.assertNotIn("data", response)
         self.assertIn("meta", response)
 
-        self.assertNotIn(f"{CONFIG.provider['prefix']}traceback", response["meta"])
+        self.assertIn(f"{CONFIG.provider['prefix']}traceback", response["meta"])
 
 
-class IndexTestDebugOn(unittest.TestCase):
-    def __init__(self, methodName: str = "runTest"):
-        super().__init__(methodName=methodName)
-        os.environ["DEBUG"] = "1"
-        self.client = get_index_client()
+class IndexTestDebugOn(SetClient, unittest.TestCase):
+
+    server = "index"
 
     def test_debug_is_respected_when_off(self):
         """Make sure traceback is toggleable according to debug mode - here OFF
 
         TODO: This should be moved to a separate test file that tests the exception handlers.
         """
+        CONFIG.debug = True
+
         response = self.client.get("/non/existent/path")
         self.assertEqual(
             response.status_code,
@@ -148,4 +154,4 @@ class IndexTestDebugOn(unittest.TestCase):
         self.assertNotIn("data", response)
         self.assertIn("meta", response)
 
-        self.assertNotIn(f"{CONFIG.provider['prefix']}traceback", response["meta"])
+        self.assertIn(f"{CONFIG.provider['prefix']}traceback", response["meta"])

--- a/tests/server/test_config.py
+++ b/tests/server/test_config.py
@@ -45,12 +45,12 @@ class TestDebug(unittest.TestCase):
     """Test if debug mode is correctly set and respected"""
 
     def test_env_variable(self):
-        """Set DEBUG environment variable and check CONFIG picks up on it correctly"""
-        os.environ["DEBUG"] = "1"
+        """Set OPTIMADE_DEBUG environment variable and check CONFIG picks up on it correctly"""
+        os.environ["OPTIMADE_DEBUG"] = "1"
         CONFIG = ServerConfig()
         self.assertTrue(CONFIG.debug)
 
-        os.environ.pop("DEBUG", None)
+        os.environ.pop("OPTIMADE_DEBUG", None)
         CONFIG = ServerConfig()
         self.assertFalse(CONFIG.debug)
 

--- a/tests/server/test_config.py
+++ b/tests/server/test_config.py
@@ -1,7 +1,12 @@
-# pylint: disable=import-outside-toplevel,protected-access,pointless-statement
+# pylint: disable=protected-access,pointless-statement,relative-beyond-top-level
+import os
 import unittest
 
 from pathlib import Path
+
+from optimade.server.config import ServerConfig, CONFIG
+
+from .utils import SetClient, get_regular_client, get_index_client
 
 
 class LoadFromIniTest(unittest.TestCase):
@@ -9,8 +14,6 @@ class LoadFromIniTest(unittest.TestCase):
 
     def test_config_ini(self):
         """Invoke CONFIG using config_test.ini"""
-        from optimade.server.config import ServerConfig
-
         CONFIG = ServerConfig(
             server_cfg=Path(__file__).parent.joinpath("server_test_ini.cfg").resolve()
         )
@@ -27,8 +30,6 @@ class LoadFromJsonTest(unittest.TestCase):
 
     def test_config_json(self):
         """Invoke CONFIG using config_test.json"""
-        from optimade.server.config import ServerConfig
-
         CONFIG = ServerConfig(
             server_cfg=Path(__file__).parent.joinpath("server_test_json.cfg").resolve()
         )
@@ -38,3 +39,113 @@ class LoadFromJsonTest(unittest.TestCase):
         self.assertEqual(
             CONFIG._path, Path(__file__).parent.joinpath("config_test.json").resolve()
         )
+
+
+class TestDebug(unittest.TestCase):
+    """Test if debug mode is correctly set and respected"""
+
+    def test_env_variable(self):
+        """Set DEBUG environment variable and check CONFIG picks up on it correctly"""
+        os.environ["DEBUG"] = "1"
+        CONFIG = ServerConfig()
+        self.assertTrue(CONFIG.debug)
+
+        os.environ.pop("DEBUG", None)
+        CONFIG = ServerConfig()
+        self.assertFalse(CONFIG.debug)
+
+
+class TestDebugOff(SetClient, unittest.TestCase):
+
+    server = "regular"
+
+    def test_debug_is_respected_when_off(self):
+        """Make sure traceback is toggleable according to debug mode - here OFF
+
+        TODO: This should be moved to a separate test file that tests the exception handlers.
+        """
+        response = self.client.get("/non/existent/path")
+        self.assertEqual(
+            response.status_code,
+            404,
+            msg=f"Request should have failed, but didn't: {response.json()}",
+        )
+
+        response = response.json()
+        self.assertNotIn("data", response)
+        self.assertIn("meta", response)
+
+        self.assertNotIn(f"{CONFIG.provider['prefix']}traceback", response["meta"])
+
+
+class IndexTestDebugOff(SetClient, unittest.TestCase):
+
+    server = "index"
+
+    def test_debug_is_respected_when_off(self):
+        """Make sure traceback is toggleable according to debug mode - here OFF
+
+        TODO: This should be moved to a separate test file that tests the exception handlers.
+        """
+        response = self.client.get("/non/existent/path")
+        self.assertEqual(
+            response.status_code,
+            404,
+            msg=f"Request should have failed, but didn't: {response.json()}",
+        )
+
+        response = response.json()
+        self.assertNotIn("data", response)
+        self.assertIn("meta", response)
+
+        self.assertNotIn(f"{CONFIG.provider['prefix']}traceback", response["meta"])
+
+
+class TestDebugOn(unittest.TestCase):
+    def __init__(self, methodName: str = "runTest"):
+        super().__init__(methodName=methodName)
+        os.environ["DEBUG"] = "1"
+        self.client = get_regular_client()
+
+    def test_debug_is_respected_when_off(self):
+        """Make sure traceback is toggleable according to debug mode - here OFF
+
+        TODO: This should be moved to a separate test file that tests the exception handlers.
+        """
+        response = self.client.get("/non/existent/path")
+        self.assertEqual(
+            response.status_code,
+            404,
+            msg=f"Request should have failed, but didn't: {response.json()}",
+        )
+
+        response = response.json()
+        self.assertNotIn("data", response)
+        self.assertIn("meta", response)
+
+        self.assertNotIn(f"{CONFIG.provider['prefix']}traceback", response["meta"])
+
+
+class IndexTestDebugOn(unittest.TestCase):
+    def __init__(self, methodName: str = "runTest"):
+        super().__init__(methodName=methodName)
+        os.environ["DEBUG"] = "1"
+        self.client = get_index_client()
+
+    def test_debug_is_respected_when_off(self):
+        """Make sure traceback is toggleable according to debug mode - here OFF
+
+        TODO: This should be moved to a separate test file that tests the exception handlers.
+        """
+        response = self.client.get("/non/existent/path")
+        self.assertEqual(
+            response.status_code,
+            404,
+            msg=f"Request should have failed, but didn't: {response.json()}",
+        )
+
+        response = response.json()
+        self.assertNotIn("data", response)
+        self.assertIn("meta", response)
+
+        self.assertNotIn(f"{CONFIG.provider['prefix']}traceback", response["meta"])


### PR DESCRIPTION
Closes #130 

I have attempted to add a "debug" mode to the server.
At the moment it only toggles whether a Python traceback should be added under the toplevel `meta` response if an error occurs.

It is implemented so it can be activated if `debug` is added when running the server, e.g.:
```bash
./run.sh debug
```
or
```bash
./run.sh index debug
```
To start the regular or index server in debug mode, respectively.

The debug mode can also be run "always" by setting the environment variable DEBUG to 1, i.e. `export DEBUG=1`.

I've added some tests. Currently I've put them in `test_config.py`, but the main part of them should be moved to a future `test_exception_handlers.py` or even better, their own file completely.
It was more difficult than expected to make sure the debug mode was set properly for the test clients, ~so I needed to circumvent the "standard" setup of inheriting from `SetClient`, and instead use the utility functions to create the clients directly. This also means the test time has increased significantly for a very small test. This may be more justified in the future if more debug tests are added, to make sure other things are properly toggled according to the debug mode. But at the moment its a bit overkill - but it was the only way I could figure out to do the tests.~

Edit: I have made `CONFIG.debug` togglable, i.e., one can now set it on the go - this is quite useful for the tests - but I originally wanted it _not_ to be settable, since at no time would you change it while the server is running.