### PR TITLE
Update handling of include parameter (and other query parameters)

### DIFF
--- a/optimade/server/exceptions.py
+++ b/optimade/server/exceptions.py
@@ -1,0 +1,15 @@
+from fastapi import HTTPException
+
+
+class BadRequest(HTTPException):
+    """400 Bad Request"""
+
+    def __init__(
+        self,
+        status_code: int = 400,
+        detail: str = None,
+        headers: dict = None,
+        title: str = "Bad Request",
+    ) -> None:
+        super().__init__(status_code=status_code, detail=detail, headers=headers)
+        self.title = title

--- a/optimade/server/main.py
+++ b/optimade/server/main.py
@@ -10,14 +10,14 @@ from fastapi import FastAPI
 from fastapi.exceptions import RequestValidationError, StarletteHTTPException
 from fastapi.middleware.cors import CORSMiddleware
 
+from optimade import __api_version__, __version__
+import optimade.server.exception_handlers as exc_handlers
+
 from .entry_collections import MongoCollection
 from .config import CONFIG
 from .middleware import EnsureQueryParamIntegrity
 from .routers import info, links, references, structures, landing
 from .routers.utils import get_providers, BASE_URL_PREFIXES
-
-from optimade import __api_version__, __version__
-import optimade.server.exception_handlers as exc_handlers
 
 
 if CONFIG.debug:  # pragma: no cover

--- a/optimade/server/main.py
+++ b/optimade/server/main.py
@@ -12,6 +12,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from .entry_collections import MongoCollection
 from .config import CONFIG
+from .middleware import EnsureQueryParamIntegrity
 from .routers import info, links, references, structures, landing
 from .routers.utils import get_providers, BASE_URL_PREFIXES
 
@@ -67,6 +68,7 @@ if not CONFIG.use_real_mongo and all(path.exists() for path in test_paths.values
 
 # Add various middleware
 app.add_middleware(CORSMiddleware, allow_origins=["*"])
+app.add_middleware(EnsureQueryParamIntegrity)
 
 
 # Add various exception handlers

--- a/optimade/server/main_index.py
+++ b/optimade/server/main_index.py
@@ -10,12 +10,13 @@ from fastapi import FastAPI
 from fastapi.exceptions import RequestValidationError, StarletteHTTPException
 from fastapi.middleware.cors import CORSMiddleware
 
-from .config import CONFIG
-from .routers import index_info, links
-from .routers.utils import BASE_URL_PREFIXES
-
 from optimade import __api_version__, __version__
 import optimade.server.exception_handlers as exc_handlers
+
+from .config import CONFIG
+from .middleware import EnsureQueryParamIntegrity
+from .routers import index_info, links
+from .routers.utils import BASE_URL_PREFIXES
 
 
 if CONFIG.debug:  # pragma: no cover
@@ -61,6 +62,7 @@ if not CONFIG.use_real_mongo and CONFIG.index_links_path.exists():
 
 # Add various middleware
 app.add_middleware(CORSMiddleware, allow_origins=["*"])
+app.add_middleware(EnsureQueryParamIntegrity)
 
 
 # Add various exception handlers

--- a/optimade/server/middleware.py
+++ b/optimade/server/middleware.py
@@ -1,0 +1,26 @@
+import urllib.parse
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+
+from optimade.server.routers.utils import BadRequest
+
+
+class EnsureQueryParamIntegrity(BaseHTTPMiddleware):
+    """Ensure all query parameters are followed by an equal sign (`=`)"""
+
+    async def dispatch(self, request: Request, call_next):
+        parsed_url = urllib.parse.urlsplit(str(request.url))
+        if parsed_url.query:
+            queries_amp = set(parsed_url.query.split("&"))
+            queries = set()
+            for query in queries_amp:
+                queries.update(set(query.split(";")))
+            queries = list(queries)
+            for query in queries:
+                if "=" not in query:
+                    raise BadRequest(
+                        detail="A query parameter without an equal sign (=) is not supported by this server"
+                    )
+        response = await call_next(request)
+        return response

--- a/optimade/server/middleware.py
+++ b/optimade/server/middleware.py
@@ -3,24 +3,29 @@ import urllib.parse
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 
-from optimade.server.routers.utils import BadRequest
+from optimade.server.exceptions import BadRequest
 
 
 class EnsureQueryParamIntegrity(BaseHTTPMiddleware):
     """Ensure all query parameters are followed by an equal sign (`=`)"""
 
+    @staticmethod
+    def check_url(url_query: str):
+        """Check parsed URL query part for parameters not followed by `=`"""
+        queries_amp = set(url_query.split("&"))
+        queries = set()
+        for query in queries_amp:
+            queries.update(set(query.split(";")))
+        for query in queries:
+            if "=" not in query and query != "":
+                raise BadRequest(
+                    detail="A query parameter without an equal sign (=) is not supported by this server"
+                )
+        return queries  # Useful for testing
+
     async def dispatch(self, request: Request, call_next):
         parsed_url = urllib.parse.urlsplit(str(request.url))
         if parsed_url.query:
-            queries_amp = set(parsed_url.query.split("&"))
-            queries = set()
-            for query in queries_amp:
-                queries.update(set(query.split(";")))
-            queries = list(queries)
-            for query in queries:
-                if "=" not in query:
-                    raise BadRequest(
-                        detail="A query parameter without an equal sign (=) is not supported by this server"
-                    )
+            self.check_url(parsed_url.query)
         response = await call_next(request)
         return response

--- a/optimade/server/routers/utils.py
+++ b/optimade/server/routers/utils.py
@@ -2,7 +2,7 @@
 import re
 import urllib
 from datetime import datetime
-from typing import Union, List, Dict, Any
+from typing import Union, List, Dict
 
 from fastapi import HTTPException, Request
 
@@ -19,6 +19,7 @@ from optimade.models import (
 
 from optimade.server.config import CONFIG
 from optimade.server.entry_collections import EntryCollection
+from optimade.server.exceptions import BadRequest
 from optimade.server.query_params import EntryListingQueryParams, SingleEntryQueryParams
 
 
@@ -32,20 +33,6 @@ BASE_URL_PREFIXES = {
     "minor": f"/v{'.'.join(__api_version__.split('.')[:2])}",
     "patch": f"/v{__api_version__}",
 }
-
-
-class BadRequest(HTTPException):
-    """400 Bad Request"""
-
-    def __init__(
-        self,
-        status_code: int = 400,
-        detail: Any = None,
-        headers: dict = None,
-        title: str = "Bad Request",
-    ) -> None:
-        super().__init__(status_code=status_code, detail=detail, headers=headers)
-        self.title = title
 
 
 def meta_values(
@@ -209,7 +196,6 @@ def get_entries(
     include = []
     if getattr(params, "include", False):
         include.extend(params.include.split(","))
-    print(include)
     included = get_included_relationships(results, ENTRY_COLLECTIONS, include)
 
     if more_data_available:
@@ -255,9 +241,6 @@ def get_single_entry(
     include = []
     if getattr(params, "include", False):
         include.extend(params.include.split(","))
-    else:
-        include.append(SingleEntryQueryParams().include.default)
-
     included = get_included_relationships(results, ENTRY_COLLECTIONS, include)
 
     if more_data_available:

--- a/optimade/server/routers/utils.py
+++ b/optimade/server/routers/utils.py
@@ -130,9 +130,8 @@ def get_included_relationships(
     if not isinstance(results, list):
         results = [results]
 
-    empty_values = {'""', "''"}
     for entry_type in include_param:
-        if entry_type not in ENTRY_COLLECTIONS and entry_type not in empty_values:
+        if entry_type not in ENTRY_COLLECTIONS and entry_type != "":
             raise BadRequest(
                 detail=f"'{entry_type}' cannot be identified as a valid relationship type. "
                 f"Known relationship types: {sorted(ENTRY_COLLECTIONS.keys())}"
@@ -202,6 +201,7 @@ def get_entries(
     params: EntryListingQueryParams,
 ) -> EntryResponseMany:
     """Generalized /{entry} endpoint getter"""
+    print(params.__dict__)
     from optimade.server.routers import ENTRY_COLLECTIONS
 
     results, data_returned, more_data_available, fields = collection.find(params)
@@ -209,9 +209,7 @@ def get_entries(
     include = []
     if getattr(params, "include", False):
         include.extend(params.include.split(","))
-    else:
-        include.append(EntryListingQueryParams().include.default)
-
+    print(include)
     included = get_included_relationships(results, ENTRY_COLLECTIONS, include)
 
     if more_data_available:

--- a/optimade/server/routers/utils.py
+++ b/optimade/server/routers/utils.py
@@ -188,7 +188,6 @@ def get_entries(
     params: EntryListingQueryParams,
 ) -> EntryResponseMany:
     """Generalized /{entry} endpoint getter"""
-    print(params.__dict__)
     from optimade.server.routers import ENTRY_COLLECTIONS
 
     results, data_returned, more_data_available, fields = collection.find(params)

--- a/tests/server/test_middleware.py
+++ b/tests/server/test_middleware.py
@@ -109,8 +109,8 @@ class EnsureQueryParamIntegrityTest(SetClient, unittest.TestCase):
         """No matter the chosen (valid) parameter separator (either & or ;) the parameters should be split correctly"""
         from optimade.server.middleware import EnsureQueryParamIntegrity
 
-        query_part = 'filter=""&include=;response_format=json'
-        expected_result = {'filter=""', "include=", "response_format=json"}
+        query_part = 'filter=id="mpf_1"&include=;response_format=json'
+        expected_result = {'filter=id="mpf_1"', "include=", "response_format=json"}
 
         parsed_set_of_queries = EnsureQueryParamIntegrity(self.client.app).check_url(
             query_part

--- a/tests/server/test_middleware.py
+++ b/tests/server/test_middleware.py
@@ -70,37 +70,16 @@ class EnsureQueryParamIntegrityTest(SetClient, unittest.TestCase):
 
     def _check_error_response(
         self,
-        request,
-        expected_status: int = 400,
-        expected_title: str = "Bad Request",
+        request: str,
+        expected_status: int = None,
+        expected_title: str = None,
         expected_detail: str = None,
     ):
-        try:
-            response = self.client.get(request)
-            self.assertEqual(
-                response.status_code,
-                expected_status,
-                msg=f"Request should have been an error with status code {expected_status}, "
-                f"but instead {response.status_code} was received.\nResponse:\n{response.json()}",
-            )
-            response = response.json()
-            self.assertEqual(len(response["errors"]), 1)
-            self.assertEqual(response["meta"]["data_returned"], 0)
-
-            error = response["errors"][0]
-            self.assertEqual(str(expected_status), error["status"])
-            self.assertEqual(expected_title, error["title"])
-
-            if expected_detail is None:
-                expected_detail = "Error trying to process rule "
-                self.assertTrue(error["detail"].startswith(expected_detail))
-            else:
-                self.assertEqual(expected_detail, error["detail"])
-
-        except Exception as exc:
-            print("Request attempted:")
-            print(f"{self.client.base_url}{request}")
-            raise exc
+        expected_status = 400 if expected_status is None else expected_status
+        expected_title = "Bad Request" if expected_title is None else expected_title
+        super()._check_error_response(
+            request, expected_status, expected_title, expected_detail
+        )
 
     def test_wrong_html_form(self):
         """Using a parameter without equality sign `=` or values should result in a `400 Bad Request` response"""

--- a/tests/server/test_middleware.py
+++ b/tests/server/test_middleware.py
@@ -1,5 +1,7 @@
-# pylint: disable=relative-beyond-top-level
+# pylint: disable=relative-beyond-top-level,import-outside-toplevel
 import unittest
+
+from optimade.server.exceptions import BadRequest
 
 from .utils import SetClient
 
@@ -60,3 +62,90 @@ class IndexCORSMiddlewareTest(SetClient, unittest.TestCase):
                 list(response.headers.keys()),
                 msg=f"{response_header} header not found in response headers: {response.headers}",
             )
+
+
+class EnsureQueryParamIntegrityTest(SetClient, unittest.TestCase):
+
+    server = "regular"
+
+    def _check_error_response(
+        self,
+        request,
+        expected_status: int = 400,
+        expected_title: str = "Bad Request",
+        expected_detail: str = None,
+    ):
+        try:
+            response = self.client.get(request)
+            self.assertEqual(
+                response.status_code,
+                expected_status,
+                msg=f"Request should have been an error with status code {expected_status}, "
+                f"but instead {response.status_code} was received.\nResponse:\n{response.json()}",
+            )
+            response = response.json()
+            self.assertEqual(len(response["errors"]), 1)
+            self.assertEqual(response["meta"]["data_returned"], 0)
+
+            error = response["errors"][0]
+            self.assertEqual(str(expected_status), error["status"])
+            self.assertEqual(expected_title, error["title"])
+
+            if expected_detail is None:
+                expected_detail = "Error trying to process rule "
+                self.assertTrue(error["detail"].startswith(expected_detail))
+            else:
+                self.assertEqual(expected_detail, error["detail"])
+
+        except Exception as exc:
+            print("Request attempted:")
+            print(f"{self.client.base_url}{request}")
+            raise exc
+
+    def test_wrong_html_form(self):
+        """Using a parameter without equality sign `=` or values should result in a `400 Bad Request` response"""
+        from optimade.server.query_params import EntryListingQueryParams
+
+        for valid_query_parameter in EntryListingQueryParams().__dict__:
+            request = f"/structures?{valid_query_parameter}"
+            with self.assertRaises(BadRequest):
+                self._check_error_response(
+                    request,
+                    expected_detail="A query parameter without an equal sign (=) is not supported by this server",
+                )
+
+    def test_wrong_html_form_one_wrong(self):
+        """Using a parameter without equality sign `=` or values should result in a `400 Bad Request` response
+
+        This should hold true, no matter the chosen (valid) parameter separator (either & or ;).
+        """
+        request = f"/structures?filter&include=;response_format=json"
+        with self.assertRaises(BadRequest):
+            self._check_error_response(
+                request,
+                expected_detail="A query parameter without an equal sign (=) is not supported by this server",
+            )
+
+    def test_parameter_separation(self):
+        """No matter the chosen (valid) parameter separator (either & or ;) the parameters should be split correctly"""
+        from optimade.server.middleware import EnsureQueryParamIntegrity
+
+        query_part = 'filter=""&include=;response_format=json'
+        expected_result = {'filter=""', "include=", "response_format=json"}
+
+        parsed_set_of_queries = EnsureQueryParamIntegrity(self.client.app).check_url(
+            query_part
+        )
+        self.assertSetEqual(expected_result, parsed_set_of_queries)
+
+    def test_empy_parameters(self):
+        """If parameter separators are present, the middleware should still succeed"""
+        from optimade.server.middleware import EnsureQueryParamIntegrity
+
+        query_part = ";;&&;&"
+        expected_result = {""}
+
+        parsed_set_of_queries = EnsureQueryParamIntegrity(self.client.app).check_url(
+            query_part
+        )
+        self.assertSetEqual(expected_result, parsed_set_of_queries)

--- a/tests/server/test_query_params.py
+++ b/tests/server/test_query_params.py
@@ -1,10 +1,6 @@
 # pylint: disable=relative-beyond-top-level,import-outside-toplevel
-import os
 import unittest
-import pytest
 from typing import Sequence
-
-from mongomock import __version__ as mongomock_version
 
 from optimade.server.config import CONFIG
 from optimade.server import mappers
@@ -178,7 +174,10 @@ class IncludeTests(SetClient, unittest.TestCase):
     def test_wrong_html_form(self):
         """Using the parameter without equality sign `=` or values should result in a `400 Bad Request` response"""
         request = "/structures?include"
-        self.check_error_response(request)
+        self.check_error_response(
+            request,
+            expected_detail="A query parameter without an equal sign (=) is not supported by this server",
+        )
 
 
 class ResponseFieldTests(SetClient, unittest.TestCase):

--- a/tests/server/utils.py
+++ b/tests/server/utils.py
@@ -53,6 +53,41 @@ class SetClient(abc.ABC):
             return self._client[self.server]
         raise ValueError(exception_message)
 
+    # pylint: disable=no-member
+    def _check_error_response(
+        self,
+        request: str,
+        expected_status: int = None,
+        expected_title: str = None,
+        expected_detail: str = None,
+    ):
+        try:
+            response = self.client.get(request)
+            self.assertEqual(
+                response.status_code,
+                expected_status,
+                msg=f"Request should have been an error with status code {expected_status}, "
+                f"but instead {response.status_code} was received.\nResponse:\n{response.json()}",
+            )
+            response = response.json()
+            self.assertEqual(len(response["errors"]), 1)
+            self.assertEqual(response["meta"]["data_returned"], 0)
+
+            error = response["errors"][0]
+            self.assertEqual(str(expected_status), error["status"])
+            self.assertEqual(expected_title, error["title"])
+
+            if expected_detail is None:
+                expected_detail = "Error trying to process rule "
+                self.assertTrue(error["detail"].startswith(expected_detail))
+            else:
+                self.assertEqual(expected_detail, error["detail"])
+
+        except Exception as exc:
+            print("Request attempted:")
+            print(f"{self.client.base_url}{request}")
+            raise exc
+
 
 class EndpointTestsMixin(SetClient):
     """ Mixin "base" class for common tests between endpoints. """


### PR DESCRIPTION
Fixes #208

A middleware checks the integrity of the incoming raw query part of the URL.
If it is found that a parameter is given without an equal sign, it will raise `BadRequest`.

`BadRequest` has been moved from `optimade.server.routers.utils` to a new file `optimade.server.exceptions`.

The handling of `include` has been updated to treat `'""'` and `"''"` as incorrect, and rather have the actual `""` be equal to a user request for not returning any included resources.

Tests have been updated to reflect the new handling, and a `test_wrong_html_form()` designed to raise a `BadRequest` from the middleware has been added to each current class testing the query parameters.