### PR TITLE
Up to v0.8.0

### DIFF
--- a/openapi/index_openapi.json
+++ b/openapi/index_openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.2",
   "info": {
     "title": "OPTIMADE API - Index meta-database",
-    "description": "The [Open Databases Integration for Materials Design (OPTIMADE) consortium](https://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.\nThis is the \"special\" index meta-database.\n\nThis specification is generated using [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools/tree/v0.7.0) v0.7.0.",
+    "description": "The [Open Databases Integration for Materials Design (OPTIMADE) consortium](https://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.\nThis is the \"special\" index meta-database.\n\nThis specification is generated using [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools/tree/v0.8.0) v0.8.0.",
     "version": "0.10.1"
   },
   "paths": {

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.2",
   "info": {
     "title": "OPTIMADE API",
-    "description": "The [Open Databases Integration for Materials Design (OPTIMADE) consortium](https://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.\n\nThis specification is generated using [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools/tree/v0.7.0) v0.7.0.",
+    "description": "The [Open Databases Integration for Materials Design (OPTIMADE) consortium](https://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.\n\nThis specification is generated using [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools/tree/v0.8.0) v0.8.0.",
     "version": "0.10.1"
   },
   "paths": {

--- a/optimade/__init__.py
+++ b/optimade/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "0.7.0"
+__version__ = "0.8.0"
 __api_version__ = "0.10.1"

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ all_deps = dev_deps + django_deps + elastic_deps + aiida_deps + ase_deps + pymat
 
 setup(
     name="optimade",
-    version="0.7.0",
+    version="0.8.0",
     url="https://github.com/Materials-Consortia/optimade-python-tools",
     license="MIT",
     author="OPTIMADE Development Team",


### PR DESCRIPTION
**New features**:
- Resource adapter. Intended for use in clients. It mimicks the `EntryResource` class in models, while also open the possibility to convert an OPTIMADE resource to other well-known formats for the specific resource (e.g., ASE Atoms or CIF file for structures). See more info in the commit descriptions for 9bedc78 (#241, @CasperWA with testing by @ml-evs)
- Enable passing an URI, when using MongoDB (#150, @shyamd)
- Enable filtering on entry resource `relationships` for the MongoDB transformer (#234, @ml-evs)
- Concept of `LENGTH` aliases, where one may link a resource property's size/length to another resource property (#222, @ml-evs)
- Move to `pydantic`'s `BaseSettings` for the server configuration details (#226, @shyamd)
- Use [Dependabot](https://dependabot.com/) to keep track of dependencies (@CasperWA)

**Updates**:
- Remove query constraints for the `/links`-endpoint, making it able to handle a query on the same level as an entry resource endpoint (#244, @CasperWA)
- Add handling of the `filter`'s `LENGTH` operator when using the MongoDB transformer (#222, @ml-evs)
- Scrape all `filter` query examples from [the OPTIMADE API specification](https://github.com/Materials-Consortia/OPTIMADE/blob/develop/optimade.rst) for testing (#227, @ml-evs)
- Use [new OPTIMADE capitalization](https://github.com/Materials-Consortia/OPTIMADE/issues/193) throughout the repository (#233, @ml-evs)
- README now reflects the extraction of the GH Action for validation into a [different repository](https://github.com/Materials-Consortia/optimade-validator-action) (#231, @ml-evs)

**Bug fixes**:
- Release to PyPI _only_ when a GitHub release is published (#235, #236, @shyamd, @CasperWA)
- Several minor fixes related to the changes included in this update already (@ml-evs, @CasperWA, @shyamd)
