### PR TITLE
Add special species for adapters testing

### DIFF
--- a/optimade/adapters/structures/ase.py
+++ b/optimade/adapters/structures/ase.py
@@ -40,6 +40,13 @@ def get_ase_atoms(optimade_structure: OptimadeStructure) -> Atoms:
         species.name: species for species in attributes.species
     }
 
+    # Since we've made sure there are no species with more than 1 chemical symbol,
+    # asking for index 0 will always work.
+    if "X" in [specie.chemical_symbols[0] for specie in species.values()]:
+        raise ConversionError(
+            "ASE cannot handle structures with unknown ('X') chemical symbols, sorry."
+        )
+
     atoms = []
     for site_number in range(attributes.nsites):
         species_name = attributes.species_at_sites[site_number]

--- a/tests/adapters/structures/special_species.json
+++ b/tests/adapters/structures/special_species.json
@@ -136,5 +136,74 @@
         ]
         }
     }
+  },
+  {
+    "id": "mpf_1",
+    "type": "structures",
+    "attributes": {
+        "last_modified": "2019-06-08T05:13:37.331000",
+        "elements": [
+        "Ac"
+        ],
+        "nelements": 1,
+        "elements_ratios": [
+        1
+        ],
+        "chemical_formula_descriptive": "Ac",
+        "chemical_formula_reduced": "Ac",
+        "chemical_formula_anonymous": "A",
+        "dimension_types": [
+        1,
+        1,
+        1
+        ],
+        "lattice_vectors": [
+        [
+            1.2503264826932692,
+            0,
+            0
+        ],
+        [
+            0,
+            9.888509716321765,
+            0
+        ],
+        [
+            0,
+            0,
+            0.2972637673241818
+        ]
+        ],
+        "cartesian_site_positions": [
+        [
+            0.17570227444196573,
+            0.17570227444196573,
+            0.17570227444196573
+        ]
+        ],
+        "nsites": 1,
+        "species_at_sites": [
+        "Unknown"
+        ],
+        "species": [
+        {
+            "name": "Unknown",
+            "chemical_symbols": ["X"],
+            "concentration": [1.0]
+        }
+        ],
+        "structure_features": [],
+        "_exmpl_chemsys": "Unknown"
+    },
+    "relationships": {
+        "references": {
+        "data": [
+            {
+            "id": "dijkstra1968",
+            "type": "references"
+            }
+        ]
+        }
+    }
   }
 ]

--- a/tests/adapters/structures/test_aiida.py
+++ b/tests/adapters/structures/test_aiida.py
@@ -45,11 +45,16 @@ def test_special_species(SPECIAL_SPECIES_STRUCTURES):
     for special_structure in SPECIAL_SPECIES_STRUCTURES:
         structure = Structure(special_structure)
 
-        assert isinstance(get_aiida_structure_data(structure), StructureData)
+        aiida_structure = get_aiida_structure_data(structure)
+
+        assert isinstance(aiida_structure, StructureData)
 
         if "vacancy" in structure.attributes.species[0].chemical_symbols:
-            assert get_aiida_structure_data(structure).has_vacancies
-            assert not get_aiida_structure_data(structure).is_alloy
+            assert aiida_structure.has_vacancies
+            assert not aiida_structure.is_alloy
+        elif len(structure.attributes.species[0].chemical_symbols) > 1:
+            assert not aiida_structure.has_vacancies
+            assert aiida_structure.is_alloy
         else:
-            assert not get_aiida_structure_data(structure).has_vacancies
-            assert get_aiida_structure_data(structure).is_alloy
+            assert not aiida_structure.has_vacancies
+            assert not aiida_structure.is_alloy

--- a/tests/adapters/structures/test_ase.py
+++ b/tests/adapters/structures/test_ase.py
@@ -41,6 +41,7 @@ def test_special_species(SPECIAL_SPECIES_STRUCTURES):
 
         with pytest.raises(
             ConversionError,
-            match="ASE cannot handle structures with partial occupancies",
+            match=r"(ASE cannot handle structures with partial occupancies)|"
+            r"(ASE cannot handle structures with unknown \('X'\) chemical symbols)",
         ):
             get_ase_atoms(structure)

--- a/tests/adapters/structures/test_pymatgen.py
+++ b/tests/adapters/structures/test_pymatgen.py
@@ -1,4 +1,4 @@
-# pylint: disable=import-error,E402
+# pylint: disable=import-error
 import pytest
 
 from .utils import get_min_ver


### PR DESCRIPTION
Fixes #304

Add a structure with a species that only has chemical_symbols=["X"].
Update ASE conversion to handle this scenario as well as update AiiDA testing of this scenario.