### PR TITLE
Test mandatory queries in validator

### DIFF
--- a/optimade/validator/validator.py
+++ b/optimade/validator/validator.py
@@ -257,6 +257,10 @@ class ImplementationValidator:
             REQUIRED_ENTRY_ENDPOINTS_INDEX if self.index else REQUIRED_ENTRY_ENDPOINTS
         )
         self.test_entry_endpoints = set(self.expected_entry_endpoints)
+        self.endpoint_mandatory_queries = (
+            {} if self.index else ENDPOINT_MANDATORY_QUERIES
+        )
+
         self.response_classes = (
             RESPONSE_CLASSES_INDEX if self.index else RESPONSE_CLASSES
         )
@@ -326,11 +330,13 @@ class ImplementationValidator:
             self._log.debug("Testing single entry request of type %s", endp)
             self.test_single_entry_endpoint(endp)
 
-        for endp in ENDPOINT_MANDATORY_QUERIES:
+        for endp in self.endpoint_mandatory_queries:
             # skip empty endpoint query lists
-            if ENDPOINT_MANDATORY_QUERIES[endp]:
+            if self.endpoint_mandatory_queries[endp]:
                 self._log.debug("Testing mandatory query syntax on endpoint %s", endp)
-                self.test_mandatory_query_syntax(endp, ENDPOINT_MANDATORY_QUERIES[endp])
+                self.test_mandatory_query_syntax(
+                    endp, self.endpoint_mandatory_queries[endp]
+                )
 
         self._log.debug("Testing %s endpoint", LINKS_ENDPOINT)
         self.test_info_or_links_endpoints(LINKS_ENDPOINT)


### PR DESCRIPTION
This PR currently adds a mechanism for testing mandatory query syntax in the validator. It expects nothing in return (but if it receives data, it validates it) but does checks that an error is not returned.

Some thoughts:
- At one point we spoke about keeping a centralized list of example queries, did this ever go anywhere? It would be nice to take these directly from the spec... (EDIT: this is now handled in #213)
- The validator needs to be able to handle "optional features", I can either add that to this PR, or make another one... (EDIT: this is for a future PR...)