### PR TITLE
Use mongo for CI

### DIFF
--- a/.github/workflows/deps_eager.yml
+++ b/.github/workflows/deps_eager.yml
@@ -17,6 +17,12 @@ jobs:
       matrix:
         python-version: [3.6, 3.7, 3.8]
 
+    services:
+        mongo:
+            image: mongo:4.2
+            ports:
+            - 27017:27017
+
     steps:
     - uses: actions/checkout@v2
 
@@ -36,6 +42,8 @@ jobs:
     - name: Run tests on updated packages
       run: |
         pytest -rs --cov=./optimade/
+      env:
+        OPTIMADE_CI_FORCE_MONGO: 1
 
   # deps_clean-install:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/deps_eager.yml
+++ b/.github/workflows/deps_eager.yml
@@ -40,10 +40,14 @@ jobs:
         pip install -U --upgrade-strategy eager -r .github/workflows/requirements_eager.txt
 
     - name: Run tests on updated packages
-      run: |
-        pytest -rs --cov=./optimade/
+      run: pytest -rs --cov=./optimade/ --cov-report=xml
       env:
         OPTIMADE_CI_FORCE_MONGO: 1
+
+    - name: Run tests relevant for index meta-db (using `mongomock`)
+      run: pytest -rs --cov=./optimade/ --cov-report=xml --cov-append tests/server/test_middleware.py tests/server/test_server_validation.py tests/server/test_config.py
+      env:
+        OPTIMADE_CI_FORCE_MONGO: 0
 
   # deps_clean-install:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/deps_lint.yml
+++ b/.github/workflows/deps_lint.yml
@@ -157,11 +157,15 @@ jobs:
         python -m pip install -r .github/workflows/requirements.txt
         pip install -e .[all]
 
-    - name: Run tests
-      run: |
-        pytest -rs --cov=./optimade/ --cov-report=xml
+    - name: Run all tests (using a real MongoDB)
+      run: pytest -rs --cov=./optimade/ --cov-report=xml
       env:
         OPTIMADE_CI_FORCE_MONGO: 1
+
+    - name: Run tests only for index meta-db (using `mongomock`)
+      run: pytest -rs --cov=./optimade/ --cov-report=xml --cov-append tests/server/test_middleware.py tests/server/test_server_validation.py tests/server/test_config.py
+      env:
+        OPTIMADE_CI_FORCE_MONGO: 0
 
     - name: Upload coverage to Codecov
       if: matrix.python-version == 3.7

--- a/.github/workflows/deps_lint.yml
+++ b/.github/workflows/deps_lint.yml
@@ -135,6 +135,12 @@ jobs:
       matrix:
         python-version: [3.6, 3.7, 3.8]
 
+    services:
+        mongo:
+            image: mongo:4.2
+            ports:
+            - 27017:27017
+
     steps:
     - uses: actions/checkout@v2
 
@@ -154,6 +160,8 @@ jobs:
     - name: Run tests
       run: |
         pytest -rs --cov=./optimade/ --cov-report=xml
+      env:
+        OPTIMADE_CI_FORCE_MONGO: 1
 
     - name: Upload coverage to Codecov
       if: matrix.python-version == 3.7

--- a/optimade/server/entry_collections.py
+++ b/optimade/server/entry_collections.py
@@ -16,7 +16,7 @@ from .query_params import EntryListingQueryParams, SingleEntryQueryParams
 
 try:
     ci_force_mongo = bool(int(os.environ.get("OPTIMADE_CI_FORCE_MONGO", 0)))
-except (TypeError, ValueError):
+except (TypeError, ValueError):  # pragma: no cover
     ci_force_mongo = False
 
 

--- a/optimade/server/entry_collections.py
+++ b/optimade/server/entry_collections.py
@@ -16,7 +16,7 @@ from .query_params import EntryListingQueryParams, SingleEntryQueryParams
 
 try:
     ci_force_mongo = bool(int(os.environ.get("OPTIMADE_CI_FORCE_MONGO", 0)))
-except Exception:
+except (TypeError, ValueError):
     ci_force_mongo = False
 
 
@@ -24,10 +24,12 @@ if CONFIG.use_real_mongo or ci_force_mongo:
     from pymongo import MongoClient
 
     client = MongoClient(CONFIG.mongo_uri)
+    print("Using: Real MongoDB (pymongo)")
 else:
     from mongomock import MongoClient
 
     client = MongoClient()
+    print("Using: Mock MongoDB (mongomock)")
 
 
 class EntryCollection(Collection):  # pylint: disable=inherit-non-class

--- a/optimade/server/entry_collections.py
+++ b/optimade/server/entry_collections.py
@@ -1,3 +1,4 @@
+import os
 from abc import abstractmethod
 from typing import Collection, Tuple, List, Union
 
@@ -13,8 +14,13 @@ from .config import CONFIG
 from .mappers import ResourceMapper
 from .query_params import EntryListingQueryParams, SingleEntryQueryParams
 
+try:
+    ci_force_mongo = bool(int(os.environ.get("OPTIMADE_CI_FORCE_MONGO", 0)))
+except Exception:
+    ci_force_mongo = False
 
-if CONFIG.use_real_mongo:
+
+if CONFIG.use_real_mongo or ci_force_mongo:
     from pymongo import MongoClient
 
     client = MongoClient(CONFIG.mongo_uri)

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,4 @@ filterwarnings =
     ignore:.*PY_SSIZE_T_CLEAN will be required for '#' formats.*:DeprecationWarning
     ignore:.*"@coroutine" decorator is deprecated since Python 3.8, use "async def" instead.*:DeprecationWarning
     ignore:.*Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated.*:DeprecationWarning
+    ignore:.*the imp module is deprecated in favour of importlib.*:DeprecationWarning

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ server_deps = ["uvicorn", "Jinja2~=2.11"] + mongo_deps
 django_deps = ["django~=2.2,>=2.2.9"]
 elastic_deps = ["elasticsearch-dsl~=6.4"]
 testing_deps = [
-    "pytest~=3.10",
+    "pytest~=5.3",
     "pytest-cov",
     "codecov",
     "openapi-spec-validator",

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -146,7 +146,6 @@ def test_available_api_versions():
         {"url": "https://example.com/optimade/v1.0.2", "version": "1.0.2"},
         {"url": "http://example.com/optimade/v2.3", "version": "2.3.1"},
     ]
-
     bad_combos = [
         {"url": "https://example.com/optimade/v0", "version": "1.0.0"},
         {"url": "https://example.com/optimade/v1.0.2", "version": "1.0.3"},
@@ -154,15 +153,16 @@ def test_available_api_versions():
     ]
 
     for url in bad_urls:
-        with pytest.raises(ValueError, message=f"Url {url} should have failed"):
+        with pytest.raises(ValueError):
             AvailableApiVersion(url=url, version="1.0")
+            pytest.fail(f"Url {url} should have failed")
 
     for data in bad_combos:
-        with pytest.raises(
-            ValueError,
-            message=f"{data['url']} should have failed with version {data['version']}",
-        ):
+        with pytest.raises(ValueError):
             AvailableApiVersion(**data)
+            pytest.fail(
+                f"{data['url']} should have failed with version {data['version']}"
+            )
 
     for data in good_urls:
         AvailableApiVersion(**data)

--- a/tests/server/test_server_validation.py
+++ b/tests/server/test_server_validation.py
@@ -1,4 +1,5 @@
-# pylint: disable=relative-beyond-top-level
+# pylint: disable=relative-beyond-top-level,import-outside-toplevel
+import os
 import unittest
 
 from optimade.validator import ImplementationValidator
@@ -24,3 +25,22 @@ class IndexServerTestWithValidator(SetClient, unittest.TestCase):
         validator = ImplementationValidator(client=self.client, index=True)
         validator.main()
         self.assertTrue(validator.valid)
+
+
+def test_mongo_backend_package_used():
+    import pymongo
+    import mongomock
+    from optimade.server.entry_collections import client
+
+    force_mongo_env_var = os.environ.get("OPTIMADE_CI_FORCE_MONGO", None)
+    if force_mongo_env_var is None:
+        return
+
+    if int(force_mongo_env_var) == 1:
+        assert issubclass(client.__class__, pymongo.MongoClient)
+    elif int(force_mongo_env_var) == 0:
+        assert issubclass(client.__class__, mongomock.MongoClient)
+    else:
+        raise Exception(
+            f"The environment variable OPTIMADE_CI_FORCE_MONGO cannot be parsed as an int."
+        )


### PR DESCRIPTION
This PR adds an environment variable that we can use in the CI to force the use of a real mongo with the default settings. It's a bit of a hack, but I think this is the least intrusive way of doing it, otherwise, the way we handle passing the `MongoCollection`s to the routers would have to be changed.

Since the tests assume that the mongo is ephemeral, we don't ever want a user running the tests locally with mongo turned on, as it would either a) fail, b) require them to delete any existing "optimade" database.

I have run into this problem a couple of times when trying to reuse as much of the test server as possible, in a perfect world I think we would decouple the structures collection from the router (which only needs to be passed general `EntryCollection`) but I don't think it's worth doing that here.