### PR TITLE
Enable filtering on relationships with mongo 

### DIFF
--- a/optimade/filtertransformers/mongo.py
+++ b/optimade/filtertransformers/mongo.py
@@ -362,6 +362,10 @@ class MongoTransformer(Transformer):
 
         def replace_with_relationship(subdict, prop, expr):
             _prop, _field = str(prop).split(".")
+            if _field != "id":
+                raise NotImplementedError(
+                    f'Cannot filter relationships by field "{_field}", only "id" is supported.'
+                )
 
             # in the case of HAS ONLY, the size operator needs to be applied
             # one level up, i.e. excluding the field

--- a/optimade/filtertransformers/mongo.py
+++ b/optimade/filtertransformers/mongo.py
@@ -362,8 +362,23 @@ class MongoTransformer(Transformer):
 
         def replace_with_relationship(subdict, prop, expr):
             _prop, _field = str(prop).split(".")
-            subdict[f"relationships.{_prop}.data.{_field}"] = expr
+
+            # in the case of HAS ONLY, the size operator needs to be applied
+            # one level up, i.e. excluding the field
+            if "$size" in expr:
+                if "$and" not in subdict:
+                    subdict["$and"] = []
+                subdict["$and"].extend(
+                    [
+                        {f"relationships.{_prop}.data": {"$size": expr.pop("$size")}},
+                        {f"relationships.{_prop}.data.{_field}": expr},
+                    ]
+                )
+            else:
+                subdict[f"relationships.{_prop}.data.{_field}"] = expr
+
             subdict.pop(prop)
+
             return subdict
 
         return recursive_postprocessing(

--- a/optimade/server/exception_handlers.py
+++ b/optimade/server/exception_handlers.py
@@ -108,5 +108,13 @@ def grammar_not_implemented_handler(request: Request, exc: VisitError):
     return general_exception(request, exc, status_code=status, errors=[error])
 
 
+def not_implemented_handler(request: Request, exc: NotImplementedError):
+    status = 501
+    title = "NotImplementedError"
+    detail = str(exc)
+    error = OptimadeError(detail=detail, status=status, title=title)
+    return general_exception(request, exc, status_code=status, errors=[error])
+
+
 def general_exception_handler(request: Request, exc: Exception):
     return general_exception(request, exc)

--- a/optimade/server/main.py
+++ b/optimade/server/main.py
@@ -70,6 +70,7 @@ app.add_exception_handler(
 )
 app.add_exception_handler(ValidationError, exc_handlers.validation_exception_handler)
 app.add_exception_handler(VisitError, exc_handlers.grammar_not_implemented_handler)
+app.add_exception_handler(NotImplementedError, exc_handlers.not_implemented_handler)
 app.add_exception_handler(Exception, exc_handlers.general_exception_handler)
 
 

--- a/tests/filtertransformers/test_mongo.py
+++ b/tests/filtertransformers/test_mongo.py
@@ -289,6 +289,41 @@ class TestMongoTransformer(unittest.TestCase):
         with self.assertRaises(VisitError):
             self.transform('"some string" > "some other string"')
 
+    def test_filtering_on_relationships(self):
+        """ Test the nested properties with special names
+        like "structures", "references" etc. are applied
+        to the relationships field.
+
+        """
+
+        self.assertEqual(
+            self.transform('references.id HAS "dummy/2019"'),
+            {"relationships.references.data.id": {"$in": ["dummy/2019"]}},
+        )
+
+        self.assertEqual(
+            self.transform('structures.id HAS ANY "dummy/2019", "dijkstra1968"'),
+            {
+                "relationships.structures.data.id": {
+                    "$in": ["dummy/2019", "dijkstra1968"]
+                }
+            },
+        )
+
+        self.assertEqual(
+            self.transform('structures.id HAS ALL "dummy/2019", "dijkstra1968"'),
+            {
+                "relationships.structures.data.id": {
+                    "$all": ["dummy/2019", "dijkstra1968"]
+                }
+            },
+        )
+
+        self.assertEqual(
+            self.transform('structures.id HAS ONLY "dummy/2019"'),
+            {"relationships.structures.data.id": {"$all": ["dummy/2019"], "$size": 1}},
+        )
+
     def test_not_implemented(self):
         """ Test that list properties that are currently not implemented
         give a sensible response.

--- a/tests/filtertransformers/test_mongo.py
+++ b/tests/filtertransformers/test_mongo.py
@@ -321,7 +321,33 @@ class TestMongoTransformer(unittest.TestCase):
 
         self.assertEqual(
             self.transform('structures.id HAS ONLY "dummy/2019"'),
-            {"relationships.structures.data.id": {"$all": ["dummy/2019"], "$size": 1}},
+            {
+                "$and": [
+                    {"relationships.structures.data": {"$size": 1}},
+                    {"relationships.structures.data.id": {"$all": ["dummy/2019"]}},
+                ]
+            },
+        )
+
+        self.assertEqual(
+            self.transform(
+                'structures.id HAS ONLY "dummy/2019" AND structures.id HAS "dummy/2019"'
+            ),
+            {
+                "$and": [
+                    {
+                        "$and": [
+                            {"relationships.structures.data": {"$size": 1}},
+                            {
+                                "relationships.structures.data.id": {
+                                    "$all": ["dummy/2019"]
+                                }
+                            },
+                        ]
+                    },
+                    {"relationships.structures.data.id": {"$in": ["dummy/2019"]}},
+                ],
+            },
         )
 
     def test_not_implemented(self):

--- a/tests/server/test_query_params.py
+++ b/tests/server/test_query_params.py
@@ -504,6 +504,21 @@ class FilterTests(SetClient, unittest.TestCase):
         expected_ids = ["mpf_1"]
         self._check_response(request, expected_ids, len(expected_ids))
 
+    def test_filter_on_relationships(self):
+        request = '/structures?filter=references.id HAS "dummy/2019"'
+        expected_ids = ["mpf_3819"]
+        self._check_response(request, expected_ids, len(expected_ids))
+
+        request = (
+            '/structures?filter=references.id HAS ANY "dummy/2019", "dijkstra1968"'
+        )
+        expected_ids = ["mpf_1", "mpf_2", "mpf_3819"]
+        self._check_response(request, expected_ids, len(expected_ids))
+
+        request = '/structures?filter=references.id HAS ONLY "dijkstra1968"'
+        expected_ids = ["mpf_1", "mpf_2"]
+        self._check_response(request, expected_ids, len(expected_ids))
+
     def _check_response(
         self, request: str, expected_ids: Union[List, Set], expected_return: int
     ):

--- a/tests/server/test_query_params.py
+++ b/tests/server/test_query_params.py
@@ -519,6 +519,17 @@ class FilterTests(SetClient, unittest.TestCase):
         expected_ids = ["mpf_1", "mpf_2"]
         self._check_response(request, expected_ids, len(expected_ids))
 
+        request = '/structures?filter=references.doi HAS ONLY "10/123"'
+        error_detail = (
+            'Cannot filter relationships by field "doi", only "id" is supported.'
+        )
+        self._check_error_response(
+            request,
+            expected_status=501,
+            expected_title="NotImplementedError",
+            expected_detail=error_detail,
+        )
+
     def _check_response(
         self, request: str, expected_ids: Union[List, Set], expected_return: int
     ):


### PR DESCRIPTION
Now #222 is done, this PR adds the ability to filter on relationships, e.g. `/structures?filter=references.id HAS "dijkstra1968"`. The relevant part of the spec is [section 6.2.6](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst#filtering-on-relationships) (please check I am interpreting it correctly).

This is done with another post-processing method that looks for the pattern `<entry_type>.<property>` in a query, and replaces it with a search over the `relationships` dictionary.