### PR TITLE
Validate all non-optional :filter: examples from the spec

### DIFF
--- a/optimade/filtertransformers/mongo.py
+++ b/optimade/filtertransformers/mongo.py
@@ -92,6 +92,9 @@ class MongoTransformer(Transformer):
             # without NOT
             return arg[0]
 
+        if list(arg[1].keys()) == ["$or"]:
+            return {"$nor": arg[1]["$or"]}
+
         # with NOT
         # TODO: This implementation probably fails in the case of `"(" expression ")"`
         return {prop: {"$not": expr} for prop, expr in arg[1].items()}

--- a/optimade/filtertransformers/mongo.py
+++ b/optimade/filtertransformers/mongo.py
@@ -190,14 +190,19 @@ class MongoTransformer(Transformer):
         # string: ESCAPED_STRING
         return string.strip('"')
 
-    def number(self, arg):
+    @v_args(inline=True)
+    def signed_int(self, number):
+        # signed_int : SIGNED_INT
+        return int(number)
+
+    @v_args(inline=True)
+    def number(self, number):
         # number: SIGNED_INT | SIGNED_FLOAT
-        token = arg[0]
-        if token.type == "SIGNED_INT":
+        if number.type == "SIGNED_INT":
             type_ = int
-        elif token.type == "SIGNED_FLOAT":
+        elif number.type == "SIGNED_FLOAT":
             type_ = float
-        return type_(token)
+        return type_(number)
 
     def __default__(self, data, children, meta):
         raise NotImplementedError(

--- a/optimade/grammar/v0.10.1.lark
+++ b/optimade/grammar/v0.10.1.lark
@@ -49,7 +49,7 @@ set_op_rhs: HAS ( [ OPERATOR ] value
                  | ONLY value_list )
 
 // Note: support for [ OPERATOR ] is OPTIONAL
-length_op_rhs: LENGTH [ OPERATOR ] value
+length_op_rhs: LENGTH [ OPERATOR ] signed_int
 
 set_zip_op_rhs: property_zip_addon HAS ( value_zip | ONLY value_zip_list | ALL value_zip_list | ANY value_zip_list )
 property_zip_addon: ":" property (":" property)*
@@ -62,6 +62,9 @@ string: ESCAPED_STRING
 
 // Number token syntax
 number: SIGNED_INT | SIGNED_FLOAT
+
+// Custom signed int
+signed_int: SIGNED_INT
 
 // Tokens
 

--- a/optimade/server/entry_collections.py
+++ b/optimade/server/entry_collections.py
@@ -107,6 +107,16 @@ class MongoCollection(EntryCollection):
             version=(0, 10, 1), variant="default"
         )  # The MongoTransformer only supports v0.10.1 as the latest grammar
 
+        # check aliases do not clash with mongo operators
+        self._mapper_aliases = self.resource_mapper.all_aliases()
+        if any(
+            alias[0].startswith("$") or alias[1].startswith("$")
+            for alias in self._mapper_aliases
+        ):
+            raise RuntimeError(
+                f"Cannot define an alias starting with a '$': {self._mapper_aliases}"
+            )
+
     def __len__(self):
         return self.collection.estimated_document_count()
 

--- a/optimade/server/entry_collections.py
+++ b/optimade/server/entry_collections.py
@@ -11,7 +11,7 @@ from optimade.filtertransformers.mongo import MongoTransformer
 from optimade.models import EntryResource
 
 from .config import CONFIG
-from .mappers import ResourceMapper
+from .mappers import BaseResourceMapper
 from .query_params import EntryListingQueryParams, SingleEntryQueryParams
 
 try:
@@ -34,7 +34,10 @@ else:
 
 class EntryCollection(Collection):  # pylint: disable=inherit-non-class
     def __init__(
-        self, collection, resource_cls: EntryResource, resource_mapper: ResourceMapper
+        self,
+        collection,
+        resource_cls: EntryResource,
+        resource_mapper: BaseResourceMapper,
     ):
         self.collection = collection
         self.parser = LarkParser()
@@ -93,7 +96,7 @@ class MongoCollection(EntryCollection):
             pymongo.collection.Collection, mongomock.collection.Collection
         ],
         resource_cls: EntryResource,
-        resource_mapper: ResourceMapper,
+        resource_mapper: BaseResourceMapper,
     ):
         super().__init__(collection, resource_cls, resource_mapper)
         self.transformer = MongoTransformer()

--- a/optimade/server/mappers/entries.py
+++ b/optimade/server/mappers/entries.py
@@ -1,11 +1,26 @@
 from typing import Tuple
 from optimade.server.config import CONFIG
 
-__all__ = ("ResourceMapper",)
+__all__ = ("BaseResourceMapper",)
 
 
-class ResourceMapper:
-    """Generic Resource Mapper"""
+class BaseResourceMapper:
+    """ Generic Resource Mapper that defines and performs the mapping
+    between objects in the database and the resource objects defined by
+    the specification.
+
+    Attributes:
+        ENDPOINT (str): defines the endpoint for which to apply this
+            mapper.
+        ALIASES (Tuple[Tuple[str, str]]): a tuple of aliases between
+            OPTiMaDe field names and the field names in the database ,
+            e.g. `(("elements", "custom_elements_field"))`.
+        REQUIRED_FIELDS (set[str]): the set of fieldnames to return
+            when mapping to the OPTiMaDe format.
+        TOP_LEVEL_NON_ATTRIBUTES_FIELDS (set[str]): the set of top-level
+            field names common to all endpoints.
+
+    """
 
     ENDPOINT: str = ""
     ALIASES: Tuple[Tuple[str, str]] = ()
@@ -27,7 +42,7 @@ class ResourceMapper:
     def alias_for(cls, field: str) -> str:
         """Return aliased field name
 
-        :param field: OPtiMaDe field name
+        :param field: OPTiMaDe field name
         :type field: str
 
         :return: Aliased field as found in PROVIDER_ALIASES + ALIASES
@@ -57,6 +72,7 @@ class ResourceMapper:
 
         :return: A resource object in OPTiMaDe format
         :rtype: dict
+
         """
         if "_id" in doc:
             del doc["_id"]

--- a/optimade/server/mappers/links.py
+++ b/optimade/server/mappers/links.py
@@ -1,9 +1,9 @@
-from .entries import ResourceMapper
+from .entries import BaseResourceMapper
 
 __all__ = ("LinksMapper",)
 
 
-class LinksMapper(ResourceMapper):
+class LinksMapper(BaseResourceMapper):
 
     ENDPOINT = "links"
 

--- a/optimade/server/mappers/references.py
+++ b/optimade/server/mappers/references.py
@@ -1,8 +1,8 @@
-from .entries import ResourceMapper
+from .entries import BaseResourceMapper
 
 __all__ = ("ReferenceMapper",)
 
 
-class ReferenceMapper(ResourceMapper):
+class ReferenceMapper(BaseResourceMapper):
 
     ENDPOINT = "references"

--- a/optimade/server/mappers/structures.py
+++ b/optimade/server/mappers/structures.py
@@ -1,8 +1,8 @@
-from .entries import ResourceMapper
+from .entries import BaseResourceMapper
 
 __all__ = ("StructureMapper",)
 
 
-class StructureMapper(ResourceMapper):
+class StructureMapper(BaseResourceMapper):
 
     ENDPOINT = "structures"

--- a/optimade/validator/__init__.py
+++ b/optimade/validator/__init__.py
@@ -1,6 +1,5 @@
 """ This module contains the ImplementationValidator class and corresponding command line tools. """
 # pylint: disable=import-outside-toplevel
-
 from .validator import ImplementationValidator
 
 __all__ = ["ImplementationValidator", "validate"]
@@ -9,6 +8,7 @@ __all__ = ["ImplementationValidator", "validate"]
 def validate():
     import argparse
     import sys
+    import os
     import traceback
 
     parser = argparse.ArgumentParser(
@@ -39,7 +39,7 @@ def validate():
         ),
     )
     parser.add_argument(
-        "--verbosity", "-v", type=int, default=1, help="The verbosity of the output"
+        "--verbosity", "-v", type=int, default=0, help="The verbosity of the output"
     )
     parser.add_argument(
         "--as_type",
@@ -59,6 +59,12 @@ def validate():
     )
 
     args = vars(parser.parse_args())
+
+    if os.environ.get("OPTIMADE_VERBOSITY") is not None:
+        try:
+            args["verbosity"] = int(os.environ.get("OPTIMADE_VERBOSITY", 0))
+        except (TypeError, ValueError):
+            pass
 
     valid_types = [
         "info",

--- a/optimade/validator/data/__init__.py
+++ b/optimade/validator/data/__init__.py
@@ -1,0 +1,36 @@
+""" This submodule loads the filter examples that have been scraped
+from the specification.
+
+- `filters.txt` is a automatically generated file containing all
+examples. It is generated using the `invoke` task `parse_spec_for_filters`.
+- `optional_filters.txt` is human-generated, and allows for filters that
+are inside `filters.txt` to be skipped, if it has been deemed that they
+are optional (external to the parsed file). In the future, it is hoped
+that the spec will be fully parseable and as such this file could be
+generated automatically too.
+
+When being loaded in, these filter examples are also made more concrete
+by replacing references to vague `values`/`value` with specific examples.
+
+"""
+
+from pathlib import Path
+
+__all__ = ["MANDATORY_FILTER_EXAMPLES"]
+
+ALIASES = {"values": '"1", "2", "3"', "value": "1", "inverse": "1"}
+
+with open(Path(__file__).parent.joinpath("optional_filters.txt"), "r") as f:
+    OPTIONAL_FILTER_EXAMPLES = [line.strip() for line in f.readlines()]
+
+with open(Path(__file__).parent.joinpath("filters.txt"), "r") as f:
+    _filters = []
+    for line in f.readlines():
+        if line.strip() in OPTIONAL_FILTER_EXAMPLES:
+            continue
+        for alias in ALIASES:
+            if alias in line:
+                line = line.replace(alias, ALIASES[alias])
+        _filters.append(line)
+
+    MANDATORY_FILTER_EXAMPLES = _filters

--- a/optimade/validator/data/filters.txt
+++ b/optimade/validator/data/filters.txt
@@ -1,0 +1,53 @@
+_exmpl1_bandgap<2.0 OR _exmpl2_bandgap<2.5
+NOT ( chemical_formula_hill = "Al" AND chemical_formula_anonymous = "A" OR chemical_formula_anonymous = "H2O" AND NOT chemical_formula_hill = "Ti" )
+nelements > 3
+chemical_formula_hill = "H2O" AND chemical_formula_anonymous != "AB"
+_exmpl_aax <= +.1e8 OR nelements >= 10 AND NOT ( _exmpl_x != "Some string" OR NOT _exmpl_a = 7)
+_exmpl_spacegroup="P2"
+_exmpl_cell_volume<100.0
+_exmpl_bandgap > 5.0 AND _exmpl_molecular_weight < 350
+_exmpl_melting_point<300 AND nelements=4 AND elements="Si,O2"
+_exmpl_some_string_property = 42
+5 < _exmpl_a
+((NOT (_exmpl_a>_exmpl_b)) AND _exmpl_x>0)
+5 < 7
+identifier CONTAINS x
+identifier STARTS WITH x
+identifier ENDS WITH x
+chemical_formula_anonymous CONTAINS "C2" AND chemical_formula_anonymous STARTS WITH "A2"
+chemical_formula_anonymous STARTS "B2" AND chemical_formula_anonymous ENDS WITH "D2"
+list HAS value
+list HAS ALL values
+list HAS ANY values
+list LENGTH value
+list HAS ONLY values
+NOT list HAS inverse
+list HAS < 3
+list HAS ALL < 3, > 3
+list:list HAS >=2:<=5
+elements HAS "H" AND elements HAS ALL "H","He","Ga","Ta" AND elements HAS ONLY "H","He","Ga","Ta" AND elements HAS ANY "H", "He", "Ga", "Ta"
+elements HAS ONLY "H","He","Ga","Ta"
+elements:_exmpl_element_counts HAS "H":6 AND elements:_exmpl_element_counts HAS ALL "H":6,"He":7 AND elements:_exmpl_element_counts HAS ONLY "H":6 AND elements:_exmpl_element_counts HAS ANY "H":6,"He":7 AND elements:_exmpl_element_counts HAS ONLY "H":6,"He":7
+_exmpl_element_counts HAS < 3 AND _exmpl_element_counts HAS ANY > 3, = 6, 4, != 8
+elements:_exmpl_element_counts:_exmpl_element_weights HAS ANY > 3:"He":>55.3 , = 6:>"Ti":<37.6 , 8:<"Ga":0
+calculations.id HAS "calc-id-96"
+authors.lastname HAS "Schmit"
+identifier IS UNKNOWN
+NOT identifier IS KNOWN
+chemical_formula_hill IS KNOWN AND NOT chemical_formula_anonymous IS UNKNOWN
+NOT a > b OR c = 100 AND f = "C2 H6"
+(NOT (a > b)) OR ( (c = 100) AND (f = "C2 H6") )
+a >= 0 AND NOT b < c OR c = 0
+((a >= 0) AND (NOT (b < c))) OR (c = 0)
+elements HAS ALL "Si", "Al", "O"
+elements HAS ALL "Si", "Al", "O" AND elements LENGTH 3
+nelements=4
+nelements>=2 AND nelements<=7
+elements:elements_ratios HAS ALL "Al":>0.3333, "Al":<0.3334
+chemical_formula_descriptive="(H2O)2 Na"
+chemical_formula_descriptive CONTAINS "H2O"
+chemical_formula_reduced="H2NaO"
+chemical_formula_hill="H2O2"
+chemical_formula_anonymous="A2B"
+nsites=4
+nsites>=2 AND nsites<=7

--- a/optimade/validator/data/optional_filters.txt
+++ b/optimade/validator/data/optional_filters.txt
@@ -1,0 +1,9 @@
+list HAS ONLY values
+list HAS < 3
+list HAS ALL < 3, > 3
+list:list HAS >=2:<=5
+elements:elements_ratios HAS ALL "Al":>0.3333, "Al":<0.3334
+elements:_exmpl_element_counts HAS "H":6 AND elements:_exmpl_element_counts HAS ALL "H":6,"He":7 AND elements:_exmpl_element_counts HAS ONLY "H":6 AND elements:_exmpl_element_counts HAS ANY "H":6,"He":7 AND elements:_exmpl_element_counts HAS ONLY "H":6,"He":7
+_exmpl_element_counts HAS < 3 AND _exmpl_element_counts HAS ANY > 3, = 6, 4, != 8
+elements:_exmpl_element_counts:_exmpl_element_weights HAS ANY > 3:"He":>55.3 , = 6:>"Ti":<37.6 , 8:<"Ga":0
+5 < 7

--- a/optimade/validator/validator.py
+++ b/optimade/validator/validator.py
@@ -10,7 +10,6 @@ import requests
 import sys
 import logging
 import json
-import traceback
 
 from typing import Union
 
@@ -19,6 +18,7 @@ from fastapi.testclient import TestClient
 
 from optimade.models import InfoResponse, EntryInfoResponse, IndexInfoResponse
 
+from .data import MANDATORY_FILTER_EXAMPLES
 from .validator_model_patches import (
     ValidatorLinksResponse,
     ValidatorEntryResponseOne,
@@ -35,11 +35,7 @@ LINKS_ENDPOINT = "links"
 REQUIRED_ENTRY_ENDPOINTS = ["references", "structures"]
 
 ENDPOINT_MANDATORY_QUERIES = {
-    "structures": [
-        'elements HAS "Na"',
-        'elements HAS ANY "Na","Cl"',
-        'elements HAS ALL "Na","Cl"',
-    ],
+    "structures": MANDATORY_FILTER_EXAMPLES,
     "references": [],
 }
 
@@ -59,26 +55,26 @@ REQUIRED_ENTRY_ENDPOINTS_INDEX = []
 RESPONSE_CLASSES_INDEX = {"info": IndexInfoResponse, "links": ValidatorLinksResponse}
 
 
-def print_warning(string):
+def print_warning(string, **kwargs):
     """ Print but angry. """
-    print(f"\033[93m{string}\033[0m")
+    print(f"\033[93m{string}\033[0m", **kwargs)
 
 
-def print_failure(string):
+def print_failure(string, **kwargs):
     """ Print but sad. """
-    print(f"\033[91m\033[4m{string}\033[0m")
+    print(f"\033[91m\033[4m{string}\033[0m", **kwargs)
 
 
-def print_success(string):
+def print_success(string, **kwargs):
     """ Print but happy. """
-    print(f"\033[92m\033[1m{string}\033[0m")
+    print(f"\033[92m\033[1m{string}\033[0m", **kwargs)
 
 
 class ResponseError(Exception):
     """ This exception should be raised for a manual hardcoded test failure. """
 
 
-class Client:
+class Client:  # pragma: no cover
     def __init__(self, base_url: str, max_retries=5):
         """ Initialises the Client with the given `base_url` without testing
         if it is valid.
@@ -113,7 +109,7 @@ class Client:
 
         """
         if request:
-            self.last_request = f"{self.base_url}{request}"
+            self.last_request = f"{self.base_url}{request}".replace("\n", "")
         else:
             self.last_request = self.base_url
 
@@ -156,9 +152,9 @@ def test_case(test_fn):
     from functools import wraps
 
     @wraps(test_fn)
-    def wrapper(*args, **kwargs):
+    def wrapper(validator, *args, **kwargs):
         try:
-            result, msg = test_fn(*args, **kwargs)
+            result, msg = test_fn(validator, *args, **kwargs)
         except json.JSONDecodeError as exc:
             result = None
             msg = (
@@ -166,26 +162,31 @@ def test_case(test_fn):
                 f"Error: {type(exc).__name__}: {exc}"
             )
         except (ResponseError, ValidationError) as exc:
-            if args[0].verbosity > 1:
-                traceback.print_exc()
-
             result = None
             msg = f"{type(exc).__name__}: {exc}"
 
         try:
-            request = args[0].client.last_request
+            request = validator.client.last_request
         except AttributeError:
-            request = args[0].base_url
+            request = validator.base_url
         if result is not None:
-            args[0].success_count += 1
-            if args[0].verbosity > 0:
+            validator.success_count += 1
+            if validator.verbosity > 0:
                 print_success(f"✔: {request} - {msg}")
+            else:
+                print_success(".", end="", flush=True)
         else:
-            args[0].failure_count += 1
-            print_failure(f"✖: {request} - {test_fn.__name__} - failed with error")
+            validator.failure_count += 1
+            request = request.replace("\n", "")
             message = f"{msg}".split("\n")
-            for line in message:
-                print_warning(f"\t{line}")
+            summary = f"✖: {request} - {test_fn.__name__} - failed with error"
+            validator.failure_messages.append((summary, message))
+            if validator.verbosity > 0:
+                print_failure(summary)
+                for line in message:
+                    print_warning(f"\t{line}")
+            else:
+                print_failure(f"✖", end="", flush=True)
 
         return result
 
@@ -272,6 +273,7 @@ class ImplementationValidator:
 
         self.success_count = 0
         self.failure_count = 0
+        self.failure_messages = []
 
     def _setup_log(self):
         """ Define stdout log based on given verbosity. """
@@ -312,7 +314,7 @@ class ImplementationValidator:
             )
 
         # test entire implementation
-        self._log.info("Testing entire implementation %s...", self.base_url)
+        print(f"Testing entire implementation at {self.base_url}...")
         self._log.debug("Testing base info endpoint of %s", BASE_INFO_ENDPOINT)
         base_info = self.test_info_or_links_endpoints(BASE_INFO_ENDPOINT)
         self.get_available_endpoints(base_info)
@@ -343,11 +345,18 @@ class ImplementationValidator:
 
         self.valid = not bool(self.failure_count)
 
-        self._log.info(
-            "Passed %d out of %d tests.",
-            self.success_count,
-            self.success_count + self.failure_count,
-        )
+        if not self.valid:
+            print(f"\n\nFAILURES\n")
+            for message in self.failure_messages:
+                print_failure(message[0])
+                for line in message[1]:
+                    print_warning("\t" + line)
+
+        final_message = f"\nPassed {self.success_count} out of {self.success_count + self.failure_count} tests."
+        if not self.valid:
+            print_failure(final_message)
+        else:
+            print_success(final_message)
 
     def test_info_or_links_endpoints(self, request_str):
         """ Runs the test cases for the info endpoints. """
@@ -505,12 +514,20 @@ class ImplementationValidator:
     @test_case
     def get_endpoint(self, request_str):
         """ Gets the response from the endpoint specified by `request_str`. """
-        request_str = f"/{request_str}"
+        request_str = f"/{request_str}".replace("\n", "")
         response = self.client.get(request_str)
         if response.status_code != 200:
-            raise ResponseError(
-                f"Request to '{request_str}' returned HTTP code: {response.status_code}"
-            )
+            error_titles = [
+                error.get("title", "") for error in response.json().get("errors", [])
+            ]
+            error_details = [
+                error.get("detail", "") for error in response.json().get("errors", [])
+            ]
+            message = f"Request to '{request_str}' returned HTTP code {response.status_code}. Errors:\n"
+            for error_title, error_detail in zip(error_titles, error_details):
+                message += f"{error_title}: {error_details}"
+            raise ResponseError(message)
+
         return response, "request successful."
 
     def test_mandatory_query_syntax(self, endpoint, endpoint_queries):

--- a/tasks.py
+++ b/tasks.py
@@ -106,3 +106,29 @@ def set_optimade_ver(_, ver=""):
     )
 
     print(f"Bumped OPTiMaDe version to {ver}")
+
+
+@task
+def parse_spec_for_filters(_):
+    import requests
+
+    filter_path = TOP_DIR.joinpath("optimade/validator/data/filters.txt")
+
+    specification_flines = (
+        requests.get(
+            "https://raw.githubusercontent.com/Materials-Consortia/OPTiMaDe/develop/optimade.rst"
+        )
+        .content.decode("utf-8")
+        .split("\n")
+    )
+
+    filters = []
+    for line in specification_flines:
+        if ":filter:" in line:
+            for _split in line.replace("filter=", "").split(":filter:")[1:]:
+                _filter = _split.split("`")[1].strip()
+                filters.append(_filter)
+
+    with open(filter_path, "w") as f:
+        for _filter in filters:
+            f.write(_filter + "\n")

--- a/tests/filtertransformers/test_mongo.py
+++ b/tests/filtertransformers/test_mongo.py
@@ -116,26 +116,26 @@ class TestMongoTransformer(unittest.TestCase):
         # TODO: {'$not': {'$eq': 'Ti'}} can be simplified to {'$ne': 'Ti'}
         self.assertEqual(
             self.transform(
-                'NOT ( chemical_formula_hill = "Al" AND chemical_formula_anonymous = "A" OR '
-                'chemical_formula_anonymous = "H2O" AND NOT chemical_formula_hill = "Ti" )'
+                "NOT ( "
+                'chemical_formula_hill = "Al" AND chemical_formula_anonymous = "A" OR '
+                'chemical_formula_anonymous = "H2O" AND NOT chemical_formula_hill = "Ti" '
+                ")"
             ),
             {
-                "$or": {
-                    "$not": [
-                        {
-                            "$and": [
-                                {"chemical_formula_hill": {"$eq": "Al"}},
-                                {"chemical_formula_anonymous": {"$eq": "A"}},
-                            ]
-                        },
-                        {
-                            "$and": [
-                                {"chemical_formula_anonymous": {"$eq": "H2O"}},
-                                {"chemical_formula_hill": {"$not": {"$eq": "Ti"}}},
-                            ]
-                        },
-                    ]
-                }
+                "$nor": [
+                    {
+                        "$and": [
+                            {"chemical_formula_hill": {"$eq": "Al"}},
+                            {"chemical_formula_anonymous": {"$eq": "A"}},
+                        ]
+                    },
+                    {
+                        "$and": [
+                            {"chemical_formula_anonymous": {"$eq": "H2O"}},
+                            {"chemical_formula_hill": {"$not": {"$eq": "Ti"}}},
+                        ]
+                    },
+                ]
             },
         )
 
@@ -164,12 +164,10 @@ class TestMongoTransformer(unittest.TestCase):
                         "$and": [
                             {"nelements": {"$gte": 10}},
                             {
-                                "$or": {
-                                    "$not": [
-                                        {"_exmpl_x": {"$ne": "Some string"}},
-                                        {"_exmpl_a": {"$not": {"$eq": 7}}},
-                                    ]
-                                }
+                                "$nor": [
+                                    {"_exmpl_x": {"$ne": "Some string"}},
+                                    {"_exmpl_a": {"$not": {"$eq": 7}}},
+                                ]
                             },
                         ]
                     },

--- a/tests/server/test_mappers.py
+++ b/tests/server/test_mappers.py
@@ -1,0 +1,48 @@
+# pylint: disable=relative-beyond-top-level,import-outside-toplevel
+import unittest
+import mongomock
+
+from optimade.server.mappers import BaseResourceMapper
+from optimade.server.entry_collections import MongoCollection
+from optimade.models import StructureResource
+
+
+class ResourceMapperTests(unittest.TestCase):
+    def test_disallowed_aliases(self):
+        class MyMapper(BaseResourceMapper):
+            ALIASES = (("$and", "my_special_and"), ("not", "$not"))
+
+        mapper = MyMapper()
+        toy_collection = mongomock.MongoClient()["fake"]["fake"]
+        with self.assertRaises(RuntimeError):
+            MongoCollection(toy_collection, StructureResource, mapper)
+
+    def test_allowed_aliases(self):
+        class MyStructureMapper(BaseResourceMapper):
+            ALIASES = (
+                ("elements", "my_elements"),
+                ("A", "D"),
+                ("B", "E"),
+                ("C", "F"),
+            )
+
+        mapper = MyStructureMapper()
+        self.assertEqual(mapper.alias_for("elements"), "my_elements")
+
+        toy_collection = mongomock.MongoClient()["fake"]["fake"]
+        collection = MongoCollection(toy_collection, StructureResource, mapper)
+
+        test_filter = {"elements": {"$in": ["A", "B", "C"]}}
+        self.assertEqual(
+            collection._alias_filter(test_filter),
+            {"my_elements": {"$in": ["A", "B", "C"]}},
+        )
+        test_filter = {"$and": [{"elements": {"$in": ["A", "B", "C"]}}]}
+        self.assertEqual(
+            collection._alias_filter(test_filter),
+            {"$and": [{"my_elements": {"$in": ["A", "B", "C"]}}]},
+        )
+        test_filter = {"elements": "A"}
+        self.assertEqual(collection._alias_filter(test_filter), {"my_elements": "A"})
+        test_filter = ["A", "B", "C"]
+        self.assertEqual(collection._alias_filter(test_filter), ["A", "B", "C"])


### PR DESCRIPTION
This PR builds on #205 by scraping the spec for `:filter:` tags and pushing them through the validator.

Changes:
- [x] invoke task to update filter example list (done, but requires manual tweaking of the results unless the spec is updated Materials-Consortia/OPTiMaDe#262)
    - [x] provide mechanism to automatically update filter examples based on spec
    - [x] provide manual mechanism to skip filters that are tagged as optional but not directly parseable as optional
    - [x] add concrete test values to spec examples when validating (i.e. `HAS LENGTH value` becomes `HAS LENGTH 1`)
- [x] fix the failing queries in #217 
    - [x] fix alias_mapper when dealing with nested queries
        - [x] added some tests and tweaks to `ResourceMapper` to properly test for this
    - [x] fix mongo non-compliant queries involving $not and test operator precedence
    - [x] fix misleading mongo error when non-int char is passed to `LENGTH` by updating grammar