### PR TITLE
Not so quick fix to allow "/" at end of validator URL, plus fixes and tests for --as_type

### DIFF
--- a/optimade/validator/validator.py
+++ b/optimade/validator/validator.py
@@ -288,6 +288,8 @@ class ImplementationValidator:
             self.client = client
             self.base_url = self.client.base_url
         else:
+            if base_url.endswith("/"):
+                base_url = base_url[:-1]
             self.base_url = base_url
             self.client = Client(base_url, max_retries=self.max_retries)
 

--- a/optimade/validator/validator.py
+++ b/optimade/validator/validator.py
@@ -288,7 +288,7 @@ class ImplementationValidator:
             self.client = client
             self.base_url = self.client.base_url
         else:
-            if base_url.endswith("/"):
+            while base_url.endswith("/"):
                 base_url = base_url[:-1]
             self.base_url = base_url
             self.client = Client(base_url, max_retries=self.max_retries)

--- a/tests/server/test_server_validation.py
+++ b/tests/server/test_server_validation.py
@@ -5,7 +5,7 @@ from traceback import print_exc
 
 from optimade.validator import ImplementationValidator
 
-from .utils import SetClient
+from .utils import SetClient, TestClient
 
 
 class ServerTestWithValidator(SetClient, unittest.TestCase):
@@ -51,3 +51,31 @@ def test_mongo_backend_package_used():
         raise Exception(
             f"The environment variable OPTIMADE_CI_FORCE_MONGO cannot be parsed as an int."
         )
+
+
+class AsTypeTestsWithValidator(SetClient, unittest.TestCase):
+
+    server = "regular"
+
+    def test_as_type_with_validator(self):
+
+        test_urls = {
+            "http://example.org/v0/structures": "structures",
+            "http://example.org/v0/structures/mpf_1": "structure",
+            "http://example.org/v0/references": "references",
+            "http://example.org/v0/references/dijkstra1968": "reference",
+            "http://example.org/v0/info": "info",
+            "http://example.org/v0/links": "links",
+        }
+        with unittest.mock.patch(
+            "requests.get", unittest.mock.Mock(side_effect=self.client.get)
+        ):
+            for url, as_type in test_urls.items():
+                validator = ImplementationValidator(
+                    base_url=url, as_type=as_type, verbosity=5
+                )
+                try:
+                    validator.main()
+                except Exception:
+                    print_exc()
+                self.assertTrue(validator.valid)

--- a/tests/server/test_server_validation.py
+++ b/tests/server/test_server_validation.py
@@ -5,7 +5,7 @@ from traceback import print_exc
 
 from optimade.validator import ImplementationValidator
 
-from .utils import SetClient, TestClient
+from .utils import SetClient
 
 
 class ServerTestWithValidator(SetClient, unittest.TestCase):


### PR DESCRIPTION
Handles an edge case that got lost in the last PR, i.e. handling slashes at the end of the URL provided at the CLI.