### PR TITLE
Add null check to mongo filtertransformer for KNOWN/UNKNOWN filters

### DIFF
--- a/optimade/filtertransformers/mongo.py
+++ b/optimade/filtertransformers/mongo.py
@@ -400,7 +400,7 @@ class MongoTransformer(Transformer):
 
         """
 
-        def check_for_known_filter(prop, expr):
+        def check_for_known_filter(_, expr):
             """ Find cases where the query dict looks like
             `{"field": {"#known": T/F}}` or
             `{"field": "$not": {"#known": T/F}}`, which is a magic word
@@ -412,15 +412,15 @@ class MongoTransformer(Transformer):
             )
 
         def replace_known_filter_with_or(subdict, prop, expr):
-            nor = set(expr.keys()) == {"$not"}
-            if nor:
+            not_ = set(expr.keys()) == {"$not"}
+            if not_:
                 expr = expr["$not"]
             if "$or" not in subdict:
                 subdict["$or"] = []
 
             known = expr["#known"]
-            subdict["$or"].append({prop: {"$exists": known ^ nor}})
-            subdict["$or"].append({prop: {("$ne" if known ^ nor else "$eq"): None}})
+            subdict["$or"].append({prop: {"$exists": known ^ not_}})
+            subdict["$or"].append({prop: {("$ne" if known ^ not_ else "$eq"): None}})
 
             subdict.pop(prop)
 

--- a/tests/filtertransformers/test_mongo.py
+++ b/tests/filtertransformers/test_mongo.py
@@ -612,7 +612,7 @@ class TestMongoTransformer(unittest.TestCase):
         self.assertEqual(
             self.transform("chemical_formula_anonymous IS KNOWN"),
             {
-                "$or": [
+                "$and": [
                     {"chemical_formula_anonymous": {"$exists": True}},
                     {"chemical_formula_anonymous": {"$ne": None}},
                 ]
@@ -621,7 +621,7 @@ class TestMongoTransformer(unittest.TestCase):
         self.assertEqual(
             self.transform("NOT chemical_formula_anonymous IS UNKNOWN"),
             {
-                "$or": [
+                "$and": [
                     {"chemical_formula_anonymous": {"$exists": True}},
                     {"chemical_formula_anonymous": {"$ne": None}},
                 ]
@@ -644,13 +644,13 @@ class TestMongoTransformer(unittest.TestCase):
             {
                 "$and": [
                     {
-                        "$or": [
+                        "$and": [
                             {"chemical_formula_hill": {"$exists": True}},
                             {"chemical_formula_hill": {"$ne": None}},
                         ]
                     },
                     {
-                        "$or": [
+                        "$and": [
                             {"chemical_formula_anonymous": {"$exists": True}},
                             {"chemical_formula_anonymous": {"$ne": None}},
                         ]
@@ -666,7 +666,7 @@ class TestMongoTransformer(unittest.TestCase):
             {
                 "$and": [
                     {
-                        "$or": [
+                        "$and": [
                             {"chemical_formula_hill": {"$exists": True}},
                             {"chemical_formula_hill": {"$ne": None}},
                         ]

--- a/tests/filtertransformers/test_mongo.py
+++ b/tests/filtertransformers/test_mongo.py
@@ -598,15 +598,44 @@ class TestMongoTransformer(unittest.TestCase):
             },
         )
 
-    def test_properties(self):
+    def test_known_properties(self):
         #  Filtering on Properties with unknown value
-        # TODO: {'$not': {'$exists': False}} can be simplified to {'$exists': True}
-        # The { $not: { $gt: 1.99 } } is different from the $lte operator. { $lte: 1.99 } returns only the documents
-        # where price field exists and its value is less than or equal to 1.99.
-        # Remember that the $not operator only affects other operators and cannot check fields and documents
-        # independently. So, use the $not operator for logical disjunctions and the $ne operator to test
-        # the contents of fields directly.
-        # source: https://docs.mongodb.com/manual/reference/operator/query/not/
+        self.assertEqual(
+            self.transform("chemical_formula_anonymous IS UNKNOWN"),
+            {
+                "$or": [
+                    {"chemical_formula_anonymous": {"$exists": False}},
+                    {"chemical_formula_anonymous": {"$eq": None}},
+                ]
+            },
+        )
+        self.assertEqual(
+            self.transform("chemical_formula_anonymous IS KNOWN"),
+            {
+                "$or": [
+                    {"chemical_formula_anonymous": {"$exists": True}},
+                    {"chemical_formula_anonymous": {"$ne": None}},
+                ]
+            },
+        )
+        self.assertEqual(
+            self.transform("NOT chemical_formula_anonymous IS UNKNOWN"),
+            {
+                "$or": [
+                    {"chemical_formula_anonymous": {"$exists": True}},
+                    {"chemical_formula_anonymous": {"$ne": None}},
+                ]
+            },
+        )
+        self.assertEqual(
+            self.transform("NOT chemical_formula_anonymous IS KNOWN"),
+            {
+                "$or": [
+                    {"chemical_formula_anonymous": {"$exists": False}},
+                    {"chemical_formula_anonymous": {"$eq": None}},
+                ]
+            },
+        )
 
         self.assertEqual(
             self.transform(
@@ -614,8 +643,40 @@ class TestMongoTransformer(unittest.TestCase):
             ),
             {
                 "$and": [
-                    {"chemical_formula_hill": {"$exists": True}},
-                    {"chemical_formula_anonymous": {"$not": {"$exists": False}}},
+                    {
+                        "$or": [
+                            {"chemical_formula_hill": {"$exists": True}},
+                            {"chemical_formula_hill": {"$ne": None}},
+                        ]
+                    },
+                    {
+                        "$or": [
+                            {"chemical_formula_anonymous": {"$exists": True}},
+                            {"chemical_formula_anonymous": {"$ne": None}},
+                        ]
+                    },
+                ]
+            },
+        )
+
+        self.assertEqual(
+            self.transform(
+                "chemical_formula_hill IS KNOWN AND chemical_formula_anonymous IS UNKNOWN"
+            ),
+            {
+                "$and": [
+                    {
+                        "$or": [
+                            {"chemical_formula_hill": {"$exists": True}},
+                            {"chemical_formula_hill": {"$ne": None}},
+                        ]
+                    },
+                    {
+                        "$or": [
+                            {"chemical_formula_anonymous": {"$exists": False}},
+                            {"chemical_formula_anonymous": {"$eq": None}},
+                        ]
+                    },
                 ]
             },
         )


### PR DESCRIPTION
Closes #254, by adding comparison against `null` during KNOWN/UNKNOWN filters.

This had to be added as another post-processor, due to the mismatch between Lark/mongo. There is also some additional logic to handle the case of e.g. `NOT x is UNKNOWN`. This was achieved by adding a dummy magic keyword "#known" when building the lark query, which is then expanded out by the post-processor after the `NOT (expr)` rule has been applied.