### PR TITLE
add providers to openapi.json

### DIFF
--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -3369,5 +3369,15 @@
         "description": "OPTIMADE-specific warning class based on OPTIMADE-specific JSON API Error.\nFrom the specification:\n\n    A warning resource object is defined similarly to a JSON API\n    error object, but MUST also include the field type, which MUST\n    have the value \"warning\". The field detail MUST be present and\n    SHOULD contain a non-critical message, e.g., reporting\n    unrecognized search attributes or deprecated features.\n\nNote: Must be named \"Warnings\", since \"Warning\" is a built-in Python class."
       }
     }
-  }
+  },
+  "servers": [
+    {
+      "url": "https://optimade.herokuapp.com/",
+      "description": "Heroku instance tracking 'master' branch of optimade-python-tools"
+    },
+    {
+      "url": "https://dev-aiida-dev.materialscloud.org/optimade-sample/optimade",
+      "description": "Database with example structures for OPTIMADE tests."
+    }
+  ]
 }

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -3376,7 +3376,7 @@
       "description": "Heroku instance tracking 'master' branch of optimade-python-tools"
     },
     {
-      "url": "https://dev-aiida-dev.materialscloud.org/optimade-sample/optimade",
+      "url": "https://aiida.materialscloud.org/optimade-sample/optimade",
       "description": "Database with example structures for OPTIMADE tests."
     }
   ]

--- a/optimade/server/config.py
+++ b/optimade/server/config.py
@@ -3,6 +3,7 @@ import json
 import logging
 from typing import Optional, Dict, List
 
+
 try:
     from typing import Literal
 except ImportError:
@@ -108,6 +109,11 @@ class ServerConfig(BaseSettings):
     index_links_path: Path = Field(
         Path(__file__).parent.joinpath("index_links.json"),
         description="Absolute path to a JSON file containing the MongoDB collection of /links resources for the index meta-database",
+    )
+
+    cors_providers_path: Path = Field(
+        Path(__file__).parent.joinpath("cors_providers.json"),
+        description="Absolute path to a JSON file containing a list of providers to add to the openapi.json file.",
     )
 
     @root_validator(pre=True)

--- a/optimade/server/cors_providers.json
+++ b/optimade/server/cors_providers.json
@@ -1,0 +1,12 @@
+{
+   "servers" : [
+      {
+         "url" : "https://optimade.herokuapp.com/",
+         "description" : "Heroku instance tracking 'master' branch of optimade-python-tools"
+      },
+      {
+         "url" : "https://dev-aiida-dev.materialscloud.org/optimade-sample/optimade",
+         "description" : "Database with example structures for OPTIMADE tests."
+      }
+   ]
+}

--- a/optimade/server/cors_providers.json
+++ b/optimade/server/cors_providers.json
@@ -5,7 +5,7 @@
          "description" : "Heroku instance tracking 'master' branch of optimade-python-tools"
       },
       {
-         "url" : "https://dev-aiida-dev.materialscloud.org/optimade-sample/optimade",
+         "url" : "https://aiida.materialscloud.org/optimade-sample/optimade",
          "description" : "Database with example structures for OPTIMADE tests."
       }
    ]

--- a/optimade/server/main.py
+++ b/optimade/server/main.py
@@ -106,8 +106,15 @@ def update_schema(app: FastAPI):
     package_root = Path(__file__).parent.parent.parent.resolve()
     if not package_root.joinpath("openapi").exists():
         os.mkdir(package_root.joinpath("openapi"))
+
+    # add list of servers to openapi spec
+    openapi = app.openapi()
+    with open(CONFIG.cors_providers_path) as f:
+        config_providers = json.load(f)
+
+    openapi.update(config_providers)
     with open(package_root.joinpath("openapi/local_openapi.json"), "w") as f:
-        json.dump(app.openapi(), f, indent=2)
+        json.dump(openapi, f, indent=2)
 
 
 @app.on_event("startup")

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -31,6 +31,7 @@ class TestSetup(unittest.TestCase):
             present = {
                 r"\.lark": False,
                 r"index_links\.json": False,
+                r"cors_providers\.json": False,
                 r"test_structures\.json": False,
                 r"test_references\.json": False,
                 r"test_links\.json": False,


### PR DESCRIPTION
fixes #193 

The OpenAPI 3 specification allows the addition of a list of servers to
the openapi.json file:
https://swagger.io/docs/specification/api-host-and-base-path/

This is can be used to get a fully interactive swagger documentation,
which also allows users to make requests.


[Try it live](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/ltalirz/optimade-python-tools/add-server-list/openapi/openapi.json)
(and, in particular, use it to try out queries)

The idea is to replace the "API Documentation" link on http://www.optimade.org/ by this


So far, this PR contains just the basics to make it work. Happy to improve configurability / think about default behavior etc.
