### PR TITLE
Add `sortable=True` to all properties

### DIFF
--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -1107,7 +1107,7 @@
           "sortable": {
             "title": "Sortable",
             "type": "boolean",
-            "description": "defines whether the entry property can be used for sorting with the \"sort\" parameter. If the entry listing endpoint supports sorting, this key MUST be present for all properties."
+            "description": "defines whether the entry property can be used for sorting with the \"sort\" parameter. If the entry listing endpoint supports sorting, this key MUST be present for sortable properties with value `true`."
           }
         }
       },

--- a/optimade/models/entries.py
+++ b/optimade/models/entries.py
@@ -146,7 +146,8 @@ class EntryInfoProperty(BaseModel):
 
     sortable: Optional[bool] = Field(
         None,
-        description='defines whether the entry property can be used for sorting with the "sort" parameter. If the entry listing endpoint supports sorting, this key MUST be present for all properties.',
+        description='defines whether the entry property can be used for sorting with the "sort" parameter. '
+        "If the entry listing endpoint supports sorting, this key MUST be present for sortable properties with value `true`.",
     )
 
 

--- a/optimade/server/routers/utils.py
+++ b/optimade/server/routers/utils.py
@@ -282,6 +282,9 @@ def retrieve_queryable_properties(schema: dict, queryable_properties: list) -> d
                 properties[name] = {"description": value.get("description", "")}
                 if "unit" in value:
                     properties[name]["unit"] = value["unit"]
+                # All properties are sortable with the MongoDB backend.
+                # While the result for sorting lists may not be as expected, they are still sorted.
+                properties[name]["sortable"] = True
     return properties
 
 


### PR DESCRIPTION
Fixes #273 

Since for MongoDB all properties can be sorted, it is done like this.
If one uses a different backend, one should overwrite the utility
function and use a different method to determine the sortability of
properties.

Slightly updated the wording of the `sortable` model attribute to be
more accurate: It is only a MUST if `sort` is supported AND the given
property can be used for sorting.