### PR TITLE
Add CORSMiddleware

### DIFF
--- a/optimade/server/main.py
+++ b/optimade/server/main.py
@@ -9,6 +9,7 @@ from pydantic import ValidationError
 from fastapi import FastAPI
 from fastapi.exceptions import RequestValidationError
 from starlette.exceptions import HTTPException as StarletteHTTPException
+from starlette.middleware.cors import CORSMiddleware
 
 from .entry_collections import MongoCollection
 from .config import CONFIG
@@ -64,6 +65,7 @@ if not CONFIG.use_real_mongo and all(path.exists() for path in test_paths.values
 
 # Add various middleware
 app.add_middleware(RedirectSlashedURLs)
+app.add_middleware(CORSMiddleware, allow_origins=["*"])
 
 
 # Add various exception handlers

--- a/optimade/server/main_index.py
+++ b/optimade/server/main_index.py
@@ -9,6 +9,7 @@ from pydantic import ValidationError
 from fastapi import FastAPI
 from fastapi.exceptions import RequestValidationError
 from starlette.exceptions import HTTPException as StarletteHTTPException
+from starlette.middleware.cors import CORSMiddleware
 
 from .config import CONFIG
 from .middleware import RedirectSlashedURLs
@@ -58,6 +59,7 @@ if not CONFIG.use_real_mongo and CONFIG.index_links_path.exists():
 
 # Add various middleware
 app.add_middleware(RedirectSlashedURLs)
+app.add_middleware(CORSMiddleware, allow_origins=["*"])
 
 
 # Add various exception handlers

--- a/tests/server/test_middleware.py
+++ b/tests/server/test_middleware.py
@@ -1,0 +1,62 @@
+# pylint: disable=relative-beyond-top-level
+import unittest
+
+from .utils import SetClient
+
+
+class CORSMiddlewareTest(SetClient, unittest.TestCase):
+
+    server = "regular"
+
+    def test_regular_CORS_request(self):
+        response = self.client.get("/info", headers={"Origin": "http://example.org"})
+        self.assertIn(
+            ("access-control-allow-origin", "*"),
+            tuple(response.headers.items()),
+            msg=f"Access-Control-Allow-Origin header not found in response headers: {response.headers}",
+        )
+
+    def test_preflight_CORS_request(self):
+        headers = {
+            "Origin": "http://example.org",
+            "Access-Control-Request-Method": "GET",
+        }
+        response = self.client.options("/info", headers=headers)
+        for response_header in (
+            "Access-Control-Allow-Origin",
+            "Access-Control-Allow-Methods",
+        ):
+            self.assertIn(
+                response_header.lower(),
+                list(response.headers.keys()),
+                msg=f"{response_header} header not found in response headers: {response.headers}",
+            )
+
+
+class IndexCORSMiddlewareTest(SetClient, unittest.TestCase):
+
+    server = "index"
+
+    def test_regular_CORS_request(self):
+        response = self.client.get("/info", headers={"Origin": "http://example.org"})
+        self.assertIn(
+            ("access-control-allow-origin", "*"),
+            tuple(response.headers.items()),
+            msg=f"Access-Control-Allow-Origin header not found in response headers: {response.headers}",
+        )
+
+    def test_preflight_CORS_request(self):
+        headers = {
+            "Origin": "http://example.org",
+            "Access-Control-Request-Method": "GET",
+        }
+        response = self.client.options("/info", headers=headers)
+        for response_header in (
+            "Access-Control-Allow-Origin",
+            "Access-Control-Allow-Methods",
+        ):
+            self.assertIn(
+                response_header.lower(),
+                list(response.headers.keys()),
+                msg=f"{response_header} header not found in response headers: {response.headers}",
+            )


### PR DESCRIPTION
Closes #159
Related to #193.

Allow cross origin requests from anywhere (`'*'`).
By default, allow `GET` requests.

Furthermore, tests are added to make sure a regular CORS request returns the correct header, as well as a "simple" preflight CORS request.

I am unsure whether the settings for CORS is correct according to what we wish to accomplish, i.e., should we have a list of allowed origins instead? Should we allow all headers by default, etc.