### PR TITLE
Relax HTTP URL constraints on meta->implementation->source_url field.

### DIFF
--- a/optimade/models/optimade_json.py
+++ b/optimade/models/optimade_json.py
@@ -1,6 +1,6 @@
 """Modified JSON API v1.0 for OPTIMADE API"""
 # pylint: disable=no-self-argument,no-name-in-module
-from pydantic import Field, root_validator, BaseModel, AnyHttpUrl, EmailStr
+from pydantic import Field, root_validator, BaseModel, AnyHttpUrl, AnyUrl, EmailStr
 from typing import Optional, Union, List
 
 from datetime import datetime
@@ -109,7 +109,7 @@ class Implementation(BaseModel):
         None, description="version string of the current implementation"
     )
 
-    source_url: Optional[AnyHttpUrl] = Field(
+    source_url: Optional[AnyUrl] = Field(
         None,
         description="URL of the implementation source, either downloadable archive or version control system",
     )


### PR DESCRIPTION
As above, and from #258 & #260.

I also notice that we don't have any real tests for the info models directly, which I guess we should rectify at some point.