### PR TITLE
v0.7.0 release

### DIFF
--- a/openapi/index_openapi.json
+++ b/openapi/index_openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.2",
   "info": {
     "title": "OPTiMaDe API - Index meta-database",
-    "description": "The [Open Databases Integration for Materials Design (OPTiMaDe) consortium](https://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.\nThis is the \"special\" index meta-database.\n\nThis specification is generated using [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools/tree/v0.6.0) v0.6.0.",
+    "description": "The [Open Databases Integration for Materials Design (OPTiMaDe) consortium](https://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.\nThis is the \"special\" index meta-database.\n\nThis specification is generated using [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools/tree/v0.7.0) v0.7.0.",
     "version": "0.10.1"
   },
   "paths": {

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.2",
   "info": {
     "title": "OPTiMaDe API",
-    "description": "The [Open Databases Integration for Materials Design (OPTiMaDe) consortium](https://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.\n\nThis specification is generated using [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools/tree/v0.6.0) v0.6.0.",
+    "description": "The [Open Databases Integration for Materials Design (OPTiMaDe) consortium](https://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.\n\nThis specification is generated using [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools/tree/v0.7.0) v0.7.0.",
     "version": "0.10.1"
   },
   "paths": {

--- a/optimade/__init__.py
+++ b/optimade/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "0.6.0"
+__version__ = "0.7.0"
 __api_version__ = "0.10.1"

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ all_deps = dev_deps + django_deps + elastic_deps
 
 setup(
     name="optimade",
-    version="0.6.0",
+    version="0.7.0",
     url="https://github.com/Materials-Consortia/optimade-python-tools",
     license="MIT",
     author="OPTiMaDe Development Team",


### PR DESCRIPTION
This PR prepares another minor release that includes the changes from this week.

**Breaking changes**:
- `optimade.server.mappers.ResourceMapper` has been renamed as `optimade.server.mappers.BaseResourceMapper` (#213).

**New features**:
- Validation of all mandatory filter examples present in the specification (#213, @ml-evs.)
- New `invoke` task to scrape the filter examples from the specification (and new submodule `optimade.validator.data` for loading them (#213, @ml-evs, with bug fixes from @CasperWA in #225).
- Dependabot is now used to ensure requirements are updated in a timely manner and new versions of django (v3) and elasticsearch-dsl (v7) are now supported (@CasperWA, #218, #219).
- The GitHub action for the validator has been moved out of this repository, and over to [Materials-Consortia/optimade-validator-action](https://github.com/Materials-Consortia/optimade-validator-action) (#224, @CasperWA).

**Bug fixes**:
- Fixed handling of nested queries involving `AND`/`OR` and `NOT` for the mongo backend (#221, @ml-evs).