### PR TITLE
Fix meta.query.representation and remove /optimade in base URLs

### DIFF
--- a/.github/workflows/deps_lint.yml
+++ b/.github/workflows/deps_lint.yml
@@ -105,11 +105,11 @@ jobs:
         .github/workflows/wait_for_it.sh localhost:3213 -t 120
         sleep 15
 
-    - name: Test server with OPTIONAL base URLs
+    - name: Test server, including OPTIONAL base URLs
       uses: ./
       with:
         port: 3213
-        path: /optimade
+        path: /
         all versioned paths: yes
 
     - name: Start Docker image - index server
@@ -118,11 +118,11 @@ jobs:
         .github/workflows/wait_for_it.sh localhost:3214 -t 120
         sleep 15
 
-    - name: Test index server with OPTIONAL base URLs
+    - name: Test index server, including OPTIONAL base URLs
       uses: ./
       with:
         port: 3214
-        path: /optimade
+        path: /
         all versioned paths: yes
         index: yes
 

--- a/.github/workflows/validator_action.yml
+++ b/.github/workflows/validator_action.yml
@@ -25,7 +25,7 @@ jobs:
         uses: ./
         with:
           port: 3213
-          path: /optimade/v0
+          path: /v1
 
   validator_index:
     runs-on: ubuntu-latest
@@ -44,7 +44,7 @@ jobs:
         uses: ./
         with:
           port: 3214
-          path: /optimade/v0
+          path: /v1
           index: yes
 
   all_versioned_paths:
@@ -64,5 +64,5 @@ jobs:
         uses: ./
         with:
           port: 3213
-          path: /optimade
+          path: /
           all versioned paths: yes

--- a/.github/workflows/validator_action.yml
+++ b/.github/workflows/validator_action.yml
@@ -66,3 +66,10 @@ jobs:
           port: 3213
           path: /
           all versioned paths: yes
+
+      - name: Run action (setting path to empty string)
+        uses: ./
+        with:
+          port: 3213
+          path: ""
+          all versioned paths: yes

--- a/.github/workflows/validator_action.yml
+++ b/.github/workflows/validator_action.yml
@@ -25,7 +25,7 @@ jobs:
         uses: ./
         with:
           port: 3213
-          path: /v1
+          path: /v0
 
   validator_index:
     runs-on: ubuntu-latest
@@ -44,7 +44,7 @@ jobs:
         uses: ./
         with:
           port: 3214
-          path: /v1
+          path: /v0
           index: yes
 
   all_versioned_paths:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,4 +1,6 @@
-# Installing the index meta-database
+# Installing OPTiMaDe Python tools
+
+## The index meta-database
 
 This package may be used to setup and run an [OPTiMaDe index meta-database](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst#index-meta-database).
 Install the package via `pip install optimade[server]` and change the file [`server.cfg`](server.cfg) found in the root of the package.
@@ -20,7 +22,7 @@ E.g., if you have installed `optimade` on a Linux machine at `/home/USERNAME/opt
 
 Then you need `server.cfg` to be located in your home folder containing either relative paths from its current location or absolute paths.
 
-# Full development installation
+## Full development installation
 
 The dependencies of this package can be found in `setup.py` with their latest supported versions.
 By default, a minimal set of requirements are installed to work with the filter language and the `pydantic` models.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -9,7 +9,7 @@ The paths must be relative from your current working directory, where your `serv
 The index meta-database is set up to populate a `mongomock` in-memory database with resources from a static `json` file containing the `child` resources you, as a database provider, want to serve under this index meta-database.
 
 Running the index meta-database is then as simple as writing `./run.sh index` in a terminal from the root of this package.
-You can find it at the base URL: [`http://localhost:5001/optimade`](http://localhost:5001/optimade).
+You can find it at the base URL: <http://localhost:5001/v0.10.1>.
 
 _Note_: `server.cfg` is loaded from the current working directory, from where you run `run.sh`.
 E.g., if you have installed `optimade` on a Linux machine at `/home/USERNAME/optimade/optimade-python-tools` and you run the following:
@@ -73,4 +73,4 @@ Running the following:
 uvicorn optimade.server.main_index:app --reload --port 5001
 ```
 
-will run the index meta-database server at <http://localhost:5001/optimade>.
+will run the index meta-database server at <http://localhost:5001/v0.10.1>.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 | Latest release | Build status | Activity |
 |:--------------:|:------------:|:--------:|
-| [![PyPI Version](https://img.shields.io/pypi/v/optimade?logo=pypi)](https://pypi.org/project/optimade/)<br>[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/optimade?logo=python)](https://pypi.org/project/optimade/)<br>[![OPTiMaDe](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Materials-Consortia/optimade-python-tools/master/.ci/optimade-version.json&logo=json)](https://github.com/Materials-Consortia/OPTiMaDe/) | [![Build Status](https://img.shields.io/github/workflow/status/Materials-Consortia/optimade-python-tools/Testing,%20linting,%20and%20OpenAPI%20validation?logo=github)](https://github.com/Materials-Consortia/optimade-python-tools/actions?query=branch%3Amaster+)<br>[![codecov](https://codecov.io/gh/Materials-Consortia/optimade-python-tools/branch/master/graph/badge.svg)](https://codecov.io/gh/Materials-Consortia/optimade-python-tools)<br>[![Heroku](https://heroku-badge.herokuapp.com/?app=optimade&root=optimade/v0/info)](https://optimade.herokuapp.com/optimade/v0/info) | [![Commit Activity](https://img.shields.io/github/commit-activity/m/Materials-Consortia/optimade-python-tools?logo=github)](https://github.com/Materials-Consortia/optimade-python-tools/pulse) |
+| [![PyPI Version](https://img.shields.io/pypi/v/optimade?logo=pypi)](https://pypi.org/project/optimade/)<br>[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/optimade?logo=python)](https://pypi.org/project/optimade/)<br>[![OPTiMaDe](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Materials-Consortia/optimade-python-tools/master/.ci/optimade-version.json&logo=json)](https://github.com/Materials-Consortia/OPTiMaDe/) | [![Build Status](https://img.shields.io/github/workflow/status/Materials-Consortia/optimade-python-tools/Testing,%20linting,%20and%20OpenAPI%20validation?logo=github)](https://github.com/Materials-Consortia/optimade-python-tools/actions?query=branch%3Amaster+)<br>[![codecov](https://codecov.io/gh/Materials-Consortia/optimade-python-tools/branch/master/graph/badge.svg)](https://codecov.io/gh/Materials-Consortia/optimade-python-tools)<br>[![Heroku](https://heroku-badge.herokuapp.com/?app=optimade&root=v0/info)](https://optimade.herokuapp.com/v0/info) | [![Commit Activity](https://img.shields.io/github/commit-activity/m/Materials-Consortia/optimade-python-tools?logo=github)](https://github.com/Materials-Consortia/optimade-python-tools/pulse) |
 
 The aim of OPTiMaDe is to develop a common API, compliant with the [JSON API 1.0](http://jsonapi.org/format/1.0/) specification.
 This is to enable interoperability among databases that contain calculated properties of existing and hypothetical materials.
@@ -30,14 +30,14 @@ This action runs `optimade_validator` from this repository on a running server.
 
 ### Example usage
 
-To run `optimade_validator` for an index meta-database at `http://gh_actions_host:5001/optimade/v0` do the following:  
+To run `optimade_validator` for an index meta-database at `http://gh_actions_host:5001/v0` do the following:  
 Within the same job, first, start a server, e.g., using the `docker-compose.yml` setup from this repository, and then add the step
 
 ```yml
 uses: Materials-Consortia/optimade-python-tools@master
 with:
   port: 5001
-  path: /optimade/v0
+  path: /v0
   index: yes
 ```
 
@@ -77,8 +77,8 @@ with:
 #### `path`
 
 **Optional** Path for the OPTiMaDe (versioned) base URL - MUST start with `/`  
-_Note_: If `all versioned paths` is `true`, this MUST be un-versioned, e.g., `/optimade`, otherwise it MUST be versioned, e.g., the default value.  
-**Default**: `/optimade/v0`
+_Note_: If `all versioned paths` is `true`, this MUST be un-versioned, e.g., `/optimade` or `/`, otherwise it MUST be versioned, e.g., the default value.  
+**Default**: `/v0`
 
 #### `all versioned paths`
 

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ inputs:
   path:
     description: Path of the OPTiMaDe (versioned) base URL - MUST start with '/'
     required: false
-    default: /optimade/v0
+    default: /v0
   all versioned paths:
     description: >
       Whether to test all possible versioned base URLs:

--- a/openapi/index_openapi.json
+++ b/openapi/index_openapi.json
@@ -6,20 +6,20 @@
     "version": "0.10.1"
   },
   "paths": {
-    "/optimade/v0/info": {
+    "/v0/info": {
       "get": {
         "tags": [
           "Info"
         ],
         "summary": "Get Info",
-        "operationId": "get_info_optimade_v0_info_get",
+        "operationId": "get_info_v0_info_get",
         "responses": {
           "200": {
             "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Response Get Info Optimade V0 Info Get",
+                  "title": "Response Get Info V0 Info Get",
                   "anyOf": [
                     {
                       "$ref": "#/components/schemas/IndexInfoResponse"
@@ -35,13 +35,13 @@
         }
       }
     },
-    "/optimade/v0/links": {
+    "/v0/links": {
       "get": {
         "tags": [
           "Links"
         ],
         "summary": "Get Links",
-        "operationId": "get_links_optimade_v0_links_get",
+        "operationId": "get_links_v0_links_get",
         "parameters": [
           {
             "description": "A filter string, in the format described in section [API Filtering Format Specification](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst#api-filtering-format-specification) of the [OPTiMaDe spec](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst).",
@@ -56,24 +56,24 @@
             "in": "query"
           },
           {
-            "description": "The output format requested (see section [Response Format](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst#response-format) in the spec). Defaults to the format string 'json', which specifies the standard output format described in this specification.\n**Example**: http://example.com/optimade/v0.9/structures?response_format=xml",
+            "description": "The output format requested (see section [Response Format](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst#response-format) in the spec). Defaults to the format string 'json', which specifies the standard output format described in this specification.\n**Example**: http://example.com/v1/structures?response_format=xml",
             "required": false,
             "schema": {
               "title": "Response Format",
               "type": "string",
-              "description": "The output format requested (see section [Response Format](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst#response-format) in the spec). Defaults to the format string 'json', which specifies the standard output format described in this specification.\n**Example**: http://example.com/optimade/v0.9/structures?response_format=xml",
+              "description": "The output format requested (see section [Response Format](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst#response-format) in the spec). Defaults to the format string 'json', which specifies the standard output format described in this specification.\n**Example**: http://example.com/v1/structures?response_format=xml",
               "default": "json"
             },
             "name": "response_format",
             "in": "query"
           },
           {
-            "description": "An email address of the user making the request. The email SHOULD be that of a person and not an automatic system.\n**Example**: http://example.com/optimade/v0.9/structures?email_address=user@example.com",
+            "description": "An email address of the user making the request. The email SHOULD be that of a person and not an automatic system.\n**Example**: http://example.com/v1/structures?email_address=user@example.com",
             "required": false,
             "schema": {
               "title": "Email Address",
               "type": "string",
-              "description": "An email address of the user making the request. The email SHOULD be that of a person and not an automatic system.\n**Example**: http://example.com/optimade/v0.9/structures?email_address=user@example.com",
+              "description": "An email address of the user making the request. The email SHOULD be that of a person and not an automatic system.\n**Example**: http://example.com/v1/structures?email_address=user@example.com",
               "format": "email",
               "default": ""
             },
@@ -81,13 +81,13 @@
             "in": "query"
           },
           {
-            "description": "A comma-delimited set of fields to be provided in the output. If provided, these fields MUST be returned along with the REQUIRED fields. Other OPTIONAL fields MUST NOT be returned when this parameter is present.\n**Example**: http://example.com/optimade/v0.9/structures?response_fields=last_modified,nsites",
+            "description": "A comma-delimited set of fields to be provided in the output. If provided, these fields MUST be returned along with the REQUIRED fields. Other OPTIONAL fields MUST NOT be returned when this parameter is present.\n**Example**: http://example.com/v1/structures?response_fields=last_modified,nsites",
             "required": false,
             "schema": {
               "title": "Response Fields",
               "pattern": "([a-z_][a-z_0-9]*(,[a-z_][a-z_0-9]*)*)?",
               "type": "string",
-              "description": "A comma-delimited set of fields to be provided in the output. If provided, these fields MUST be returned along with the REQUIRED fields. Other OPTIONAL fields MUST NOT be returned when this parameter is present.\n**Example**: http://example.com/optimade/v0.9/structures?response_fields=last_modified,nsites",
+              "description": "A comma-delimited set of fields to be provided in the output. If provided, these fields MUST be returned along with the REQUIRED fields. Other OPTIONAL fields MUST NOT be returned when this parameter is present.\n**Example**: http://example.com/v1/structures?response_fields=last_modified,nsites",
               "default": ""
             },
             "name": "response_fields",
@@ -203,7 +203,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Response Get Links Optimade V0 Links Get",
+                  "title": "Response Get Links V0 Links Get",
                   "anyOf": [
                     {
                       "$ref": "#/components/schemas/LinksResponse"

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -6,20 +6,20 @@
     "version": "0.10.1"
   },
   "paths": {
-    "/optimade/v0/info": {
+    "/v0/info": {
       "get": {
         "tags": [
           "Info"
         ],
         "summary": "Get Info",
-        "operationId": "get_info_optimade_v0_info_get",
+        "operationId": "get_info_v0_info_get",
         "responses": {
           "200": {
             "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Response Get Info Optimade V0 Info Get",
+                  "title": "Response Get Info V0 Info Get",
                   "anyOf": [
                     {
                       "$ref": "#/components/schemas/InfoResponse"
@@ -35,13 +35,13 @@
         }
       }
     },
-    "/optimade/v0/info/{entry}": {
+    "/v0/info/{entry}": {
       "get": {
         "tags": [
           "Info"
         ],
         "summary": "Get Entry Info",
-        "operationId": "get_entry_info_optimade_v0_info__entry__get",
+        "operationId": "get_entry_info_v0_info__entry__get",
         "parameters": [
           {
             "required": true,
@@ -59,7 +59,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Response Get Entry Info Optimade V0 Info  Entry  Get",
+                  "title": "Response Get Entry Info V0 Info  Entry  Get",
                   "anyOf": [
                     {
                       "$ref": "#/components/schemas/EntryInfoResponse"
@@ -85,13 +85,13 @@
         }
       }
     },
-    "/optimade/v0/links": {
+    "/v0/links": {
       "get": {
         "tags": [
           "Links"
         ],
         "summary": "Get Links",
-        "operationId": "get_links_optimade_v0_links_get",
+        "operationId": "get_links_v0_links_get",
         "parameters": [
           {
             "description": "A filter string, in the format described in section [API Filtering Format Specification](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst#api-filtering-format-specification) of the [OPTiMaDe spec](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst).",
@@ -106,24 +106,24 @@
             "in": "query"
           },
           {
-            "description": "The output format requested (see section [Response Format](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst#response-format) in the spec). Defaults to the format string 'json', which specifies the standard output format described in this specification.\n**Example**: http://example.com/optimade/v0.9/structures?response_format=xml",
+            "description": "The output format requested (see section [Response Format](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst#response-format) in the spec). Defaults to the format string 'json', which specifies the standard output format described in this specification.\n**Example**: http://example.com/v1/structures?response_format=xml",
             "required": false,
             "schema": {
               "title": "Response Format",
               "type": "string",
-              "description": "The output format requested (see section [Response Format](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst#response-format) in the spec). Defaults to the format string 'json', which specifies the standard output format described in this specification.\n**Example**: http://example.com/optimade/v0.9/structures?response_format=xml",
+              "description": "The output format requested (see section [Response Format](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst#response-format) in the spec). Defaults to the format string 'json', which specifies the standard output format described in this specification.\n**Example**: http://example.com/v1/structures?response_format=xml",
               "default": "json"
             },
             "name": "response_format",
             "in": "query"
           },
           {
-            "description": "An email address of the user making the request. The email SHOULD be that of a person and not an automatic system.\n**Example**: http://example.com/optimade/v0.9/structures?email_address=user@example.com",
+            "description": "An email address of the user making the request. The email SHOULD be that of a person and not an automatic system.\n**Example**: http://example.com/v1/structures?email_address=user@example.com",
             "required": false,
             "schema": {
               "title": "Email Address",
               "type": "string",
-              "description": "An email address of the user making the request. The email SHOULD be that of a person and not an automatic system.\n**Example**: http://example.com/optimade/v0.9/structures?email_address=user@example.com",
+              "description": "An email address of the user making the request. The email SHOULD be that of a person and not an automatic system.\n**Example**: http://example.com/v1/structures?email_address=user@example.com",
               "format": "email",
               "default": ""
             },
@@ -131,13 +131,13 @@
             "in": "query"
           },
           {
-            "description": "A comma-delimited set of fields to be provided in the output. If provided, these fields MUST be returned along with the REQUIRED fields. Other OPTIONAL fields MUST NOT be returned when this parameter is present.\n**Example**: http://example.com/optimade/v0.9/structures?response_fields=last_modified,nsites",
+            "description": "A comma-delimited set of fields to be provided in the output. If provided, these fields MUST be returned along with the REQUIRED fields. Other OPTIONAL fields MUST NOT be returned when this parameter is present.\n**Example**: http://example.com/v1/structures?response_fields=last_modified,nsites",
             "required": false,
             "schema": {
               "title": "Response Fields",
               "pattern": "([a-z_][a-z_0-9]*(,[a-z_][a-z_0-9]*)*)?",
               "type": "string",
-              "description": "A comma-delimited set of fields to be provided in the output. If provided, these fields MUST be returned along with the REQUIRED fields. Other OPTIONAL fields MUST NOT be returned when this parameter is present.\n**Example**: http://example.com/optimade/v0.9/structures?response_fields=last_modified,nsites",
+              "description": "A comma-delimited set of fields to be provided in the output. If provided, these fields MUST be returned along with the REQUIRED fields. Other OPTIONAL fields MUST NOT be returned when this parameter is present.\n**Example**: http://example.com/v1/structures?response_fields=last_modified,nsites",
               "default": ""
             },
             "name": "response_fields",
@@ -253,7 +253,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Response Get Links Optimade V0 Links Get",
+                  "title": "Response Get Links V0 Links Get",
                   "anyOf": [
                     {
                       "$ref": "#/components/schemas/LinksResponse"
@@ -279,13 +279,13 @@
         }
       }
     },
-    "/optimade/v0/references": {
+    "/v0/references": {
       "get": {
         "tags": [
           "References"
         ],
         "summary": "Get References",
-        "operationId": "get_references_optimade_v0_references_get",
+        "operationId": "get_references_v0_references_get",
         "parameters": [
           {
             "description": "A filter string, in the format described in section [API Filtering Format Specification](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst#api-filtering-format-specification) of the [OPTiMaDe spec](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst).",
@@ -300,24 +300,24 @@
             "in": "query"
           },
           {
-            "description": "The output format requested (see section [Response Format](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst#response-format) in the spec). Defaults to the format string 'json', which specifies the standard output format described in this specification.\n**Example**: http://example.com/optimade/v0.9/structures?response_format=xml",
+            "description": "The output format requested (see section [Response Format](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst#response-format) in the spec). Defaults to the format string 'json', which specifies the standard output format described in this specification.\n**Example**: http://example.com/v1/structures?response_format=xml",
             "required": false,
             "schema": {
               "title": "Response Format",
               "type": "string",
-              "description": "The output format requested (see section [Response Format](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst#response-format) in the spec). Defaults to the format string 'json', which specifies the standard output format described in this specification.\n**Example**: http://example.com/optimade/v0.9/structures?response_format=xml",
+              "description": "The output format requested (see section [Response Format](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst#response-format) in the spec). Defaults to the format string 'json', which specifies the standard output format described in this specification.\n**Example**: http://example.com/v1/structures?response_format=xml",
               "default": "json"
             },
             "name": "response_format",
             "in": "query"
           },
           {
-            "description": "An email address of the user making the request. The email SHOULD be that of a person and not an automatic system.\n**Example**: http://example.com/optimade/v0.9/structures?email_address=user@example.com",
+            "description": "An email address of the user making the request. The email SHOULD be that of a person and not an automatic system.\n**Example**: http://example.com/v1/structures?email_address=user@example.com",
             "required": false,
             "schema": {
               "title": "Email Address",
               "type": "string",
-              "description": "An email address of the user making the request. The email SHOULD be that of a person and not an automatic system.\n**Example**: http://example.com/optimade/v0.9/structures?email_address=user@example.com",
+              "description": "An email address of the user making the request. The email SHOULD be that of a person and not an automatic system.\n**Example**: http://example.com/v1/structures?email_address=user@example.com",
               "format": "email",
               "default": ""
             },
@@ -325,13 +325,13 @@
             "in": "query"
           },
           {
-            "description": "A comma-delimited set of fields to be provided in the output. If provided, these fields MUST be returned along with the REQUIRED fields. Other OPTIONAL fields MUST NOT be returned when this parameter is present.\n**Example**: http://example.com/optimade/v0.9/structures?response_fields=last_modified,nsites",
+            "description": "A comma-delimited set of fields to be provided in the output. If provided, these fields MUST be returned along with the REQUIRED fields. Other OPTIONAL fields MUST NOT be returned when this parameter is present.\n**Example**: http://example.com/v1/structures?response_fields=last_modified,nsites",
             "required": false,
             "schema": {
               "title": "Response Fields",
               "pattern": "([a-z_][a-z_0-9]*(,[a-z_][a-z_0-9]*)*)?",
               "type": "string",
-              "description": "A comma-delimited set of fields to be provided in the output. If provided, these fields MUST be returned along with the REQUIRED fields. Other OPTIONAL fields MUST NOT be returned when this parameter is present.\n**Example**: http://example.com/optimade/v0.9/structures?response_fields=last_modified,nsites",
+              "description": "A comma-delimited set of fields to be provided in the output. If provided, these fields MUST be returned along with the REQUIRED fields. Other OPTIONAL fields MUST NOT be returned when this parameter is present.\n**Example**: http://example.com/v1/structures?response_fields=last_modified,nsites",
               "default": ""
             },
             "name": "response_fields",
@@ -447,7 +447,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Response Get References Optimade V0 References Get",
+                  "title": "Response Get References V0 References Get",
                   "anyOf": [
                     {
                       "$ref": "#/components/schemas/ReferenceResponseMany"
@@ -473,13 +473,13 @@
         }
       }
     },
-    "/optimade/v0/references/{entry_id}": {
+    "/v0/references/{entry_id}": {
       "get": {
         "tags": [
           "References"
         ],
         "summary": "Get Single Reference",
-        "operationId": "get_single_reference_optimade_v0_references__entry_id__get",
+        "operationId": "get_single_reference_v0_references__entry_id__get",
         "parameters": [
           {
             "required": true,
@@ -491,24 +491,24 @@
             "in": "path"
           },
           {
-            "description": "The output format requested (see section [Response Format](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst#response-format) in the spec). Defaults to the format string 'json', which specifies the standard output format described in this specification.\n**Example**: http://example.com/optimade/v0.9/structures?response_format=xml",
+            "description": "The output format requested (see section [Response Format](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst#response-format) in the spec). Defaults to the format string 'json', which specifies the standard output format described in this specification.\n**Example**: http://example.com/v1/structures?response_format=xml",
             "required": false,
             "schema": {
               "title": "Response Format",
               "type": "string",
-              "description": "The output format requested (see section [Response Format](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst#response-format) in the spec). Defaults to the format string 'json', which specifies the standard output format described in this specification.\n**Example**: http://example.com/optimade/v0.9/structures?response_format=xml",
+              "description": "The output format requested (see section [Response Format](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst#response-format) in the spec). Defaults to the format string 'json', which specifies the standard output format described in this specification.\n**Example**: http://example.com/v1/structures?response_format=xml",
               "default": "json"
             },
             "name": "response_format",
             "in": "query"
           },
           {
-            "description": "An email address of the user making the request. The email SHOULD be that of a person and not an automatic system.\n**Example**: http://example.com/optimade/v0.9/structures?email_address=user@example.com",
+            "description": "An email address of the user making the request. The email SHOULD be that of a person and not an automatic system.\n**Example**: http://example.com/v1/structures?email_address=user@example.com",
             "required": false,
             "schema": {
               "title": "Email Address",
               "type": "string",
-              "description": "An email address of the user making the request. The email SHOULD be that of a person and not an automatic system.\n**Example**: http://example.com/optimade/v0.9/structures?email_address=user@example.com",
+              "description": "An email address of the user making the request. The email SHOULD be that of a person and not an automatic system.\n**Example**: http://example.com/v1/structures?email_address=user@example.com",
               "format": "email",
               "default": ""
             },
@@ -516,13 +516,13 @@
             "in": "query"
           },
           {
-            "description": "A comma-delimited set of fields to be provided in the output. If provided, these fields MUST be returned along with the REQUIRED fields. Other OPTIONAL fields MUST NOT be returned when this parameter is present.\n**Example**: http://example.com/optimade/v0.9/structures?response_fields=last_modified,nsites",
+            "description": "A comma-delimited set of fields to be provided in the output. If provided, these fields MUST be returned along with the REQUIRED fields. Other OPTIONAL fields MUST NOT be returned when this parameter is present.\n**Example**: http://example.com/v1/structures?response_fields=last_modified,nsites",
             "required": false,
             "schema": {
               "title": "Response Fields",
               "pattern": "([a-z_][a-z_0-9]*(,[a-z_][a-z_0-9]*)*)?",
               "type": "string",
-              "description": "A comma-delimited set of fields to be provided in the output. If provided, these fields MUST be returned along with the REQUIRED fields. Other OPTIONAL fields MUST NOT be returned when this parameter is present.\n**Example**: http://example.com/optimade/v0.9/structures?response_fields=last_modified,nsites",
+              "description": "A comma-delimited set of fields to be provided in the output. If provided, these fields MUST be returned along with the REQUIRED fields. Other OPTIONAL fields MUST NOT be returned when this parameter is present.\n**Example**: http://example.com/v1/structures?response_fields=last_modified,nsites",
               "default": ""
             },
             "name": "response_fields",
@@ -547,7 +547,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Response Get Single Reference Optimade V0 References  Entry Id  Get",
+                  "title": "Response Get Single Reference V0 References  Entry Id  Get",
                   "anyOf": [
                     {
                       "$ref": "#/components/schemas/ReferenceResponseOne"
@@ -573,13 +573,13 @@
         }
       }
     },
-    "/optimade/v0/structures": {
+    "/v0/structures": {
       "get": {
         "tags": [
           "Structures"
         ],
         "summary": "Get Structures",
-        "operationId": "get_structures_optimade_v0_structures_get",
+        "operationId": "get_structures_v0_structures_get",
         "parameters": [
           {
             "description": "A filter string, in the format described in section [API Filtering Format Specification](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst#api-filtering-format-specification) of the [OPTiMaDe spec](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst).",
@@ -594,24 +594,24 @@
             "in": "query"
           },
           {
-            "description": "The output format requested (see section [Response Format](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst#response-format) in the spec). Defaults to the format string 'json', which specifies the standard output format described in this specification.\n**Example**: http://example.com/optimade/v0.9/structures?response_format=xml",
+            "description": "The output format requested (see section [Response Format](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst#response-format) in the spec). Defaults to the format string 'json', which specifies the standard output format described in this specification.\n**Example**: http://example.com/v1/structures?response_format=xml",
             "required": false,
             "schema": {
               "title": "Response Format",
               "type": "string",
-              "description": "The output format requested (see section [Response Format](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst#response-format) in the spec). Defaults to the format string 'json', which specifies the standard output format described in this specification.\n**Example**: http://example.com/optimade/v0.9/structures?response_format=xml",
+              "description": "The output format requested (see section [Response Format](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst#response-format) in the spec). Defaults to the format string 'json', which specifies the standard output format described in this specification.\n**Example**: http://example.com/v1/structures?response_format=xml",
               "default": "json"
             },
             "name": "response_format",
             "in": "query"
           },
           {
-            "description": "An email address of the user making the request. The email SHOULD be that of a person and not an automatic system.\n**Example**: http://example.com/optimade/v0.9/structures?email_address=user@example.com",
+            "description": "An email address of the user making the request. The email SHOULD be that of a person and not an automatic system.\n**Example**: http://example.com/v1/structures?email_address=user@example.com",
             "required": false,
             "schema": {
               "title": "Email Address",
               "type": "string",
-              "description": "An email address of the user making the request. The email SHOULD be that of a person and not an automatic system.\n**Example**: http://example.com/optimade/v0.9/structures?email_address=user@example.com",
+              "description": "An email address of the user making the request. The email SHOULD be that of a person and not an automatic system.\n**Example**: http://example.com/v1/structures?email_address=user@example.com",
               "format": "email",
               "default": ""
             },
@@ -619,13 +619,13 @@
             "in": "query"
           },
           {
-            "description": "A comma-delimited set of fields to be provided in the output. If provided, these fields MUST be returned along with the REQUIRED fields. Other OPTIONAL fields MUST NOT be returned when this parameter is present.\n**Example**: http://example.com/optimade/v0.9/structures?response_fields=last_modified,nsites",
+            "description": "A comma-delimited set of fields to be provided in the output. If provided, these fields MUST be returned along with the REQUIRED fields. Other OPTIONAL fields MUST NOT be returned when this parameter is present.\n**Example**: http://example.com/v1/structures?response_fields=last_modified,nsites",
             "required": false,
             "schema": {
               "title": "Response Fields",
               "pattern": "([a-z_][a-z_0-9]*(,[a-z_][a-z_0-9]*)*)?",
               "type": "string",
-              "description": "A comma-delimited set of fields to be provided in the output. If provided, these fields MUST be returned along with the REQUIRED fields. Other OPTIONAL fields MUST NOT be returned when this parameter is present.\n**Example**: http://example.com/optimade/v0.9/structures?response_fields=last_modified,nsites",
+              "description": "A comma-delimited set of fields to be provided in the output. If provided, these fields MUST be returned along with the REQUIRED fields. Other OPTIONAL fields MUST NOT be returned when this parameter is present.\n**Example**: http://example.com/v1/structures?response_fields=last_modified,nsites",
               "default": ""
             },
             "name": "response_fields",
@@ -741,7 +741,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Response Get Structures Optimade V0 Structures Get",
+                  "title": "Response Get Structures V0 Structures Get",
                   "anyOf": [
                     {
                       "$ref": "#/components/schemas/StructureResponseMany"
@@ -767,13 +767,13 @@
         }
       }
     },
-    "/optimade/v0/structures/{entry_id}": {
+    "/v0/structures/{entry_id}": {
       "get": {
         "tags": [
           "Structures"
         ],
         "summary": "Get Single Structure",
-        "operationId": "get_single_structure_optimade_v0_structures__entry_id__get",
+        "operationId": "get_single_structure_v0_structures__entry_id__get",
         "parameters": [
           {
             "required": true,
@@ -785,24 +785,24 @@
             "in": "path"
           },
           {
-            "description": "The output format requested (see section [Response Format](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst#response-format) in the spec). Defaults to the format string 'json', which specifies the standard output format described in this specification.\n**Example**: http://example.com/optimade/v0.9/structures?response_format=xml",
+            "description": "The output format requested (see section [Response Format](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst#response-format) in the spec). Defaults to the format string 'json', which specifies the standard output format described in this specification.\n**Example**: http://example.com/v1/structures?response_format=xml",
             "required": false,
             "schema": {
               "title": "Response Format",
               "type": "string",
-              "description": "The output format requested (see section [Response Format](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst#response-format) in the spec). Defaults to the format string 'json', which specifies the standard output format described in this specification.\n**Example**: http://example.com/optimade/v0.9/structures?response_format=xml",
+              "description": "The output format requested (see section [Response Format](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst#response-format) in the spec). Defaults to the format string 'json', which specifies the standard output format described in this specification.\n**Example**: http://example.com/v1/structures?response_format=xml",
               "default": "json"
             },
             "name": "response_format",
             "in": "query"
           },
           {
-            "description": "An email address of the user making the request. The email SHOULD be that of a person and not an automatic system.\n**Example**: http://example.com/optimade/v0.9/structures?email_address=user@example.com",
+            "description": "An email address of the user making the request. The email SHOULD be that of a person and not an automatic system.\n**Example**: http://example.com/v1/structures?email_address=user@example.com",
             "required": false,
             "schema": {
               "title": "Email Address",
               "type": "string",
-              "description": "An email address of the user making the request. The email SHOULD be that of a person and not an automatic system.\n**Example**: http://example.com/optimade/v0.9/structures?email_address=user@example.com",
+              "description": "An email address of the user making the request. The email SHOULD be that of a person and not an automatic system.\n**Example**: http://example.com/v1/structures?email_address=user@example.com",
               "format": "email",
               "default": ""
             },
@@ -810,13 +810,13 @@
             "in": "query"
           },
           {
-            "description": "A comma-delimited set of fields to be provided in the output. If provided, these fields MUST be returned along with the REQUIRED fields. Other OPTIONAL fields MUST NOT be returned when this parameter is present.\n**Example**: http://example.com/optimade/v0.9/structures?response_fields=last_modified,nsites",
+            "description": "A comma-delimited set of fields to be provided in the output. If provided, these fields MUST be returned along with the REQUIRED fields. Other OPTIONAL fields MUST NOT be returned when this parameter is present.\n**Example**: http://example.com/v1/structures?response_fields=last_modified,nsites",
             "required": false,
             "schema": {
               "title": "Response Fields",
               "pattern": "([a-z_][a-z_0-9]*(,[a-z_][a-z_0-9]*)*)?",
               "type": "string",
-              "description": "A comma-delimited set of fields to be provided in the output. If provided, these fields MUST be returned along with the REQUIRED fields. Other OPTIONAL fields MUST NOT be returned when this parameter is present.\n**Example**: http://example.com/optimade/v0.9/structures?response_fields=last_modified,nsites",
+              "description": "A comma-delimited set of fields to be provided in the output. If provided, these fields MUST be returned along with the REQUIRED fields. Other OPTIONAL fields MUST NOT be returned when this parameter is present.\n**Example**: http://example.com/v1/structures?response_fields=last_modified,nsites",
               "default": ""
             },
             "name": "response_fields",
@@ -841,7 +841,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Response Get Single Structure Optimade V0 Structures  Entry Id  Get",
+                  "title": "Response Get Single Structure V0 Structures  Entry Id  Get",
                   "anyOf": [
                     {
                       "$ref": "#/components/schemas/StructureResponseOne"

--- a/optimade/server/config.ini
+++ b/optimade/server/config.ini
@@ -21,7 +21,7 @@ prefix = _exmpl_
 name = Example provider
 description = Provider used for examples, not to be assigned to a real database
 homepage = http://example.com
-index_base_url = http://localhost:5001/optimade
+index_base_url = http://localhost:5001
 
 [structures]
 band_gap :

--- a/optimade/server/data/test_links.json
+++ b/optimade/server/data/test_links.json
@@ -7,7 +7,7 @@
     "type": "parent",
     "name": "Index meta-database",
     "description": "Index for example's OPTiMaDe databases",
-    "base_url": "http://localhost:5001/optimade",
+    "base_url": "http://localhost:5001",
     "homepage": "https://example.com"
   }
 ]

--- a/optimade/server/exception_handlers.py
+++ b/optimade/server/exception_handlers.py
@@ -54,7 +54,7 @@ def general_exception(
         )
     except Exception:
         # This was introduced due to the original raise of an HTTPException if the
-        # path prefix could not be found, e.g., `/optimade/v0`.
+        # path prefix could not be found, e.g., `/v0`.
         # However, due to the testing, this error cannot be raised anymore.
         # Instead, an OPTiMaDe warning should be issued.
         # Having this try and except is still good practice though.

--- a/optimade/server/index_links.json
+++ b/optimade/server/index_links.json
@@ -4,7 +4,7 @@
     "type": "child",
     "name": "OPTiMaDe API",
     "description": "The [Open Databases Integration for Materials Design (OPTiMaDe) consortium](https://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.",
-    "base_url": "http://localhost:5000/optimade",
+    "base_url": "http://localhost:5000",
     "homepage": "https://example.com"
   }
 ]

--- a/optimade/server/main.py
+++ b/optimade/server/main.py
@@ -83,6 +83,7 @@ app.include_router(structures.router, prefix=BASE_URL_PREFIXES["major"])
 
 
 # Add the router for the landing page for all prefixes
+app.include_router(landing.router)
 app.include_router(landing.router, prefix=BASE_URL_PREFIXES["major"])
 
 

--- a/optimade/server/main.py
+++ b/optimade/server/main.py
@@ -75,23 +75,22 @@ app.add_exception_handler(VisitError, exc_handlers.grammar_not_implemented_handl
 app.add_exception_handler(Exception, exc_handlers.general_exception_handler)
 
 
-# Add various endpoints to `/optimade/vMAJOR`
+# Add various endpoints to `/vMAJOR`
 app.include_router(info.router, prefix=BASE_URL_PREFIXES["major"])
 app.include_router(links.router, prefix=BASE_URL_PREFIXES["major"])
 app.include_router(references.router, prefix=BASE_URL_PREFIXES["major"])
 app.include_router(structures.router, prefix=BASE_URL_PREFIXES["major"])
 
 
-# Add the router for the landing page at `/optimade` and for all prefixes
-app.include_router(landing.router, prefix="/optimade")
+# Add the router for the landing page for all prefixes
 app.include_router(landing.router, prefix=BASE_URL_PREFIXES["major"])
 
 
 def add_optional_versioned_base_urls(app: FastAPI):
     """Add the following OPTIONAL prefixes/base URLs to server:
     ```
-        /optimade/vMajor.Minor
-        /optimade/vMajor.Minor.Patch
+        /vMajor.Minor
+        /vMajor.Minor.Patch
     ```
     """
     for version in ("minor", "patch"):
@@ -113,7 +112,7 @@ def update_schema(app: FastAPI):
 
 @app.on_event("startup")
 async def startup_event():
-    # Update OpenAPI schema on versioned base URL `/optimade/vMAJOR`
+    # Update OpenAPI schema on versioned base URL `/vMAJOR`
     update_schema(app)
-    # Add API endpoints for OPTIONAL base URLs `/optimade/vMAJOR.MINOR` and `/optimade/vMAJOR.MINOR.PATCH`
+    # Add API endpoints for OPTIONAL base URLs `/vMAJOR.MINOR` and `/vMAJOR.MINOR.PATCH`
     add_optional_versioned_base_urls(app)

--- a/optimade/server/main_index.py
+++ b/optimade/server/main_index.py
@@ -69,7 +69,7 @@ app.add_exception_handler(VisitError, exc_handlers.grammar_not_implemented_handl
 app.add_exception_handler(Exception, exc_handlers.general_exception_handler)
 
 
-# Add various endpoints to `/optimade/vMAJOR`
+# Add various endpoints to `/vMAJOR`
 app.include_router(index_info.router, prefix=BASE_URL_PREFIXES["major"])
 app.include_router(links.router, prefix=BASE_URL_PREFIXES["major"])
 
@@ -77,8 +77,8 @@ app.include_router(links.router, prefix=BASE_URL_PREFIXES["major"])
 def add_optional_versioned_base_urls(app: FastAPI):
     """Add the following OPTIONAL prefixes/base URLs to server:
     ```
-        /optimade/vMajor.Minor
-        /optimade/vMajor.Minor.Patch
+        /vMajor.Minor
+        /vMajor.Minor.Patch
     ```
     """
     for version in ("minor", "patch"):
@@ -97,7 +97,7 @@ def update_schema(app: FastAPI):
 
 @app.on_event("startup")
 async def startup_event():
-    # Update OpenAPI schema on versioned base URL `/optimade/vMAJOR`
+    # Update OpenAPI schema on versioned base URL `/vMAJOR`
     update_schema(app)
-    # Add API endpoints for OPTIONAL base URLs `/optimade/vMAJOR.MINOR` and `/optimade/vMAJOR.MINOR.PATCH`
+    # Add API endpoints for OPTIONAL base URLs `/vMAJOR.MINOR` and `/vMAJOR.MINOR.PATCH`
     add_optional_versioned_base_urls(app)

--- a/optimade/server/query_params.py
+++ b/optimade/server/query_params.py
@@ -20,18 +20,18 @@ class EntryListingQueryParams:
             "json",
             description="The output format requested (see section [Response Format](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/"
             "optimade.rst#response-format) in the spec). Defaults to the format string 'json', which specifies the standard output format "
-            "described in this specification.\n**Example**: http://example.com/optimade/v0.9/structures?response_format=xml",
+            "described in this specification.\n**Example**: http://example.com/v1/structures?response_format=xml",
         ),
         email_address: EmailStr = Query(
             "",
             description="An email address of the user making the request. The email SHOULD be that of a person and not an automatic system.\n"
-            "**Example**: http://example.com/optimade/v0.9/structures?email_address=user@example.com",
+            "**Example**: http://example.com/v1/structures?email_address=user@example.com",
         ),
         response_fields: str = Query(
             "",
             description="A comma-delimited set of fields to be provided in the output. If provided, these fields MUST be returned along with "
             "the REQUIRED fields. Other OPTIONAL fields MUST NOT be returned when this parameter is present.\n"
-            "**Example**: http://example.com/optimade/v0.9/structures?response_fields=last_modified,nsites",
+            "**Example**: http://example.com/v1/structures?response_fields=last_modified,nsites",
             regex=r"([a-z_][a-z_0-9]*(,[a-z_][a-z_0-9]*)*)?",
         ),
         sort: str = Query(
@@ -134,18 +134,18 @@ class SingleEntryQueryParams:
             "json",
             description="The output format requested (see section [Response Format](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/"
             "optimade.rst#response-format) in the spec). Defaults to the format string 'json', which specifies the standard output format "
-            "described in this specification.\n**Example**: http://example.com/optimade/v0.9/structures?response_format=xml",
+            "described in this specification.\n**Example**: http://example.com/v1/structures?response_format=xml",
         ),
         email_address: EmailStr = Query(
             "",
             description="An email address of the user making the request. The email SHOULD be that of a person and not an automatic system.\n"
-            "**Example**: http://example.com/optimade/v0.9/structures?email_address=user@example.com",
+            "**Example**: http://example.com/v1/structures?email_address=user@example.com",
         ),
         response_fields: str = Query(
             "",
             description="A comma-delimited set of fields to be provided in the output. If provided, these fields MUST be returned along with "
             "the REQUIRED fields. Other OPTIONAL fields MUST NOT be returned when this parameter is present.\n"
-            "**Example**: http://example.com/optimade/v0.9/structures?response_fields=last_modified,nsites",
+            "**Example**: http://example.com/v1/structures?response_fields=last_modified,nsites",
             regex=r"([a-z_][a-z_0-9]*(,[a-z_][a-z_0-9]*)*)?",
         ),
         include: str = Query(

--- a/optimade/server/routers/utils.py
+++ b/optimade/server/routers/utils.py
@@ -28,9 +28,9 @@ ENTRY_INFO_SCHEMAS = {
 }
 
 BASE_URL_PREFIXES = {
-    "major": f"/optimade/v{__api_version__.split('.')[0]}",
-    "minor": f"/optimade/v{'.'.join(__api_version__.split('.')[:2])}",
-    "patch": f"/optimade/v{__api_version__}",
+    "major": f"/v{__api_version__.split('.')[0]}",
+    "minor": f"/v{'.'.join(__api_version__.split('.')[:2])}",
+    "patch": f"/v{__api_version__}",
 }
 
 
@@ -61,8 +61,8 @@ def meta_values(
     parse_result = urllib.parse.urlparse(url)
 
     # To catch all (valid) variations of the version part of the URL, a regex is used
-    if re.match(r"/optimade/v[0-9]+(\.[0-9]+){,2}/.*", parse_result.path) is not None:
-        url_path = re.sub(r"/optimade/v[0-9]+(\.[0-9]+){,2}/", "/", parse_result.path)
+    if re.match(r"/v[0-9]+(\.[0-9]+){,2}/.*", parse_result.path) is not None:
+        url_path = re.sub(r"/v[0-9]+(\.[0-9]+){,2}/", "/", parse_result.path)
     else:
         url_path = parse_result.path
 

--- a/optimade/server/routers/utils.py
+++ b/optimade/server/routers/utils.py
@@ -1,4 +1,5 @@
 # pylint: disable=import-outside-toplevel,too-many-locals
+import re
 import urllib
 from datetime import datetime
 from typing import Union, List, Dict, Any
@@ -59,12 +60,10 @@ def meta_values(
 
     parse_result = urllib.parse.urlparse(url)
 
-    for prefix in list(BASE_URL_PREFIXES.values()):
-        if parse_result.path.startswith(prefix):
-            url_path = parse_result.path[len(prefix) :]
-            break
+    # To catch all (valid) variations of the version part of the URL, a regex is used
+    if re.match(r"/optimade/v[0-9]+(\.[0-9]+){,2}/.*", parse_result.path) is not None:
+        url_path = re.sub(r"/optimade/v[0-9]+(\.[0-9]+){,2}/", "/", parse_result.path)
     else:
-        # Raise warning
         url_path = parse_result.path
 
     provider = CONFIG.provider.copy()

--- a/optimade/validator/__init__.py
+++ b/optimade/validator/__init__.py
@@ -1,4 +1,5 @@
 """ This module contains the ImplementationValidator class and corresponding command line tools. """
+# pylint: disable=import-outside-toplevel
 
 from .validator import ImplementationValidator
 
@@ -14,27 +15,27 @@ def validate():
         prog="optimade_validator",
         description="""Tests OPTiMaDe implementations for compliance with the optimade-python-tools models.
 
-    - To test an entire implementation (at say example.com/optimade) for all required/available endpoints:
+    - To test an entire implementation (at say example.com/optimade/v1) for all required/available endpoints:
 
-        $ optimade_validator http://example.com/optimade
-
-    - To test a particular response of an implementation against a particular model:
-
-        $ optimade_validator http://example.com/optimade/structures/id=1234 --as_type structure
+        $ optimade_validator http://example.com/optimade/v1
 
     - To test a particular response of an implementation against a particular model:
 
-        $ optimade_validator http://example.com/optimade/structures --as_type structures
+        $ optimade_validator http://example.com/optimade/v1/structures/id=1234 --as_type structure
+
+    - To test a particular response of an implementation against a particular model:
+
+        $ optimade_validator http://example.com/optimade/v1/structures --as_type structures
         """,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(
         "base_url",
         nargs="?",
-        default="http://localhost:5000/optimade",
+        default="http://localhost:5000/v0",
         help=(
             "The base URL of the OPTiMaDe implementation to point at, "
-            "e.g. 'http://example.com/optimade' or 'http://localhost:5000/optimade"
+            "e.g. 'http://example.com/optimade/v1' or 'http://localhost:5000/v1"
         ),
     )
     parser.add_argument(
@@ -46,7 +47,7 @@ def validate():
         type=str,
         help=(
             "Validate the request URL with the provided type, rather than scanning the entire implementation e.g. "
-            "optimade_validator `http://example.com/optimade/structures/0 --as_type structures`"
+            "optimade_validator `http://example.com/optimade/v1/structures/0 --as_type structures`"
         ),
     )
     parser.add_argument(

--- a/optimade/validator/github_action/entrypoint.sh
+++ b/optimade/validator/github_action/entrypoint.sh
@@ -2,42 +2,46 @@
 
 # Retrieve and add GitHub Actions host runner IP to known hosts
 DOCKER_HOST_IP=$(cat /docker_host_ip)
-echo $DOCKER_HOST_IP gh_actions_host >> /etc/hosts
+echo ${DOCKER_HOST_IP} gh_actions_host >> /etc/hosts
 
 run_validator="optimade_validator"
 
-if [ ! -z "$INPUT_PORT" ]; then
-    BASE_URL="$INPUT_PROTOCOL://$INPUT_DOMAIN:$INPUT_PORT"
+if [ ! -z "${INPUT_PORT}" ]; then
+    BASE_URL="${INPUT_PROTOCOL}://${INPUT_DOMAIN}:${INPUT_PORT}"
 else
-    BASE_URL="$INPUT_PROTOCOL://$INPUT_DOMAIN"
+    BASE_URL="${INPUT_PROTOCOL}://${INPUT_DOMAIN}"
 fi
-run_validator="$run_validator $BASE_URL"
+run_validator="${run_validator} ${BASE_URL}"
 
 index=""
-case $INPUT_INDEX in
+case ${INPUT_INDEX} in
     y | Y | yes | Yes | YES | true | True | TRUE | on | On | ON)
         index=" --index"
         ;;
     n | N | no | No | NO | false | False | FALSE | off | Off | OFF)
         ;;
     *)
-        echo "Non-valid input for 'index': $INPUT_INDEX. Will use default (false)."
+        echo "Non-valid input for 'index': ${INPUT_INDEX}. Will use default (false)."
         ;;
 esac
 
-case $INPUT_ALL_VERSIONED_PATHS in
+case ${INPUT_ALL_VERSIONED_PATHS} in
     y | Y | yes | Yes | YES | true | True | TRUE | on | On | ON)
         for version in '0' '0.10' '0.10.1'; do
-            sh -c "$run_validator$INPUT_PATH/v$version$index"
+            if [ "${INPUT_PATH}" = "/" ]; then
+                sh -c "${run_validator}${INPUT_PATH}v${version}${index}"
+            else
+                sh -c "${run_validator}${INPUT_PATH}/v${version}${index}"
+            fi
         done
         ;;
     n | N | no | No | NO | false | False | FALSE | off | Off | OFF)
-        run_validator="$run_validator$INPUT_PATH$index"
-        sh -c "$run_validator"
+        run_validator="${run_validator}${INPUT_PATH}${index}"
+        sh -c "${run_validator}"
         ;;
     *)
-        echo "Non-valid input for 'all versioned paths': $INPUT_ALL_VERSIONED_PATHS. Will use default (false)."
-        run_validator="$run_validator$INPUT_PATH$index"
-        sh -c "$run_validator"
+        echo "Non-valid input for 'all versioned paths': ${INPUT_ALL_VERSIONED_PATHS}. Will use default (false)."
+        run_validator="${run_validator}${INPUT_PATH}${index}"
+        sh -c "${run_validator}"
         ;;
 esac

--- a/optimade/validator/validator.py
+++ b/optimade/validator/validator.py
@@ -78,7 +78,7 @@ class Client:
             base_url (str): the base URL of the optimade implementation, including
             request protocol (e.g. `'http://'`) and API version number if necessary.
             Examples:
-                - `'http://example.org/optimade'`,
+                - `'http://example.org/optimade/v1'`,
                 - `'www.crystallography.net/cod-test/optimade/v0.10.0/'`
             Note: A maximum of one slash ("/") is allowed as the last character.
 

--- a/tasks.py
+++ b/tasks.py
@@ -85,4 +85,12 @@ def set_optimade_ver(_, ver=""):
         ),
     )
 
+    with open("INSTALL.md", "r") as f:
+        lines = [
+            re.sub(r"/v[0-9]+(\.[0-9]+){2}", f"/v{version}", l.rstrip()) for l in f
+        ]
+    with open("INSTALL.md", "w") as f:
+        f.write("\n".join(lines))
+        f.write("\n")
+
     print(f"Bumped OPTiMaDe version to {ver}")

--- a/tasks.py
+++ b/tasks.py
@@ -71,12 +71,10 @@ def set_optimade_ver(_, ver=""):
             "README.md", (f"example/v{regex}", f"example/v{version}"), strip="\n"
         )
     update_file(
-        ".github/workflows/validator_action.yml",
-        ("/optimade/v[0-9]+", f"/optimade/v{ver.split('.')[0]}"),
+        ".github/workflows/validator_action.yml", ("/v[0-9]+", f"/v{ver.split('.')[0]}")
     )
-    update_file(
-        "README.md", ("optimade/v[0-9]+", f"optimade/v{ver.split('.')[0]}"), strip="\n"
-    )
+    update_file("README.md", ("v[0-9]+", f"v{ver.split('.')[0]}"), strip="\n")
+    update_file("action.yml", ("/v[0-9]+", f"/v{ver.split('.')[0]}"))
     update_file(
         "optimade/validator/github_action/entrypoint.sh",
         (
@@ -84,13 +82,6 @@ def set_optimade_ver(_, ver=""):
             f"'{ver.split('.')[0]}' '{'.'.join(ver.split('.')[:2])}' '{ver}'",
         ),
     )
-
-    with open("INSTALL.md", "r") as f:
-        lines = [
-            re.sub(r"/v[0-9]+(\.[0-9]+){2}", f"/v{version}", l.rstrip()) for l in f
-        ]
-    with open("INSTALL.md", "w") as f:
-        f.write("\n".join(lines))
-        f.write("\n")
+    update_file("INSTALL.md", (r"/v[0-9]+(\.[0-9]+){2}", f"/v{version}"))
 
     print(f"Bumped OPTiMaDe version to {ver}")

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -136,20 +136,20 @@ class TestPydanticValidation(unittest.TestCase):
 
 def test_available_api_versions():
     bad_urls = [
-        "asfdsafhttps://example.com/optimade/v0.0",
+        "asfdsafhttps://example.com/v0.0",
         "https://example.com/optimade",
-        "https://example.com/optimade/v0",
-        "https://example.com/optimade/v0999",
+        "https://example.com/v0",
+        "https://example.com/v0999",
     ]
     good_urls = [
-        {"url": "https://example.com/optimade/v0", "version": "0.1.9"},
-        {"url": "https://example.com/optimade/v1.0.2", "version": "1.0.2"},
-        {"url": "http://example.com/optimade/v2.3", "version": "2.3.1"},
+        {"url": "https://example.com/v0", "version": "0.1.9"},
+        {"url": "https://example.com/v1.0.2", "version": "1.0.2"},
+        {"url": "http://example.com/v2.3", "version": "2.3.1"},
     ]
     bad_combos = [
-        {"url": "https://example.com/optimade/v0", "version": "1.0.0"},
-        {"url": "https://example.com/optimade/v1.0.2", "version": "1.0.3"},
-        {"url": "http://example.com/optimade/v2.3", "version": "2.0.1"},
+        {"url": "https://example.com/v0", "version": "1.0.0"},
+        {"url": "https://example.com/v1.0.2", "version": "1.0.3"},
+        {"url": "http://example.com/v2.3", "version": "2.0.1"},
     ]
 
     for url in bad_urls:

--- a/tests/server/config_test.ini
+++ b/tests/server/config_test.ini
@@ -19,7 +19,7 @@ prefix = _exmpl_
 name = Example provider
 description = Provider used for examples, not to be assigned to a real database
 homepage = http://example.com
-index_base_url = http://localhost:5001/optimade
+index_base_url = http://localhost:5001
 
 [structures]
 band_gap :

--- a/tests/server/config_test.json
+++ b/tests/server/config_test.json
@@ -16,7 +16,7 @@
         "name": "Example provider",
         "description": "Provider used for examples, not to be assigned to a real database",
         "homepage": "http://example.com",
-        "index_base_url": "http://localhost:5001/optimade"
+        "index_base_url": "http://localhost:5001"
     },
     "provider_fields": {
         "structures": [

--- a/tests/server/utils.py
+++ b/tests/server/utils.py
@@ -12,14 +12,14 @@ def get_regular_client() -> TestClient:
     from optimade.server.main import app
     from optimade.server.routers import info, links, references, structures
 
-    # We need to remove the /optimade prefixes in order to have the tests run correctly.
+    # We need to remove the version prefixes in order to have the tests run correctly.
     app.include_router(info.router)
     app.include_router(links.router)
     app.include_router(references.router)
     app.include_router(structures.router)
     # need to explicitly set base_url, as the default "http://testserver"
     # does not validate as pydantic AnyUrl model
-    return TestClient(app, base_url="http://example.org/optimade/v0")
+    return TestClient(app, base_url="http://example.org/v0")
 
 
 def get_index_client() -> TestClient:
@@ -27,12 +27,12 @@ def get_index_client() -> TestClient:
     from optimade.server.main_index import app
     from optimade.server.routers import index_info, links
 
-    # We need to remove the /optimade prefixes in order to have the tests run correctly.
+    # # We need to remove the version prefixes in order to have the tests run correctly.
     app.include_router(index_info.router)
     app.include_router(links.router)
     # need to explicitly set base_url, as the default "http://testserver"
     # does not validate as pydantic UrlStr model
-    return TestClient(app, base_url="http://example.org/optimade/v0")
+    return TestClient(app, base_url="http://example.org/v0")
 
 
 class SetClient(abc.ABC):


### PR DESCRIPTION
Fixes #199 
Closes #197 

### Concerning `meta.query.representation` (#199)

For #199 a regex is now used to match the version part of the URL path.
Note, however that the regex only recognizes the form `/vMAJOR[.MINOR[.PATCH]]`. So if anything other is passed, the `meta.query.representation` value will return the full URL path.

E.g., for a server with version 0.10.1 running at `https://example.org`, a request to: `https://example.org/vTest/structures` will return a 404 and a JSON response (as expected) with an error object under the top-level `errors` field, as well as the standard `meta` fields, where `meta.query.representation` will be the full path, i.e., `/vTest/structures?`, where it maybe _should_ be simply `/structures?`. However, I think this is fine?

Otherwise, for the same server (again, running version 0.10.1 at `https://example.org`) a request to: `https://example.org/v1.0/structures` will return the same response, essentially, with the exception of the value of `meta.query.representation`, which will be `/structures?`.

For me this is fine, what do you think?

### Concerning the removal of `/optimade` from the base URL (#197)

This has been removed throughout the code base, where I could match `/optimade` and it made sense.

### Addtional

The validator GH Action did not support setting path to `/`, this PR fixes this, which is indeed crucial concerning the removal of `/optimade`.