### PR TITLE
Codecov-action supports token-less uploads

### DIFF
--- a/.github/workflows/deps_eager.yml
+++ b/.github/workflows/deps_eager.yml
@@ -24,7 +24,7 @@ jobs:
             - 27017:27017
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@master
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
@@ -58,7 +58,7 @@ jobs:
   #       python-version: [3.6, 3.7, 3.8]
 
   #   steps:
-  #   - uses: actions/checkout@v2
+  #   - uses: actions/checkout@master
 
   #   - name: Set up Python ${{ matrix.python-version }}
   #     uses: actions/setup-python@v1

--- a/.github/workflows/deps_lint.yml
+++ b/.github/workflows/deps_lint.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@master
 
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@master
 
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@master
 
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
@@ -94,7 +94,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@master
 
     - name: Build the Docker images
       run: docker-compose build
@@ -142,7 +142,7 @@ jobs:
             - 27017:27017
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@master
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
@@ -168,10 +168,9 @@ jobs:
         OPTIMADE_CI_FORCE_MONGO: 0
 
     - name: Upload coverage to Codecov
-      if: matrix.python-version == 3.7
+      if: matrix.python-version == 3.7 && github.repository == 'Materials-Consortia/optimade-python-tools'
       uses: codecov/codecov-action@v1
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
         flags: unittests
         yml: ./.codecov.yml

--- a/.github/workflows/publish-on-pypi.yml
+++ b/.github/workflows/publish-on-pypi.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@master
 
     - name: Set up Python 3.7
       uses: actions/setup-python@v1

--- a/.github/workflows/requirements_eager.txt
+++ b/.github/workflows/requirements_eager.txt
@@ -1,5 +1,6 @@
 lark-parser
 fastapi
+pydantic
 email_validator
 requests
 uvicorn

--- a/.github/workflows/validator_action.yml
+++ b/.github/workflows/validator_action.yml
@@ -13,7 +13,7 @@ jobs:
     name: Regular server
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@master
 
       - name: Set up and run regular server
         run: |
@@ -32,7 +32,7 @@ jobs:
     name: Index server
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@master
 
       - name: Set up and run index server
         run: |
@@ -52,7 +52,7 @@ jobs:
     name: All versioned paths for regular server
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@master
 
       - name: Set up and run regular server (which includes all versioned base URLs)
         run: |


### PR DESCRIPTION
Removed secret token from the workflow, since the codecov-action now supports token-less uploads for public GitHub repositories. To make sure we only upload to Codecov for the upstream repository (`Materials-Consortia/optimade-python-tools`) an additional condition for when to upload is added to the upload step.

Added `pydantic` to `requirements_eager.txt`.

Using `actions/checkout@master`, since `v2` is not up-to-date, and codecov-action will not work for `v2`.
**Note**: This should be updated as soon as they have an up-to-date version.