### PR TITLE
Update tests for available_api_versions

### DIFF
--- a/openapi/index_openapi.json
+++ b/openapi/index_openapi.json
@@ -250,12 +250,14 @@
             "title": "Url",
             "maxLength": 65536,
             "minLength": 1,
+            "pattern": ".+/v[0-1](\\.[0-9]+)*/?$",
             "type": "string",
             "description": "a string specifying a versioned base URL that MUST adhere to the rules in section Base URL",
             "format": "uri"
           },
           "version": {
             "title": "Version",
+            "pattern": "^[0-9]+(\\.[0-9]+){,2}$",
             "type": "string",
             "description": "a string containing the full version number of the API served at that versioned base URL. The version number string MUST NOT be prefixed by, e.g., 'v'."
           }

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -918,12 +918,14 @@
             "title": "Url",
             "maxLength": 65536,
             "minLength": 1,
+            "pattern": ".+/v[0-1](\\.[0-9]+)*/?$",
             "type": "string",
             "description": "a string specifying a versioned base URL that MUST adhere to the rules in section Base URL",
             "format": "uri"
           },
           "version": {
             "title": "Version",
+            "pattern": "^[0-9]+(\\.[0-9]+){,2}$",
             "type": "string",
             "description": "a string containing the full version number of the API served at that versioned base URL. The version number string MUST NOT be prefixed by, e.g., 'v'."
           }

--- a/optimade/models/baseinfo.py
+++ b/optimade/models/baseinfo.py
@@ -16,31 +16,21 @@ class AvailableApiVersion(BaseModel):
     url: AnyHttpUrl = Field(
         ...,
         description="a string specifying a versioned base URL that MUST adhere to the rules in section Base URL",
+        pattern=r".+/v[0-1](\.[0-9]+)*/?$",
     )
 
     version: str = Field(
         ...,
         description="a string containing the full version number of the API served at that versioned base URL. "
         "The version number string MUST NOT be prefixed by, e.g., 'v'.",
+        regex=r"^[0-9]+(\.[0-9]+){,2}$",
     )
 
     @validator("url")
     def url_must_be_versioned_base_url(cls, v):
-        """The URL must be a versioned Base URL"""
-        if not re.match(r".*/v[0-9]+(\.[0-9]+)*/?", v):
+        """The URL must be a valid versioned Base URL"""
+        if not re.match(r".+/v[0-1](\.[0-9]+)*/?$", v):
             raise ValueError(f"url MUST be a versioned base URL. It is: {v}")
-        return v
-
-    @validator("version")
-    def version_must_be_valid(cls, v):
-        """The version number string MUST NOT be prefixed by, e.g., 'v'"""
-        if not re.match(r"[0-9]+\.[0-9]+(\.[0-9]+)?", v):
-            raise ValueError(f"version MUST NOT be prefixed by, e.g., 'v'. It is: {v}")
-        try:
-            tuple(int(val) for val in v.split("."))
-        except ValueError:
-            raise ValueError(f"failed to parse version {v} sections as integers.")
-
         return v
 
     @root_validator(pre=False, skip_on_failure=True)
@@ -57,7 +47,6 @@ class AvailableApiVersion(BaseModel):
             raise ValueError(
                 f"API version {api_version} is not compatible with url version {url_version}."
             )
-
         return values
 
 


### PR DESCRIPTION
Fixes #204

Moved some of the validation for the fields "url" and "version" to the Field.
For "url", a `regex` validator cannot be added in Field, since the type "AnyHttpUrl" takes precedence, see https://pydantic-docs.helpmanual.io/usage/schema/#unenforced-field-constraints for more info.
Instead the validator is kept explicitly and the regex is added to the OpenAPI schema as `pattern`.

Note the extra part of the version validator has been removed, where it was checking whether or not each segment can be parsed as an integer.
This is now considered true always as a result of the regex validation.

**Important**: The regex for "url" currently _only_ allows the MAJOR versions `0` and `1`. I think this makes sense? It was to avoid invalid cases like `v09924`.