### PR TITLE
Fixes Local Tests

### DIFF
--- a/.github/workflows/deps_eager.yml
+++ b/.github/workflows/deps_eager.yml
@@ -43,13 +43,11 @@ jobs:
       run: pytest -rs --cov=./optimade/ --cov-report=xml
       env:
         OPTIMADE_CI_FORCE_MONGO: 1
-        OPTIMADE_CONFIG_FILE: ${{ github.workspace }}/tests/test_config.json
 
     - name: Run tests relevant for index meta-db (using `mongomock`)
       run: pytest -rs --cov=./optimade/ --cov-report=xml --cov-append tests/server/test_middleware.py tests/server/test_server_validation.py tests/server/test_config.py
       env:
         OPTIMADE_CI_FORCE_MONGO: 0
-        OPTIMADE_CONFIG_FILE: ${{ github.workspace }}/tests/test_config.json
 
   # deps_clean-install:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/deps_lint.yml
+++ b/.github/workflows/deps_lint.yml
@@ -163,13 +163,11 @@ jobs:
       run: pytest -rs --cov=./optimade/ --cov-report=xml
       env:
         OPTIMADE_CI_FORCE_MONGO: 1
-        OPTIMADE_CONFIG_FILE: ${{ github.workspace }}/tests/test_config.json
 
     - name: Run tests only for index meta-db (using `mongomock`)
       run: pytest -rs --cov=./optimade/ --cov-report=xml --cov-append tests/server/test_middleware.py tests/server/test_server_validation.py tests/server/test_config.py
       env:
         OPTIMADE_CI_FORCE_MONGO: 0
-        OPTIMADE_CONFIG_FILE: ${{ github.workspace }}/tests/test_config.json
 
     - name: Upload coverage to Codecov
       if: matrix.python-version == 3.7 && github.repository == 'Materials-Consortia/optimade-python-tools'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+import os
+import pytest
+from pathlib import Path
+
+
+def pytest_configure(config):
+    """
+    Method that runs before pytest collects tests so no modules
+    are imported
+    """
+    cwd = Path(__file__).parent
+    os.environ["OPTIMADE_CONFIG_FILE"] = str(cwd / "test_config.json")


### PR DESCRIPTION
This fixes #239 by making pytest set the environment variable for OPTIMADE_CONFIG_PATH before it collects any tests. This is needed since many of the objects in the server are module-level singletons that get configured on import. In the future, we should fix that.