### PR TITLE
Add mongo length operator functionality with length aliases

### DIFF
--- a/default_config.json
+++ b/default_config.json
@@ -26,5 +26,6 @@
     },
     "provider_fields": {},
     "aliases": {},
+    "length_aliases": {},
     "index_links_path": "/Users/shyamd/Codes/optimade-python-tools/optimade/server/index_links.json"
 }

--- a/example_config.json
+++ b/example_config.json
@@ -33,5 +33,10 @@
             "chemical_formula_reduced": "pretty_formula",
             "chemical_formula_anonymous": "formula_anonymous"
         }
+    },
+    "length_aliases": {
+        "structures": {
+            "chemsys": "nelements"
+        }
     }
 }

--- a/optimade/filtertransformers/mongo.py
+++ b/optimade/filtertransformers/mongo.py
@@ -179,9 +179,8 @@ class MongoTransformer(Transformer):
         if len(arg) == 2 or (len(arg) == 3 and arg[1] == "="):
             return {"$size": arg[-1]}
 
-        # the approach taken in post-process still cannot handle !=, so return error here
         elif arg[1] in self.operator_map and arg[1] != "!=":
-            # otherwise, create an invalid query that needs to be post-processed
+            # create an invalid query that needs to be post-processed
             # e.g. {'$size': {'$gt': 2}}, which is not allowed by Mongo.
             return {"$size": {self.operator_map[arg[1]]: arg[-1]}}
 

--- a/optimade/filtertransformers/mongo.py
+++ b/optimade/filtertransformers/mongo.py
@@ -176,11 +176,11 @@ class MongoTransformer(Transformer):
 
     def length_op_rhs(self, arg):
         # length_op_rhs: LENGTH [ OPERATOR ] value
-        # TODO: https://stackoverflow.com/questions/7811163/query-for-documents-where-array-size-is-greater-than-1
         if len(arg) == 2 or (len(arg) == 3 and arg[1] == "="):
             return {"$size": arg[-1]}
 
-        elif arg[1] in self.operator_map:
+        # the approach taken in post-process still cannot handle !=, so return error here
+        elif arg[1] in self.operator_map and arg[1] != "!=":
             # otherwise, create an invalid query that needs to be post-processed
             # e.g. {'$size': {'$gt': 2}}, which is not allowed by Mongo.
             return {"$size": {self.operator_map[arg[1]]: arg[-1]}}
@@ -340,11 +340,6 @@ class MongoTransformer(Transformer):
                 if _prop is not None:
                     subdict.pop(prop)
                     subdict[_prop] = {"$exists": existence}
-            else:
-                # we still can't handle not equals with this approach
-                raise NotImplementedError(
-                    f"Operator {operator} not implemented for LENGTH filter."
-                )
 
             return subdict
 

--- a/optimade/server/config.py
+++ b/optimade/server/config.py
@@ -1,15 +1,11 @@
-import os
 import json
-from typing import Any, Optional, Dict, List
+from typing import Optional, Dict, List
 
 try:
     from typing import Literal
 except ImportError:
     from typing_extensions import Literal
 from pathlib import Path
-from warnings import warn
-
-import json
 
 from pydantic import BaseSettings, Field, root_validator
 
@@ -117,5 +113,6 @@ class ServerConfig(BaseSettings):
 
     class Config:
         env_prefix = "optimade_"
+
 
 CONFIG = ServerConfig()

--- a/optimade/server/config.py
+++ b/optimade/server/config.py
@@ -118,5 +118,4 @@ class ServerConfig(BaseSettings):
     class Config:
         env_prefix = "optimade_"
 
-
 CONFIG = ServerConfig()

--- a/optimade/server/config.py
+++ b/optimade/server/config.py
@@ -88,6 +88,17 @@ class ServerConfig(BaseSettings):
         description="A mapping between field names in the database with their corresponding OPTIMADE field names, broken down by endpoint.",
     )
 
+    length_aliases: Dict[
+        Literal["links", "references", "structures"], Dict[str, str]
+    ] = Field(
+        {},
+        description=(
+            "A mapping between a list property (or otherwise) and an integer property that defines the length of that list, "
+            "for example elements -> nelements. The standard aliases are applied first, so this dictionary must refer to the "
+            "API fields, not the database fields."
+        ),
+    )
+
     index_links_path: Path = Field(
         Path(__file__).parent.joinpath("index_links.json"),
         description="Absolute path to a JSON file containing the MongoDB collection of /links resources for the index meta-database",

--- a/optimade/server/entry_collections/__init__.py
+++ b/optimade/server/entry_collections/__init__.py
@@ -1,0 +1,4 @@
+from .entry_collections import EntryCollection
+from .mongo import MongoCollection, client, CI_FORCE_MONGO
+
+__all__ = ["EntryCollection", "MongoCollection", "client", "CI_FORCE_MONGO"]

--- a/optimade/server/entry_collections/entry_collections.py
+++ b/optimade/server/entry_collections/entry_collections.py
@@ -1,0 +1,64 @@
+from abc import abstractmethod
+from typing import Collection, Tuple, List
+
+from optimade.server.mappers import BaseResourceMapper
+from optimade.filterparser import LarkParser
+from optimade.models import EntryResource
+from optimade.server.query_params import EntryListingQueryParams
+
+
+class EntryCollection(Collection):  # pylint: disable=inherit-non-class
+    def __init__(
+        self,
+        collection,
+        resource_cls: EntryResource,
+        resource_mapper: BaseResourceMapper,
+    ):
+        self.collection = collection
+        self.parser = LarkParser()
+        self.resource_cls = resource_cls
+        self.resource_mapper = resource_mapper
+
+    def __len__(self):
+        return self.collection.count()
+
+    def __iter__(self):
+        return self.collection.find()
+
+    def __contains__(self, entry):
+        return self.collection.count(entry) > 0
+
+    def get_attribute_fields(self) -> set:
+        schema = self.resource_cls.schema()
+        attributes = schema["properties"]["attributes"]
+        if "allOf" in attributes:
+            allOf = attributes.pop("allOf")
+            for dict_ in allOf:
+                attributes.update(dict_)
+        if "$ref" in attributes:
+            path = attributes["$ref"].split("/")[1:]
+            attributes = schema.copy()
+            while path:
+                next_key = path.pop(0)
+                attributes = attributes[next_key]
+        return set(attributes["properties"].keys())
+
+    @abstractmethod
+    def find(
+        self, params: EntryListingQueryParams
+    ) -> Tuple[List[EntryResource], int, bool, set]:
+        """
+        Fetches results and indicates if more data is available.
+
+        Also gives the total number of data available in the absence of page_limit.
+
+        Args:
+            params (EntryListingQueryParams): entry listing URL query params
+
+        Returns:
+            Tuple[List[Entry], int, bool, set]: (results, data_returned, more_data_available, fields)
+
+        """
+
+    def count(self, **kwargs):
+        return self.collection.count(**kwargs)

--- a/optimade/server/entry_collections/mongo.py
+++ b/optimade/server/entry_collections/mongo.py
@@ -50,14 +50,8 @@ class MongoCollection(EntryCollection):
         )  # The MongoTransformer only supports v0.10.1 as the latest grammar
 
         # check aliases do not clash with mongo operators
-        self._mapper_aliases = self.resource_mapper.all_aliases()
-        if any(
-            alias[0].startswith("$") or alias[1].startswith("$")
-            for alias in self._mapper_aliases
-        ):
-            raise RuntimeError(
-                f"Cannot define an alias starting with a '$': {self._mapper_aliases}"
-            )
+        self._check_aliases(self.resource_mapper.all_aliases())
+        self._check_aliases(self.resource_mapper.all_length_aliases())
 
     def __len__(self):
         return self.collection.estimated_document_count()
@@ -166,3 +160,10 @@ class MongoCollection(EntryCollection):
             cursor_kwargs["skip"] = params.page_offset
 
         return cursor_kwargs
+
+    def _check_aliases(self, aliases):
+        """ Check that aliases do not clash with mongo keywords. """
+        if any(
+            alias[0].startswith("$") or alias[1].startswith("$") for alias in aliases
+        ):
+            raise RuntimeError(f"Cannot define an alias starting with a '$': {aliases}")

--- a/optimade/server/entry_collections/mongo.py
+++ b/optimade/server/entry_collections/mongo.py
@@ -1,18 +1,16 @@
 import os
-from abc import abstractmethod
-from typing import Collection, Tuple, List, Union
-
+from typing import Tuple, List, Union
 import mongomock
 import pymongo.collection
 from fastapi import HTTPException
 
 from optimade.filterparser import LarkParser
 from optimade.filtertransformers.mongo import MongoTransformer
+from optimade.server.config import CONFIG
 from optimade.models import EntryResource
-
-from .config import CONFIG
-from .mappers import BaseResourceMapper
-from .query_params import EntryListingQueryParams, SingleEntryQueryParams
+from optimade.server.mappers import BaseResourceMapper
+from optimade.server.query_params import EntryListingQueryParams, SingleEntryQueryParams
+from .entry_collections import EntryCollection
 
 try:
     CI_FORCE_MONGO = bool(int(os.environ.get("OPTIMADE_CI_FORCE_MONGO", 0)))
@@ -32,63 +30,6 @@ else:
     print("Using: Mock MongoDB (mongomock)")
 
 
-class EntryCollection(Collection):  # pylint: disable=inherit-non-class
-    def __init__(
-        self,
-        collection,
-        resource_cls: EntryResource,
-        resource_mapper: BaseResourceMapper,
-    ):
-        self.collection = collection
-        self.parser = LarkParser()
-        self.resource_cls = resource_cls
-        self.resource_mapper = resource_mapper
-
-    def __len__(self):
-        return self.collection.count()
-
-    def __iter__(self):
-        return self.collection.find()
-
-    def __contains__(self, entry):
-        return self.collection.count(entry) > 0
-
-    def get_attribute_fields(self) -> set:
-        schema = self.resource_cls.schema()
-        attributes = schema["properties"]["attributes"]
-        if "allOf" in attributes:
-            allOf = attributes.pop("allOf")
-            for dict_ in allOf:
-                attributes.update(dict_)
-        if "$ref" in attributes:
-            path = attributes["$ref"].split("/")[1:]
-            attributes = schema.copy()
-            while path:
-                next_key = path.pop(0)
-                attributes = attributes[next_key]
-        return set(attributes["properties"].keys())
-
-    @abstractmethod
-    def find(
-        self, params: EntryListingQueryParams
-    ) -> Tuple[List[EntryResource], int, bool, set]:
-        """
-        Fetches results and indicates if more data is available.
-
-        Also gives the total number of data available in the absence of page_limit.
-
-        Args:
-            params (EntryListingQueryParams): entry listing URL query params
-
-        Returns:
-            Tuple[List[Entry], int, bool, set]: (results, data_returned, more_data_available, fields)
-
-        """
-
-    def count(self, **kwargs):
-        return self.collection.count(**kwargs)
-
-
 class MongoCollection(EntryCollection):
     def __init__(
         self,
@@ -99,7 +40,7 @@ class MongoCollection(EntryCollection):
         resource_mapper: BaseResourceMapper,
     ):
         super().__init__(collection, resource_cls, resource_mapper)
-        self.transformer = MongoTransformer()
+        self.transformer = MongoTransformer(mapper=resource_mapper)
 
         self.provider_prefix = CONFIG.provider.prefix
         self.provider_fields = CONFIG.provider_fields.get(resource_mapper.ENDPOINT, [])

--- a/optimade/server/mappers/entries.py
+++ b/optimade/server/mappers/entries.py
@@ -24,6 +24,7 @@ class BaseResourceMapper:
 
     ENDPOINT: str = ""
     ALIASES: Tuple[Tuple[str, str]] = ()
+    LENGTH_ALIASES: Tuple[Tuple[str, str]] = ()
     REQUIRED_FIELDS: set = set()
     TOP_LEVEL_NON_ATTRIBUTES_FIELDS: set = {"id", "type", "relationships", "links"}
 
@@ -37,6 +38,14 @@ class BaseResourceMapper:
             + tuple(CONFIG.aliases.get(cls.ENDPOINT, {}).items())
             + cls.ALIASES
         )
+
+    @classmethod
+    def all_length_aliases(cls) -> Tuple[Tuple[str, str]]:
+        return cls.LENGTH_ALIASES + CONFIG.length_aliases.get(cls.ENDPOINT, ())
+
+    @classmethod
+    def length_alias_for(cls, field: str) -> str:
+        return dict(cls.all_length_aliases()).get(field, None)
 
     @classmethod
     def alias_for(cls, field: str) -> str:

--- a/optimade/server/mappers/entries.py
+++ b/optimade/server/mappers/entries.py
@@ -15,6 +15,12 @@ class BaseResourceMapper:
         ALIASES (Tuple[Tuple[str, str]]): a tuple of aliases between
             OPTIMADE field names and the field names in the database ,
             e.g. `(("elements", "custom_elements_field"))`.
+        LENGTH_ALIASES (Tuple[Tuple[str, str]]): a tuple of aliases between
+            a field name and another field that defines its length, to be used
+            when querying, e.g. `(("elements", "nelements"))`.
+            e.g. `(("elements", "custom_elements_field"))`.
+        PROVIDER_FIELDS (Tuple[str]): a tuple of extra field names that this
+            mapper should support when querying with the database prefix.
         REQUIRED_FIELDS (set[str]): the set of fieldnames to return
             when mapping to the OPTIMADE format.
         TOP_LEVEL_NON_ATTRIBUTES_FIELDS (set[str]): the set of top-level
@@ -31,6 +37,13 @@ class BaseResourceMapper:
 
     @classmethod
     def all_aliases(cls) -> Tuple[Tuple[str, str]]:
+        """ Returns all of the associated aliases for this class, including
+        those defined by the server config.
+
+        Returns:
+            Tuple[Tuple[str, str]]: a tuple of alias tuples.
+
+        """
         return (
             tuple(
                 (f"_{CONFIG.provider.prefix}_{field}", field)
@@ -46,17 +59,28 @@ class BaseResourceMapper:
 
     @classmethod
     def all_length_aliases(cls) -> Tuple[Tuple[str, str]]:
+        """ Returns all of the associated length aliases for this class, including
+        those defined by the server config.
+
+        Returns:
+            Tuple[Tuple[str, str]]: a tuple of length alias tuples.
+
+        """
         return cls.LENGTH_ALIASES + tuple(
             CONFIG.length_aliases.get(cls.ENDPOINT, {}).items()
         )
 
     @classmethod
     def length_alias_for(cls, field: str) -> str:
+        """ Returns the length alias for the particular field, or `None` if no
+        such alias is found.
+
+        """
         return dict(cls.all_length_aliases()).get(field, None)
 
     @classmethod
     def alias_for(cls, field: str) -> str:
-        """Return aliased field name
+        """Return aliased field name.
 
         :param field: OPTIMADE field name
         :type field: str

--- a/optimade/server/mappers/entries.py
+++ b/optimade/server/mappers/entries.py
@@ -25,6 +25,7 @@ class BaseResourceMapper:
     ENDPOINT: str = ""
     ALIASES: Tuple[Tuple[str, str]] = ()
     LENGTH_ALIASES: Tuple[Tuple[str, str]] = ()
+    PROVIDER_FIELDS: Tuple[str] = ()
     REQUIRED_FIELDS: set = set()
     TOP_LEVEL_NON_ATTRIBUTES_FIELDS: set = {"id", "type", "relationships", "links"}
 
@@ -35,13 +36,19 @@ class BaseResourceMapper:
                 (f"_{CONFIG.provider.prefix}_{field}", field)
                 for field in CONFIG.provider_fields.get(cls.ENDPOINT, [])
             )
+            + tuple(
+                (f"_{CONFIG.provider.prefix}_{field}", field)
+                for field in cls.PROVIDER_FIELDS
+            )
             + tuple(CONFIG.aliases.get(cls.ENDPOINT, {}).items())
             + cls.ALIASES
         )
 
     @classmethod
     def all_length_aliases(cls) -> Tuple[Tuple[str, str]]:
-        return cls.LENGTH_ALIASES + CONFIG.length_aliases.get(cls.ENDPOINT, ())
+        return cls.LENGTH_ALIASES + tuple(
+            CONFIG.length_aliases.get(cls.ENDPOINT, {}).items()
+        )
 
     @classmethod
     def length_alias_for(cls, field: str) -> str:

--- a/optimade/server/mappers/structures.py
+++ b/optimade/server/mappers/structures.py
@@ -6,3 +6,9 @@ __all__ = ("StructureMapper",)
 class StructureMapper(BaseResourceMapper):
 
     ENDPOINT = "structures"
+
+    LENGTH_ALIASES = (
+        ("elements", "nelements"),
+        ("cartesian_site_positions", "nsites"),
+        ("species_at_sites", "nsites"),
+    )

--- a/optimade/server/mappers/structures.py
+++ b/optimade/server/mappers/structures.py
@@ -9,6 +9,7 @@ class StructureMapper(BaseResourceMapper):
 
     LENGTH_ALIASES = (
         ("elements", "nelements"),
+        ("element_ratios", "nelements"),
         ("cartesian_site_positions", "nsites"),
         ("species_at_sites", "nsites"),
     )

--- a/tests/filtertransformers/test_mongo.py
+++ b/tests/filtertransformers/test_mongo.py
@@ -344,6 +344,21 @@ class TestMongoTransformer(unittest.TestCase):
         with self.assertRaises(VisitError):
             self.transform("list LENGTH > 3")
 
+    def test_list_length_aliases(self):
+        from optimade.server.mappers import StructureMapper
+
+        class AliasedStructureMapper(StructureMapper):
+            LENGTH_ALIASES = (("elements", "nelements"),)
+
+        t = MongoTransformer(mapper=AliasedStructureMapper())
+        p = LarkParser(version=self.version, variant=self.variant)
+        self.assertEqual(t.transform(p.parse("elements LENGTH 3")), {"nelements": 3})
+
+        self.assertEqual(
+            t.transform(p.parse('elements HAS "Li" AND elements LENGTH = 3')),
+            {"$and": [{"elements": {"$in": ["Li"]}}, {"nelements": 3}]},
+        )
+
     def test_list_properties(self):
         """ Test the HAS ALL, ANY and optional ONLY queries.
 

--- a/tests/filtertransformers/test_mongo.py
+++ b/tests/filtertransformers/test_mongo.py
@@ -384,29 +384,25 @@ class TestMongoTransformer(unittest.TestCase):
         )
 
     def test_unaliased_length_operator(self):
-        transformer = MongoTransformer()
-        parser = LarkParser(version=self.version, variant=self.variant)
         self.assertEqual(
-            transformer.transform(parser.parse("cartesian_site_positions LENGTH <= 3")),
+            self.transform("cartesian_site_positions LENGTH <= 3"),
             {"cartesian_site_positions.4": {"$exists": False}},
         )
         self.assertEqual(
-            transformer.transform(parser.parse("cartesian_site_positions LENGTH < 3")),
+            self.transform("cartesian_site_positions LENGTH < 3"),
             {"cartesian_site_positions.3": {"$exists": False}},
         )
         self.assertEqual(
-            transformer.transform(parser.parse("cartesian_site_positions LENGTH 3")),
+            self.transform("cartesian_site_positions LENGTH 3"),
             {"cartesian_site_positions": {"$size": 3}},
         )
         self.assertEqual(
-            transformer.transform(
-                parser.parse("cartesian_site_positions LENGTH >= 10")
-            ),
+            self.transform("cartesian_site_positions LENGTH >= 10"),
             {"cartesian_site_positions.10": {"$exists": True}},
         )
 
         self.assertEqual(
-            transformer.transform(parser.parse("cartesian_site_positions LENGTH > 10")),
+            self.transform("cartesian_site_positions LENGTH > 10"),
             {"cartesian_site_positions.11": {"$exists": True}},
         )
 

--- a/tests/filtertransformers/test_mongo.py
+++ b/tests/filtertransformers/test_mongo.py
@@ -415,6 +415,12 @@ class TestMongoTransformer(unittest.TestCase):
 
         class MyMapper(StructureMapper):
             ALIASES = (("elements", "my_elements"), ("nelements", "nelem"))
+            LENGTH_ALIASES = (
+                ("chemsys", "nelements"),
+                ("cartesian_site_positions", "nsites"),
+                ("elements", "nelements"),
+            )
+            PROVIDER_FIELDS = ("chemsys",)
 
         transformer = MongoTransformer(mapper=MyMapper())
         parser = LarkParser(version=self.version, variant=self.variant)
@@ -454,6 +460,15 @@ class TestMongoTransformer(unittest.TestCase):
 
         self.assertEqual(
             transformer.transform(parser.parse("elements LENGTH 3")), {"nelem": 3},
+        )
+
+        self.assertEqual(
+            transformer.transform(parser.parse('elements HAS "Ag"')),
+            {"my_elements": {"$in": ["Ag"]}},
+        )
+
+        self.assertEqual(
+            transformer.transform(parser.parse("chemsys LENGTH 3")), {"nelem": 3},
         )
 
     def test_aliases(self):

--- a/tests/filtertransformers/test_mongo.py
+++ b/tests/filtertransformers/test_mongo.py
@@ -413,7 +413,10 @@ class TestMongoTransformer(unittest.TestCase):
     def test_aliased_length_operator(self):
         from optimade.server.mappers import StructureMapper
 
-        transformer = MongoTransformer(mapper=StructureMapper())
+        class MyMapper(StructureMapper):
+            ALIASES = (("elements", "my_elements"), ("nelements", "nelem"))
+
+        transformer = MongoTransformer(mapper=MyMapper())
         parser = LarkParser(version=self.version, variant=self.variant)
 
         self.assertEqual(
@@ -423,6 +426,10 @@ class TestMongoTransformer(unittest.TestCase):
         self.assertEqual(
             transformer.transform(parser.parse("cartesian_site_positions LENGTH < 3")),
             {"nsites": {"$lt": 3}},
+        )
+        self.assertEqual(
+            transformer.transform(parser.parse("cartesian_site_positions LENGTH 3")),
+            {"nsites": 3},
         )
         self.assertEqual(
             transformer.transform(parser.parse("cartesian_site_positions LENGTH 3")),
@@ -443,6 +450,10 @@ class TestMongoTransformer(unittest.TestCase):
         self.assertEqual(
             transformer.transform(parser.parse("nsites LENGTH > 10")),
             {"nsites.11": {"$exists": True}},
+        )
+
+        self.assertEqual(
+            transformer.transform(parser.parse("elements LENGTH 3")), {"nelem": 3},
         )
 
     def test_aliases(self):

--- a/tests/filtertransformers/test_mongo.py
+++ b/tests/filtertransformers/test_mongo.py
@@ -349,13 +349,7 @@ class TestMongoTransformer(unittest.TestCase):
     def test_list_length_aliases(self):
         from optimade.server.mappers import StructureMapper
 
-        class AliasedStructureMapper(StructureMapper):
-            LENGTH_ALIASES = (
-                ("elements", "nelements"),
-                ("cartesian_site_positions", "nsites"),
-            )
-
-        transformer = MongoTransformer(mapper=AliasedStructureMapper())
+        transformer = MongoTransformer(mapper=StructureMapper())
         parser = LarkParser(version=self.version, variant=self.variant)
 
         self.assertEqual(
@@ -414,6 +408,41 @@ class TestMongoTransformer(unittest.TestCase):
         self.assertEqual(
             transformer.transform(parser.parse("cartesian_site_positions LENGTH > 10")),
             {"cartesian_site_positions.11": {"$exists": True}},
+        )
+
+    def test_aliased_length_operator(self):
+        from optimade.server.mappers import StructureMapper
+
+        transformer = MongoTransformer(mapper=StructureMapper())
+        parser = LarkParser(version=self.version, variant=self.variant)
+
+        self.assertEqual(
+            transformer.transform(parser.parse("cartesian_site_positions LENGTH <= 3")),
+            {"nsites": {"$lte": 3}},
+        )
+        self.assertEqual(
+            transformer.transform(parser.parse("cartesian_site_positions LENGTH < 3")),
+            {"nsites": {"$lt": 3}},
+        )
+        self.assertEqual(
+            transformer.transform(parser.parse("cartesian_site_positions LENGTH 3")),
+            {"nsites": 3},
+        )
+        self.assertEqual(
+            transformer.transform(
+                parser.parse("cartesian_site_positions LENGTH >= 10")
+            ),
+            {"nsites": {"$gte": 10}},
+        )
+
+        self.assertEqual(
+            transformer.transform(parser.parse("structure_features LENGTH > 10")),
+            {"structure_features.11": {"$exists": True}},
+        )
+
+        self.assertEqual(
+            transformer.transform(parser.parse("nsites LENGTH > 10")),
+            {"nsites.11": {"$exists": True}},
         )
 
     def test_aliases(self):

--- a/tests/server/test_mappers.py
+++ b/tests/server/test_mappers.py
@@ -16,33 +16,3 @@ class ResourceMapperTests(unittest.TestCase):
         toy_collection = mongomock.MongoClient()["fake"]["fake"]
         with self.assertRaises(RuntimeError):
             MongoCollection(toy_collection, StructureResource, mapper)
-
-    def test_allowed_aliases(self):
-        class MyStructureMapper(BaseResourceMapper):
-            ALIASES = (
-                ("elements", "my_elements"),
-                ("A", "D"),
-                ("B", "E"),
-                ("C", "F"),
-            )
-
-        mapper = MyStructureMapper()
-        self.assertEqual(mapper.alias_for("elements"), "my_elements")
-
-        toy_collection = mongomock.MongoClient()["fake"]["fake"]
-        collection = MongoCollection(toy_collection, StructureResource, mapper)
-
-        test_filter = {"elements": {"$in": ["A", "B", "C"]}}
-        self.assertEqual(
-            collection._alias_filter(test_filter),
-            {"my_elements": {"$in": ["A", "B", "C"]}},
-        )
-        test_filter = {"$and": [{"elements": {"$in": ["A", "B", "C"]}}]}
-        self.assertEqual(
-            collection._alias_filter(test_filter),
-            {"$and": [{"my_elements": {"$in": ["A", "B", "C"]}}]},
-        )
-        test_filter = {"elements": "A"}
-        self.assertEqual(collection._alias_filter(test_filter), {"my_elements": "A"})
-        test_filter = ["A", "B", "C"]
-        self.assertEqual(collection._alias_filter(test_filter), ["A", "B", "C"])

--- a/tests/server/test_query_params.py
+++ b/tests/server/test_query_params.py
@@ -321,26 +321,37 @@ class FilterTests(SetClient, unittest.TestCase):
 
     def test_list_length(self):
         request = "/structures?filter=elements LENGTH >= 9"
-        error_detail = "Operator >= not implemented for LENGTH filter."
-        self._check_error_response(
-            request,
-            expected_status=501,
-            expected_title="NotImplementedError",
-            expected_detail=error_detail,
-        )
-        # expected_ids = ["mpf_3819"]
-        # self._check_response(request, expected_ids, len(expected_ids))
+        expected_ids = ["mpf_3819"]
+        self._check_response(request, expected_ids, len(expected_ids))
 
         request = "/structures?filter=structure_features LENGTH > 0"
-        error_detail = "Operator > not implemented for LENGTH filter."
+        expected_ids = []
+        self._check_response(request, expected_ids, len(expected_ids))
+
+        request = "/structures?filter=structure_features LENGTH > 0"
+        expected_ids = []
+        self._check_response(request, expected_ids, len(expected_ids))
+
+        request = "/structures?filter=cartesian_site_positions LENGTH > 43"
+        expected_ids = ["mpf_551", "mpf_3803", "mpf_3819"]
+        self._check_response(request, expected_ids, len(expected_ids))
+
+        request = "/structures?filter=species_at_sites LENGTH > 43"
+        expected_ids = ["mpf_551", "mpf_3803", "mpf_3819"]
+        self._check_response(request, expected_ids, len(expected_ids))
+
+        request = "/structures?filter=nsites LENGTH > 43"
+        expected_ids = []
+        self._check_response(request, expected_ids, len(expected_ids))
+
+        request = "/structures?filter=structure_features LENGTH != 0"
+        error_detail = "Operator != not implemented for LENGTH filter."
         self._check_error_response(
             request,
             expected_status=501,
             expected_title="NotImplementedError",
             expected_detail=error_detail,
         )
-        # expected_ids = []
-        # self._check_response(request, expected_ids, len(expected_ids))
 
     @unittest.skipIf(MONGOMOCK_OLD, MONGOMOCK_MSG)
     def test_list_has_only(self):

--- a/tests/test_config.json
+++ b/tests/test_config.json
@@ -27,5 +27,10 @@
             "chemical_formula_reduced": "pretty_formula",
             "chemical_formula_anonymous": "formula_anonymous"
         }
+    },
+    "length_aliases": {
+        "structures": {
+            "chemsys": "nelements"
+        }
     }
 }


### PR DESCRIPTION
This PR is a WIP/proof of concept for the introduction of "length aliases" to attempt to fix the issues in #86.

This PR adds a post-processing function to the `MongoTransformer` which recursively descends into the transformed filter and tries to change any `{"x": {"$size": 3}}` queries with the value of a value of corresponding aliased field, e.g. `elements->nelements`. The benefits are minimal when just performing `LENGTH = value` queries (as $size can do this rapidly anyway), but this will greatly speed up `LENGTH > 3` queries, which mongo does not support directly (see #86 discussion). Length operator queries that do not have a defined length alias will now fallback to using the existence test approach, i.e. `LENGTH > 3` becomes "does element 4 exist?".

Extra changes needed to support this:
- [x] splitting of `entry_collections` into submodules (`entry_collections.entry_collections` and `entry_collections.mongo`).
- [x] addition of `LENGTH_ALIASES` attribute to mappers and config.
- [x] addition of `PROVIDER_FIELDS` to mapper to mirror other aliases.
- [x] use of `$exists` for fallback length operations
- [x] moved all aliasing code out of collections and into the transformer, as post-processing
- [x] all of the spec-defined length aliases are now part of the default `StructureMapper`, but will be ignored unless a `Transformer` makes use of them.