### PR TITLE
Add txt-files in optimade.validator.data to MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 recursive-include optimade/server/ *.ini *.json
 recursive-include optimade/server/data/ *
 recursive-include optimade/grammar/ *.lark
+recursive-include optimade/validator/data/ *.txt

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -35,6 +35,8 @@ class TestSetup(unittest.TestCase):
                 r"test_structures\.json": False,
                 r"test_references\.json": False,
                 r"test_links\.json": False,
+                r"filters\.txt": False,
+                r"optional_filters\.txt": False,
             }
             count = 0
             for line in lines:


### PR DESCRIPTION
Also added to `test_setup.py` test.

I found this error, since I couldn't install the latest commit when testing Materials-Consortia/optimade-validator-action#4