### PR TITLE
Add classes to operate on model schemas directly

### DIFF
--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -2116,7 +2116,8 @@
         "properties": {
           "name": {
             "title": "Name",
-            "type": "string"
+            "type": "string",
+            "description": "Full name of the person, REQUIRED."
           },
           "firstname": {
             "title": "Firstname",
@@ -2836,7 +2837,8 @@
         "properties": {
           "name": {
             "title": "Name",
-            "type": "string"
+            "type": "string",
+            "description": "Gives the name of the species; the **name** value MUST be unique in the `species` list."
           },
           "chemical_symbols": {
             "title": "Chemical Symbols",

--- a/optimade/adapters/structures/adapter.py
+++ b/optimade/adapters/structures/adapter.py
@@ -1,12 +1,12 @@
 from optimade.models import StructureResource
 from optimade.adapters.base import EntryAdapter
 
-from .aiida import get_aiida_structure_data
-from .ase import get_ase_atoms
-from .cif import get_cif
-from .proteindatabank import get_pdb, get_pdbx_mmcif
-from .pymatgen import get_pymatgen
-from .jarvis import get_jarvis_atoms
+from optimade.adapters.structures.aiida import get_aiida_structure_data
+from optimade.adapters.structures.ase import get_ase_atoms
+from optimade.adapters.structures.cif import get_cif
+from optimade.adapters.structures.proteindatabank import get_pdb, get_pdbx_mmcif
+from optimade.adapters.structures.pymatgen import get_pymatgen
+from optimade.adapters.structures.jarvis import get_jarvis_atoms
 
 
 class Structure(EntryAdapter):

--- a/optimade/models/references.py
+++ b/optimade/models/references.py
@@ -14,7 +14,7 @@ __all__ = ("Person", "ReferenceResourceAttributes", "ReferenceResource")
 
 
 class Person(BaseModel):
-    name: str = Field(..., decsription="""Full name of the person, REQUIRED.""")
+    name: str = Field(..., description="""Full name of the person, REQUIRED.""")
     firstname: Optional[str] = Field(None, description="""First name of the person.""")
     lastname: Optional[str] = Field(None, description="""Last name of the person.""")
 

--- a/optimade/models/structures.py
+++ b/optimade/models/structures.py
@@ -66,7 +66,7 @@ class Species(BaseModel):
 
     name: str = Field(
         ...,
-        decsription="""Gives the name of the species; the **name** value MUST be unique in the `species` list.""",
+        description="""Gives the name of the species; the **name** value MUST be unique in the `species` list.""",
     )
 
     chemical_symbols: List[str] = Field(

--- a/optimade/server/entry_collections/entry_collections.py
+++ b/optimade/server/entry_collections/entry_collections.py
@@ -12,6 +12,7 @@ from optimade.server.exceptions import BadRequest, Forbidden
 from optimade.server.mappers import BaseResourceMapper
 from optimade.server.query_params import EntryListingQueryParams, SingleEntryQueryParams
 from optimade.server.warnings import FieldValueNotRecognized
+from optimade.server.schemas import ENTRY_SCHEMAS
 
 
 class EntryCollection(ABC):
@@ -41,6 +42,7 @@ class EntryCollection(ABC):
         self.collection = collection
         self.parser = LarkParser()
         self.resource_cls = resource_cls
+        self.resource_schema = ENTRY_SCHEMAS.get(resource_mapper.ENDPOINT)
         self.resource_mapper = resource_mapper
         self.transformer = transformer
 
@@ -108,19 +110,7 @@ class EntryCollection(ABC):
             Property names.
 
         """
-        schema = self.resource_cls.schema()
-        attributes = schema["properties"]["attributes"]
-        if "allOf" in attributes:
-            allOf = attributes.pop("allOf")
-            for dict_ in allOf:
-                attributes.update(dict_)
-        if "$ref" in attributes:
-            path = attributes["$ref"].split("/")[1:]
-            attributes = schema.copy()
-            while path:
-                next_key = path.pop(0)
-                attributes = attributes[next_key]
-        return set(attributes["properties"].keys())
+        return set(self.resource_schema.keys())
 
     def handle_query_params(
         self, params: Union[EntryListingQueryParams, SingleEntryQueryParams]

--- a/optimade/server/entry_collections/entry_collections.py
+++ b/optimade/server/entry_collections/entry_collections.py
@@ -42,7 +42,7 @@ class EntryCollection(ABC):
         self.collection = collection
         self.parser = LarkParser()
         self.resource_cls = resource_cls
-        self.resource_schema = ENTRY_SCHEMAS.get(resource_mapper.ENDPOINT)
+        self.resource_schema = ENTRY_SCHEMAS.get(resource_mapper.ENDPOINT, {})
         self.resource_mapper = resource_mapper
         self.transformer = transformer
 
@@ -62,30 +62,6 @@ class EntryCollection(ABC):
             kwargs (dict): Query parameters as keyword arguments.
 
         """
-
-    def get_attribute_fields(self) -> set:
-        """Get the set of attribute fields from the schema of the
-        resource class, resolving references along the way.
-
-        Returns:
-            Property names.
-
-        """
-        schema = self.resource_cls.schema()
-        attributes = schema["properties"]["attributes"]
-        if "allOf" in attributes:
-            allOf = attributes.pop("allOf")
-            for dict_ in allOf:
-                attributes.update(dict_)
-        if "$ref" in attributes:
-            path = attributes["$ref"].split("/")[1:]
-            attributes = schema.copy()
-            while path:
-                next_key = path.pop(0)
-                attributes = attributes[next_key]
-        return set(attributes["properties"].keys()).union(
-            set(self.resource_schema.keys())
-        )
 
     @abstractmethod
     def find(
@@ -125,6 +101,30 @@ class EntryCollection(ABC):
         }
 
         return fields
+
+    def get_attribute_fields(self) -> set:
+        """Get the set of attribute fields from the schema of the
+        resource class, resolving references along the way.
+
+        Returns:
+            Property names.
+
+        """
+        schema = self.resource_cls.schema()
+        attributes = schema["properties"]["attributes"]
+        if "allOf" in attributes:
+            allOf = attributes.pop("allOf")
+            for dict_ in allOf:
+                attributes.update(dict_)
+        if "$ref" in attributes:
+            path = attributes["$ref"].split("/")[1:]
+            attributes = schema.copy()
+            while path:
+                next_key = path.pop(0)
+                attributes = attributes[next_key]
+        return set(attributes["properties"].keys()).union(
+            set(self.resource_schema.keys())
+        )
 
     def handle_query_params(
         self, params: Union[EntryListingQueryParams, SingleEntryQueryParams]

--- a/optimade/server/entry_collections/entry_collections.py
+++ b/optimade/server/entry_collections/entry_collections.py
@@ -104,27 +104,13 @@ class EntryCollection(ABC):
 
     def get_attribute_fields(self) -> set:
         """Get the set of attribute fields from the schema of the
-        resource class, resolving references along the way.
+        resource class.
 
         Returns:
             Property names.
 
         """
-        schema = self.resource_cls.schema()
-        attributes = schema["properties"]["attributes"]
-        if "allOf" in attributes:
-            allOf = attributes.pop("allOf")
-            for dict_ in allOf:
-                attributes.update(dict_)
-        if "$ref" in attributes:
-            path = attributes["$ref"].split("/")[1:]
-            attributes = schema.copy()
-            while path:
-                next_key = path.pop(0)
-                attributes = attributes[next_key]
-        return set(attributes["properties"].keys()).union(
-            set(self.resource_schema.keys())
-        )
+        return set(self.resource_schema.keys())
 
     def handle_query_params(
         self, params: Union[EntryListingQueryParams, SingleEntryQueryParams]

--- a/optimade/server/routers/info.py
+++ b/optimade/server/routers/info.py
@@ -76,7 +76,10 @@ def get_entry_info(request: Request, entry: str):
 
     schema = ENTRY_INFO_SCHEMAS[entry]()
     queryable_properties = {"id", "type", "attributes"}
-    properties = retrieve_queryable_properties(schema, queryable_properties)
+    entry_provider_fields = CONFIG.provider_fields.get(entry)
+    properties = retrieve_queryable_properties(
+        schema, queryable_properties, entry_provider_fields=entry_provider_fields
+    )
 
     output_fields_by_format = {"json": list(properties.keys())}
 

--- a/optimade/server/routers/info.py
+++ b/optimade/server/routers/info.py
@@ -6,18 +6,17 @@ from fastapi import APIRouter, Request
 from fastapi.exceptions import StarletteHTTPException
 
 from optimade import __api_version__
-from optimade.server.config import CONFIG
 from optimade.models import (
     ErrorResponse,
     InfoResponse,
     EntryInfoResponse,
 )
+from optimade.server.schemas import ENTRY_SCHEMAS
+
 
 from optimade.server.routers.utils import (
     meta_values,
-    retrieve_queryable_properties,
     get_base_url,
-    ENTRY_INFO_SCHEMAS,
 )
 
 
@@ -50,8 +49,8 @@ def get_info(request: Request):
                     }
                 ],
                 formats=["json"],
-                available_endpoints=["info", "links"] + list(ENTRY_INFO_SCHEMAS.keys()),
-                entry_types_by_format={"json": list(ENTRY_INFO_SCHEMAS.keys())},
+                available_endpoints=["info", "links"] + list(ENTRY_SCHEMAS.keys()),
+                entry_types_by_format={"json": list(ENTRY_SCHEMAS.keys())},
                 is_index=False,
             ),
         ),
@@ -67,27 +66,21 @@ def get_info(request: Request):
 def get_entry_info(request: Request, entry: str):
     from optimade.models import EntryInfoResource
 
-    valid_entry_info_endpoints = ENTRY_INFO_SCHEMAS.keys()
+    valid_entry_info_endpoints = ENTRY_SCHEMAS.keys()
     if entry not in valid_entry_info_endpoints:
         raise StarletteHTTPException(
             status_code=404,
             detail=f"Entry info not found for {entry}, valid entry info endpoints are: {', '.join(valid_entry_info_endpoints)}",
         )
 
-    schema = ENTRY_INFO_SCHEMAS[entry]()
-    queryable_properties = {"id", "type", "attributes"}
-    entry_provider_fields = CONFIG.provider_fields.get(entry)
-    properties = retrieve_queryable_properties(
-        schema, queryable_properties, entry_provider_fields=entry_provider_fields
-    )
-
+    properties = ENTRY_SCHEMAS.get(entry)
     output_fields_by_format = {"json": list(properties.keys())}
 
     return EntryInfoResponse(
         meta=meta_values(str(request.url), 1, 1, more_data_available=False),
         data=EntryInfoResource(
             formats=list(output_fields_by_format.keys()),
-            description=schema.get("description", "Entry Resources"),
+            description=properties.get("description", "Entry Resources"),
             properties=properties,
             output_fields_by_format=output_fields_by_format,
         ),

--- a/optimade/server/routers/info.py
+++ b/optimade/server/routers/info.py
@@ -6,28 +6,22 @@ from fastapi import APIRouter, Request
 from fastapi.exceptions import StarletteHTTPException
 
 from optimade import __api_version__
-
+from optimade.server.config import CONFIG
 from optimade.models import (
     ErrorResponse,
     InfoResponse,
     EntryInfoResponse,
-    ReferenceResource,
-    StructureResource,
 )
 
 from optimade.server.routers.utils import (
     meta_values,
     retrieve_queryable_properties,
     get_base_url,
+    ENTRY_INFO_SCHEMAS,
 )
 
 
 router = APIRouter(redirect_slashes=True)
-
-ENTRY_INFO_SCHEMAS = {
-    "structures": StructureResource.schema,
-    "references": ReferenceResource.schema,
-}
 
 
 @router.get(

--- a/optimade/server/routers/utils.py
+++ b/optimade/server/routers/utils.py
@@ -24,10 +24,20 @@ from optimade.server.entry_collections import EntryCollection
 from optimade.server.exceptions import BadRequest
 from optimade.server.query_params import EntryListingQueryParams, SingleEntryQueryParams
 
-ENTRY_INFO_SCHEMAS = {
-    "structures": StructureResource.schema,
-    "references": ReferenceResource.schema,
-}
+
+class EntryInfoSchemas:
+    def __init__(self):
+        self.structures = StructureResource.schema
+        self.references = ReferenceResource.schema
+
+    def __getitem__(self, key):
+        return getattr(self, key)
+
+    def keys(self):
+        return {"structures", "references"}
+
+
+ENTRY_INFO_SCHEMAS = EntryInfoSchemas()
 
 # we need to get rid of any release tags (e.g. -rc.2) and any build metadata (e.g. +py36)
 # from the api_version before allowing the URL

--- a/optimade/server/schemas.py
+++ b/optimade/server/schemas.py
@@ -34,6 +34,9 @@ def retrieve_queryable_properties(
                 if key in value:
                     condOf = value.pop(key)
                     if isinstance(condOf, list):
+                        # ml-evs: A bit of late-night hack; we need to think more about how to
+                        # unwrap the case where multiple types are allowed for a given field.
+                        # Here I just grab the first, for the sake of testing.
                         value.update(condOf[0])
 
             if "$ref" in value:

--- a/optimade/server/schemas.py
+++ b/optimade/server/schemas.py
@@ -70,7 +70,7 @@ class EntrySchemas:
         self._links = None
 
     def keys(self):
-        return {"structures", "references", "links"}
+        return {"structures", "references"}
 
     def get(self, key: str):
         return getattr(self, key, {})
@@ -102,16 +102,6 @@ class EntrySchemas:
         return self._references
 
     @property
-    def links(self):
-        if self._links is None:
-            # links should not permit provider-specific fields
-            schema = self.links_model.schema()
-            self._links = retrieve_queryable_properties(
-                schema, schema["properties"].keys(), entry_provider_fields=None
-            )
-        return self._links
-
-    @property
     def structure_model(self):
         return self._structure_model
 
@@ -128,15 +118,6 @@ class EntrySchemas:
     def reference_model(self, model: EntryResource):
         self._references = None
         self._reference_model = model
-
-    @property
-    def links_model(self):
-        return self._links_model
-
-    @links_model.setter
-    def links_model(self, model: EntryResource):
-        self._links = None
-        self._links_model = model
 
 
 ENTRY_SCHEMAS = EntrySchemas()

--- a/optimade/server/schemas.py
+++ b/optimade/server/schemas.py
@@ -1,11 +1,6 @@
-from optimade.models import (
-    StructureResource,
-    ReferenceResource,
-    EntryResource,
-    DataType,
-)
+from optimade import models
 from optimade.server.config import CONFIG
-from typing import Dict, Union
+from typing import Dict, Union, Any
 
 
 def retrieve_queryable_properties(
@@ -14,7 +9,9 @@ def retrieve_queryable_properties(
     entry_provider_fields: list = None,
     base_schema: dict = None,
 ) -> dict:
-    """For a given schema dictionary and a list of desired properties,
+    """Retrieve schema properties.
+
+    For a given schema dictionary and a list of desired properties,
     recursively descend into the schema and set the appropriate values
     for the `description`, `sortable` and `unit` keys, returning the expanded
     schema dict that includes nested schemas.
@@ -62,7 +59,7 @@ def retrieve_queryable_properties(
                 # While the result for sorting lists may not be as expected, they are still sorted.
                 properties[name]["sortable"] = True
                 # Try to get OpenAPI-specific "format" if possible, else get "type"; a mandatory OpenAPI key.
-                properties[name]["type"] = DataType.from_json_type(
+                properties[name]["type"] = models.DataType.from_json_type(
                     value.get("format", value["type"])
                 )
 
@@ -73,19 +70,181 @@ def retrieve_queryable_properties(
     return properties
 
 
+class Schema:
+    """
+    Wrapper for output of pydantic model's `schema()` method.
+
+    The passed schema output can be retrieved from the `schema` property.
+    Mostly, this will be used to retrieve a de-referenced dictionary of the properties
+    of a model's schema. This can be done by retrieving the `properties` property.
+
+    It will recursively try to de-reference the properties by finding all instances of `$ref`
+    and either exchanging it with a "base" definition, i.e., a definition of the reference
+    without any references itself. Or it will try to find the reference in the specified
+    local reference location in the schema. And finally, if this does not find it, the class
+    will try to import the referenced model from `optimade.models` and return _that_ imported
+    model's `schema()` output.
+
+    Arguments:
+        schema (dict): The output of a pydantic model's `schema()` method.
+
+    """
+
+    def __init__(self, schema: dict) -> None:
+        self._schema = schema
+
+        self._properties = None
+        self._base_definitions = {
+            _: value
+            for _, value in self._schema["definitions"].items()
+            if not self._contains_reference(value)
+        }
+
+    @property
+    def schema(self) -> dict:
+        """The raw JSON Schema as a Python dictionary."""
+        return self._schema
+
+    @schema.setter
+    def schema(self, value: dict) -> None:
+        """Set a new JSON Schema.
+
+        Note, this will re-initialize the object instance, perhaps losing already set `properties` attribute.
+        """
+        if not isinstance(value, dict):
+            raise TypeError(f"schema must be a dict, you passed a {type(value)}")
+        self.__init__(value)  # Re-initalizing
+
+    @property
+    def properties(self) -> dict:
+        """The schema's properties in a de-referenced dictionary.
+
+        By de-referenced it is meant that all `$ref` entries will be replaced with actual definitions.
+        """
+        if self._properties is None:
+            self._properties = self._dereference_recursively(
+                self.schema["properties"].copy()
+            )
+
+        return self._properties
+
+    def _contains_reference(self, schema: dict) -> str:
+        """Determine whether a JSON Schema object contains a reference (`$ref` key).
+
+        Parameters:
+            schema: A JSON Schema object.
+
+        Returns:
+            The first found reference value, i.e., a `$ref` key's value.
+
+        """
+        for key, value in schema.items():
+            if key == "$ref":
+                return value
+            if isinstance(value, dict):
+                res = self._contains_reference(value)
+                if res:
+                    return res
+            elif isinstance(value, (tuple, list)):
+                for item in value:
+                    if isinstance(item, dict):
+                        res = self._contains_reference(item)
+                        if res:
+                            return res
+        return ""
+
+    def _get_py_model_schema(self, model_name: str) -> dict:
+        """Retrieve the schema from a Python pydantic model in `optimade.models`.
+
+        Parameters:
+            model_name: The name of the model to be imported from `optimade.models`.
+
+        Returns:
+            The output of the pydantic model's `schema()` method.
+
+        """
+        try:
+            model = getattr(models, model_name)
+        except AttributeError:
+            return {}
+        else:
+            return model.schema()
+
+    def _get_ref(self, reference: str) -> dict:
+        """Retrieve a JSON Schema object reference.
+
+        Parameters:
+            reference: JSON Schema `$ref` value, e.g., `"#/componenets/schemas/User"`.
+
+        Returns:
+            The referenced JSON Schema object.
+
+        """
+        if not reference.startswith("#"):
+            raise NotImplementedError(
+                "Only local JSON references can be handled by Schema."
+            )
+
+        name = reference.split("/")[-1]
+        if name in self._base_definitions:
+            return self._base_definitions[name]
+
+        path = reference[len("#/") :].split("/")
+        sub_schema = {}
+        while path:
+            name = path.pop(0)
+            sub_schema = sub_schema.get(
+                name, self.schema.get(name, self._get_py_model_schema(name))
+            )
+
+        sub_reference = self._contains_reference(sub_schema)
+        if sub_reference:
+            while sub_reference:
+                sub_schema = self._dereference_recursively(sub_schema)
+                sub_reference = self._contains_reference(sub_schema)
+        else:
+            # Update self._base_definitions
+            self._base_definitions.update({name: sub_schema})
+
+        return sub_schema
+
+    def _dereference_recursively(self, schema: Any) -> Any:
+        """De-reference a schema (part) recursively.
+
+        Since a reference will _always_ be a single `dict` with key `"$ref"`,
+        this can be exploited to return the reference target whenever `schema`
+        is a `dict` with key `"$ref"`.
+        Otherwise we return the schema right back, making sure to enter into all
+        containers of any kind.
+        """
+        if isinstance(schema, dict):
+            if "$ref" in schema:
+                return self._get_ref(schema["$ref"])
+            return {
+                _: self._dereference_recursively(value) for _, value in schema.items()
+            }
+        elif isinstance(schema, (tuple, set, list)):
+            return type(schema)([self._dereference_recursively(_) for _ in schema])
+        else:
+            return schema
+
+
 class EntrySchemas:
-    """Wrapper class for EntryResource schemas used in this server. Any
-    references in the schema are resolved to allow for easy use. If the
-    underyling model is updated, the schema will be refreshed.
+    """
+    Wrapper class for EntryResource schemas used in this server.
+
+    Any references in the schema are resolved to allow for easy use.
+    If the underlying model is updated, the schema will be refreshed.
 
     """
 
     def __init__(self):
-        self._entry_models: Dict[str, EntryResource] = {
-            "structures": StructureResource,
-            "references": ReferenceResource,
+        self._entry_models: Dict[str, models.EntryResource] = {
+            "structures": models.StructureResource,
+            "references": models.ReferenceResource,
         }
         self._entry_schemas: Dict[str, Union[None, dict]] = {}
+        self._entry_properties: Dict[str, models.EntryInfoProperty] = {}
 
     def keys(self):
         return self._entry_models.keys()
@@ -97,29 +256,41 @@ class EntrySchemas:
         return entry_type in self.keys()
 
     def __getitem__(self, entry_type: str):
-        return getattr(self, entry_type)
+        try:
+            return getattr(self, entry_type)
+        except AttributeError as exc:
+            raise KeyError(str(exc))
 
-    def __setitem__(self, entry_type: str, entry_model: EntryResource):
+    def __setitem__(self, entry_type: str, entry_model: models.EntryResource):
         if entry_type in self._entry_models:
             self._entry_models[entry_type] = entry_model
             self._entry_schemas[entry_type] = None
+        else:
+            raise KeyError(
+                f"Can only set existing keys. {entry_type!r} is not recognized as an existing key."
+            )
 
     def __getattr__(self, entry_type, default=None):
         if entry_type not in self._entry_models:
-            raise AttributeError(f"Requested entry type {entry_type} has no model.")
+            raise AttributeError(f"Requested entry type {entry_type!r} has no model.")
         return self._get_expanded_entry_schema(entry_type)
 
     def _get_expanded_entry_schema(self, entry_type):
-        if self._entry_schemas.get(entry_type, None) is None:
-            model = self._entry_models.get(entry_type, None)
+        if self._entry_schemas.get(entry_type) is None:
+            model = self._entry_models.get(entry_type)
             if model is None:
-                raise AttributeError(f"Missing model for {entry_type} in EntrySchemas.")
-            schema = model.schema()
+                raise AttributeError(
+                    f"Missing model for {entry_type!r} in EntrySchemas."
+                )
+            self._entry_schemas[entry_type] = model.schema()
+            self._entry_properties[entry_type] = self._entry_schemas[entry_type].get(
+                "properties", {}
+            )
 
             entry_provider_fields = CONFIG.provider_fields.get(entry_type)
-            self._entry_schemas[entry_type] = retrieve_queryable_properties(
-                schema,
-                schema["properties"].keys(),
+            self._entry_properties[entry_type] = retrieve_queryable_properties(
+                self._entry_schemas[entry_type],
+                self._entry_properties.keys(),
                 entry_provider_fields=entry_provider_fields,
             )
 

--- a/optimade/server/schemas.py
+++ b/optimade/server/schemas.py
@@ -1,0 +1,142 @@
+from optimade.models import (
+    StructureResource,
+    ReferenceResource,
+    LinksResource,
+    EntryResource,
+    DataType
+)
+from .config import CONFIG
+
+
+def retrieve_queryable_properties(
+    schema: dict, queryable_properties: list, entry_provider_fields: list = None
+) -> dict:
+    """ For a given schema dictionary and a list of desired properties,
+    recursively descend into the schema and set the appropriate values
+    for the `description`, `sortable` and `unit` keys, returning the expanded
+    schema dict that includes nested schemas.
+
+    """
+    properties = {}
+    if entry_provider_fields is None:
+        entry_provider_fields = []
+
+    for name, value in schema["properties"].items():
+        if name in queryable_properties:
+            if "$ref" in value:
+                path = value["$ref"].split("/")[1:]
+                sub_schema = schema.copy()
+                while path:
+                    next_key = path.pop(0)
+                    sub_schema = sub_schema[next_key]
+                sub_queryable_properties = sub_schema["properties"].keys()
+                properties.update(
+                    retrieve_queryable_properties(
+                        sub_schema, sub_queryable_properties, entry_provider_fields
+                    )
+                )
+            else:
+                properties[name] = {"description": value.get("description", "")}
+                if "unit" in value:
+                    properties[name]["unit"] = value["unit"]
+                # All properties are sortable with the MongoDB backend.
+                # While the result for sorting lists may not be as expected, they are still sorted.
+                properties[name]["sortable"] = True
+                # Try to get OpenAPI-specific "format" if possible, else get "type"; a mandatory OpenAPI key.
+                properties[name]["type"] = DataType.from_json_type(
+                    value.get("format", value["type"])
+                )
+
+            if name in entry_provider_fields:
+                # Rename fields in schema according to provider field list
+                properties[f"_{CONFIG.provider.prefix}_{name}"] = properties.pop(name)
+
+    return properties
+
+
+class EntrySchemas:
+    """ Wrapper class for EntryResource schemas used in this server. Any
+    references in the schema are resolved to allow for easy use. If the
+    underyling model is updated, the schema will be refreshed.
+
+    """
+
+    def __init__(self):
+        self._structure_model = StructureResource
+        self._reference_model = ReferenceResource
+        self._links_model = LinksResource
+        self._structures = None
+        self._references = None
+        self._links = None
+
+    def keys(self):
+        return {"structures", "references", "links"}
+
+    def get(self, key: str):
+        return getattr(self, key, {})
+
+    @property
+    def structures(self):
+        if self._structures is None:
+            schema = self.structure_model.schema()
+            entry_provider_fields = CONFIG.provider_fields.get("structures")
+            self._structures = retrieve_queryable_properties(
+                schema,
+                schema["properties"].keys(),
+                entry_provider_fields=entry_provider_fields,
+            )
+
+        return self._structures
+
+    @property
+    def references(self):
+        if self._references is None:
+            schema = self.reference_model.schema()
+            entry_provider_fields = CONFIG.provider_fields.get("references")
+            self._references = retrieve_queryable_properties(
+                schema,
+                schema["properties"].keys(),
+                entry_provider_fields=entry_provider_fields,
+            )
+
+        return self._references
+
+    @property
+    def links(self):
+        if self._links is None:
+            # links should not permit provider-specific fields
+            schema = self.links_model.schema()
+            self._links = retrieve_queryable_properties(
+                schema, schema["properties"].keys(), entry_provider_fields=None
+            )
+        return self._links
+
+    @property
+    def structure_model(self):
+        return self._structure_model
+
+    @structure_model.setter
+    def structure_model(self, model: EntryResource):
+        self._structures = None
+        self._structure_model = model
+
+    @property
+    def reference_model(self):
+        return self._reference_model
+
+    @reference_model.setter
+    def reference_model(self, model: EntryResource):
+        self._references = None
+        self._reference_model = model
+
+    @property
+    def links_model(self):
+        return self._links_model
+
+    @links_model.setter
+    def links_model(self, model: EntryResource):
+        self._links = None
+        self._links_model = model
+
+
+ENTRY_SCHEMAS = EntrySchemas()

--- a/optimade/server/schemas.py
+++ b/optimade/server/schemas.py
@@ -4,7 +4,7 @@ from optimade.models import (
     EntryResource,
     DataType,
 )
-from .config import CONFIG
+from optimade.server.config import CONFIG
 from typing import Dict, Union
 
 

--- a/tests/server/test_schemas.py
+++ b/tests/server/test_schemas.py
@@ -1,0 +1,59 @@
+# pylint: disable=relative-beyond-top-level,import-outside-toplevel
+import unittest
+
+from pydantic import Field
+from optimade.server.schemas import ENTRY_SCHEMAS, retrieve_queryable_properties
+from optimade.models import (
+    StructureResource,
+    StructureResourceAttributes,
+    ReferenceResource,
+    EntryResource,
+)
+
+
+class SchemaTests(unittest.TestCase):
+    """ Test the dynamic setting/loading of EntrySchemas from the specified models. """
+
+    def test_default_schemas(self):
+        def _test_default_schema(resource: EntryResource, endpoint_name: str):
+
+            resource_schema = resource.schema()
+
+            resource_schema = retrieve_queryable_properties(
+                resource_schema,
+                resource_schema["properties"].keys(),
+                entry_provider_fields=[],
+            )
+
+            # test key access
+            entry_schema = ENTRY_SCHEMAS[endpoint_name]
+            self.assertDictEqual(entry_schema, resource_schema)
+
+            # test getattr access
+            entry_schema = getattr(ENTRY_SCHEMAS, endpoint_name)
+            self.assertDictEqual(entry_schema, resource_schema)
+
+        endpoints = [
+            (StructureResource, "structures"),
+            (ReferenceResource, "references"),
+        ]
+        for resource, endpoint_name in endpoints:
+
+            self.assertTrue(endpoint_name in ENTRY_SCHEMAS)
+            _test_default_schema(resource, endpoint_name)
+
+    def test_modified_schema(self):
+        class MyStructureResourceAttributes(StructureResourceAttributes):
+            extra_field: float = Field(..., description="My extra field.")
+
+        class MyStructureResource(StructureResource):
+            attributes: MyStructureResourceAttributes
+
+        ENTRY_SCHEMAS["structures"] = MyStructureResource
+
+        my_structure_schema = ENTRY_SCHEMAS["structures"]
+        self.assertTrue("extra_field" in my_structure_schema)
+
+    def test_nonexistent_schema(self):
+        with self.assertRaises(AttributeError):
+            ENTRY_SCHEMAS["not_an_endpoint_name"]


### PR DESCRIPTION
EDIT: The description below still holds, but this PR has transformed into something a bit different. The main aim is now to add classes that allow us to explore the model schemas directly in Python, e.g. for use by the validator to grab expected field types and support levels.

## Original description

This PR allows for provider fields to be displayed at `/info/<entry>` endpoints, and more generally allows the use of extended models, by providing a class for `ENTRY_INFO_SCHEMAS` that can be overridden by a user-defined class. e.g. in my app code, I now add the line below, instead of having to rewrite the info router.

```
ENTRY_INFO_SCHEMAS.structure_model = MyModel
```

This required a tweak to the `retrieve_queryable_properties` function too, which now takes a list of provider fields that it will add a prefix to in the displayed schema. The info router now generates this list from `CONFIG.provider_fields`.

EDIT: I've since moved all this to a new submodule, `optimade.server.schemas` which loads the schemas and follows references so they can be used easily. Entry collections now store the unpacked schema, which removes some extra burden on each filter, where it had to unpack the schema again.

By allowing for extended models, implementations can now do the following:
- set particular fields as sortable/unsortable
- provide descriptions of provider fields for entry_info (and specify if they can be sorted on)
- errors are raised if sorting is forbidden or the field is unknown

Caveats:
- In effect, we now have two levels of support for "provider fields", one from the config (which just generates the appropriate resource mapper) and one from using extended models. Currently the latter relies on the fieldname being set in the former, but instead it should probably just loop over field names and check if they are in the base optimade spec, classing them as provider-specific if not.

Couple of extra things to consider:
- This doesn't automatically update the OpenAPI schema/swagger docs with provider fields; I'm fine with this containing OPTIMADE fields only for now.
- We lose a lot of nested data at the moment and rely on the top-level descriptions being sufficient, which forces a flat hierarchy on any provider fields too. Maybe this is fine, and hopefully the `type` field will be a useful addition in this regard. As a concrete example, the API will not return anything about our `Species` type anywhere, except in the swagger docs/OpenAPI schema. Would we want to allow nested fields, i.e. taking descriptions of sub-items in a dict field?