### PR TITLE
Remove query constraints for /links-endpoint

### DIFF
--- a/optimade/server/routers/links.py
+++ b/optimade/server/routers/links.py
@@ -26,19 +26,6 @@ links_coll = MongoCollection(
     tags=["Links"],
 )
 def get_links(request: Request, params: EntryListingQueryParams = Depends()):
-    for str_param in ["filter", "sort"]:
-        if getattr(params, str_param):
-            setattr(params, str_param, "")
-    for int_param in [
-        "page_offset",
-        "page_number",
-        "page_cursor",
-        "page_above",
-        "page_below",
-    ]:
-        if getattr(params, int_param):
-            setattr(params, int_param, 0)
-    params.page_limit = CONFIG.page_limit
     return get_entries(
         collection=links_coll, response=LinksResponse, request=request, params=params
     )

--- a/optimade/server/routers/utils.py
+++ b/optimade/server/routers/utils.py
@@ -278,10 +278,6 @@ def retrieve_queryable_properties(schema: dict, queryable_properties: list) -> d
                 properties.update(
                     retrieve_queryable_properties(sub_schema, sub_queryable_properties)
                 )
-            elif value.get("description", "") == "Not allowed key":
-                # Special case used in models to make sure not-allowed fields are not present under "attributes"
-                # NOTE: This may be removed when upgrading to pydantic v1 !
-                continue
             else:
                 properties[name] = {"description": value.get("description", "")}
                 if "unit" in value:


### PR DESCRIPTION
According to Materials-Consortia/OPTIMADE#217 there is no reason why we cannot apply the full range of query parameters for the `/links`-endpoint.

This PR removes the constraints set on the query parameters for the `/links`-endpoint and as a bonus I found an `elif` that had a note, which said it could be removed after upgrading to `pydantic` v1, so I removed it... Looking around the code, I can't see why I shouldn't be able to do so.