### PR TITLE
Update links resources

### DIFF
--- a/openapi/index_openapi.json
+++ b/openapi/index_openapi.json
@@ -898,7 +898,6 @@
         "title": "LinksResource",
         "required": [
           "id",
-          "type",
           "attributes"
         ],
         "type": "object",
@@ -911,7 +910,7 @@
           "type": {
             "title": "Type",
             "type": "string",
-            "description": "MUST be either \"parent\", \"child\", or \"provider\". These objects are described in detail in sections Parent and Child Objects and Provider Objects."
+            "description": "These objects are described in detail in the section Links Endpoint"
           },
           "links": {
             "title": "Links",
@@ -958,7 +957,8 @@
           "name",
           "description",
           "base_url",
-          "homepage"
+          "homepage",
+          "link_type"
         ],
         "type": "object",
         "properties": {
@@ -1009,6 +1009,28 @@
               }
             ],
             "description": "JSON API links object, pointing to a homepage URL for this implementation"
+          },
+          "link_type": {
+            "title": "Link Type",
+            "anyOf": [
+              {
+                "const": "child",
+                "type": "string"
+              },
+              {
+                "const": "root",
+                "type": "string"
+              },
+              {
+                "const": "external",
+                "type": "string"
+              },
+              {
+                "const": "providers",
+                "type": "string"
+              }
+            ],
+            "description": "The link type of the represented resource in relation to this implementation."
           }
         },
         "description": "Links endpoint resource object attributes"

--- a/openapi/index_openapi.json
+++ b/openapi/index_openapi.json
@@ -760,7 +760,7 @@
             "description": "Reference to the child identifier object under the links endpoint that the provider has chosen as their 'default' OPTIMADE API database. A client SHOULD present this database as the first choice when an end-user chooses this provider."
           }
         },
-        "description": "Index Meta-Database Base URL Info enpoint resource"
+        "description": "Index Meta-Database Base URL Info endpoint resource"
       },
       "IndexInfoResponse": {
         "title": "IndexInfoResponse",
@@ -837,10 +837,10 @@
             "title": "Data",
             "allOf": [
               {
-                "$ref": "#/components/schemas/RelatedChildResource"
+                "$ref": "#/components/schemas/RelatedLinksResource"
               }
             ],
-            "description": "JSON API resource linkage. It MUST be either null or contain a single child identifier object with the fields 'id' and 'type'"
+            "description": "JSON API resource linkage. It MUST be either null or contain a single Links identifier object with the fields 'id' and 'type'"
           }
         },
         "description": "Index Meta-Database relationship"
@@ -1296,8 +1296,8 @@
         },
         "description": "Similar to normal JSON API relationship, but with addition of OPTIONAL meta field for a resource"
       },
-      "RelatedChildResource": {
-        "title": "RelatedChildResource",
+      "RelatedLinksResource": {
+        "title": "RelatedLinksResource",
         "required": [
           "id"
         ],
@@ -1313,7 +1313,7 @@
             "type": "string"
           }
         },
-        "description": "Keep only type and id of a ChildResource"
+        "description": "Keep only type and id of a LinksResource of type 'child'"
       },
       "RelationshipLinks": {
         "title": "RelationshipLinks",

--- a/openapi/index_openapi.json
+++ b/openapi/index_openapi.json
@@ -1012,25 +1012,8 @@
           },
           "link_type": {
             "title": "Link Type",
-            "anyOf": [
-              {
-                "const": "child",
-                "type": "string"
-              },
-              {
-                "const": "root",
-                "type": "string"
-              },
-              {
-                "const": "external",
-                "type": "string"
-              },
-              {
-                "const": "providers",
-                "type": "string"
-              }
-            ],
-            "description": "The link type of the represented resource in relation to this implementation."
+            "type": "string",
+            "description": "The link type of the represented resource in relation to this implementation. MUST any of these values: 'child', 'root', 'external', 'providers'."
           }
         },
         "description": "Links endpoint resource object attributes"

--- a/openapi/index_openapi.json
+++ b/openapi/index_openapi.json
@@ -1013,7 +1013,7 @@
           "link_type": {
             "title": "Link Type",
             "type": "string",
-            "description": "The link type of the represented resource in relation to this implementation. MUST any of these values: 'child', 'root', 'external', 'providers'."
+            "description": "The link type of the represented resource in relation to this implementation. MUST be one of these values: 'child', 'root', 'external', 'providers'."
           }
         },
         "description": "Links endpoint resource object attributes"
@@ -1296,7 +1296,7 @@
             "type": "string"
           }
         },
-        "description": "Keep only type and id of a LinksResource of type 'child'"
+        "description": "A related Links resource object"
       },
       "RelationshipLinks": {
         "title": "RelationshipLinks",

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -1794,25 +1794,8 @@
           },
           "link_type": {
             "title": "Link Type",
-            "anyOf": [
-              {
-                "const": "child",
-                "type": "string"
-              },
-              {
-                "const": "root",
-                "type": "string"
-              },
-              {
-                "const": "external",
-                "type": "string"
-              },
-              {
-                "const": "providers",
-                "type": "string"
-              }
-            ],
-            "description": "The link type of the represented resource in relation to this implementation."
+            "type": "string",
+            "description": "The link type of the represented resource in relation to this implementation. MUST any of these values: 'child', 'root', 'external', 'providers'."
           }
         },
         "description": "Links endpoint resource object attributes"

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -1795,7 +1795,7 @@
           "link_type": {
             "title": "Link Type",
             "type": "string",
-            "description": "The link type of the represented resource in relation to this implementation. MUST any of these values: 'child', 'root', 'external', 'providers'."
+            "description": "The link type of the represented resource in relation to this implementation. MUST be one of these values: 'child', 'root', 'external', 'providers'."
           }
         },
         "description": "Links endpoint resource object attributes"

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -1680,7 +1680,6 @@
         "title": "LinksResource",
         "required": [
           "id",
-          "type",
           "attributes"
         ],
         "type": "object",
@@ -1693,7 +1692,7 @@
           "type": {
             "title": "Type",
             "type": "string",
-            "description": "MUST be either \"parent\", \"child\", or \"provider\". These objects are described in detail in sections Parent and Child Objects and Provider Objects."
+            "description": "These objects are described in detail in the section Links Endpoint"
           },
           "links": {
             "title": "Links",
@@ -1740,7 +1739,8 @@
           "name",
           "description",
           "base_url",
-          "homepage"
+          "homepage",
+          "link_type"
         ],
         "type": "object",
         "properties": {
@@ -1791,6 +1791,28 @@
               }
             ],
             "description": "JSON API links object, pointing to a homepage URL for this implementation"
+          },
+          "link_type": {
+            "title": "Link Type",
+            "anyOf": [
+              {
+                "const": "child",
+                "type": "string"
+              },
+              {
+                "const": "root",
+                "type": "string"
+              },
+              {
+                "const": "external",
+                "type": "string"
+              },
+              {
+                "const": "providers",
+                "type": "string"
+              }
+            ],
+            "description": "The link type of the represented resource in relation to this implementation."
           }
         },
         "description": "Links endpoint resource object attributes"

--- a/optimade/models/index_metadb.py
+++ b/optimade/models/index_metadb.py
@@ -1,10 +1,6 @@
-from pydantic import Field, BaseModel  # pylint: disable=no-name-in-module
+# pylint: disable=no-self-argument
+from pydantic import Field, BaseModel, validator  # pylint: disable=no-name-in-module
 from typing import Union, Dict
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
 
 from .jsonapi import BaseResource
 from .baseinfo import BaseInfoAttributes, BaseInfoResource
@@ -50,10 +46,18 @@ class IndexInfoResource(BaseInfoResource):
     """Index Meta-Database Base URL Info endpoint resource"""
 
     attributes: IndexInfoAttributes = Field(...)
-    relationships: Dict[Literal["default"], IndexRelationship] = Field(
+    relationships: Union[None, Dict[str, IndexRelationship]] = Field(
         ...,
         description="Reference to the child identifier object under the links endpoint "
         "that the provider has chosen as their 'default' OPTIMADE API database. "
         "A client SHOULD present this database as the first choice when an end-user "
         "chooses this provider.",
     )
+
+    @validator("relationships")
+    def relationships_key_must_be_default(cls, value):
+        if value is not None and all([key != "default" for key in value]):
+            raise ValueError(
+                "if the relationships value is a dict, the key MUST be 'default'"
+            )
+        return value

--- a/optimade/models/index_metadb.py
+++ b/optimade/models/index_metadb.py
@@ -27,7 +27,7 @@ class IndexInfoAttributes(BaseInfoAttributes):
 
 
 class RelatedLinksResource(BaseResource):
-    """Keep only type and id of a LinksResource of type 'child'"""
+    """A related Links resource object"""
 
     type: str = Field("links", const=True)
 

--- a/optimade/models/index_metadb.py
+++ b/optimade/models/index_metadb.py
@@ -1,5 +1,10 @@
-from pydantic import Field, BaseModel
+from pydantic import Field, BaseModel  # pylint: disable=no-name-in-module
 from typing import Union, Dict
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 from .jsonapi import BaseResource
 from .baseinfo import BaseInfoAttributes, BaseInfoResource
@@ -7,7 +12,7 @@ from .baseinfo import BaseInfoAttributes, BaseInfoResource
 
 __all__ = (
     "IndexInfoAttributes",
-    "RelatedChildResource",
+    "RelatedLinksResource",
     "IndexRelationship",
     "IndexInfoResource",
 )
@@ -25,27 +30,27 @@ class IndexInfoAttributes(BaseInfoAttributes):
     )
 
 
-class RelatedChildResource(BaseResource):
-    """Keep only type and id of a ChildResource"""
+class RelatedLinksResource(BaseResource):
+    """Keep only type and id of a LinksResource of type 'child'"""
 
-    type: str = Field("child", const=True)
+    type: str = Field("links", const=True)
 
 
 class IndexRelationship(BaseModel):
     """Index Meta-Database relationship"""
 
-    data: Union[None, RelatedChildResource] = Field(
+    data: Union[None, RelatedLinksResource] = Field(
         ...,
         description="JSON API resource linkage. It MUST be either null or contain "
-        "a single child identifier object with the fields 'id' and 'type'",
+        "a single Links identifier object with the fields 'id' and 'type'",
     )
 
 
 class IndexInfoResource(BaseInfoResource):
-    """Index Meta-Database Base URL Info enpoint resource"""
+    """Index Meta-Database Base URL Info endpoint resource"""
 
     attributes: IndexInfoAttributes = Field(...)
-    relationships: Dict[str, IndexRelationship] = Field(
+    relationships: Dict[Literal["default"], IndexRelationship] = Field(
         ...,
         description="Reference to the child identifier object under the links endpoint "
         "that the provider has chosen as their 'default' OPTIMADE API database. "

--- a/optimade/models/links.py
+++ b/optimade/models/links.py
@@ -1,6 +1,16 @@
 # pylint: disable=no-self-argument
-from pydantic import Field, AnyUrl, validator, root_validator
+from pydantic import (  # pylint: disable=no-name-in-module
+    Field,
+    AnyUrl,
+    validator,
+    root_validator,
+)
 from typing import Union
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 from .jsonapi import Link, Attributes
 from .entries import EntryResource
@@ -9,9 +19,6 @@ from .entries import EntryResource
 __all__ = (
     "LinksResourceAttributes",
     "LinksResource",
-    "ChildResource",
-    "ParentResource",
-    "ProviderResource",
 )
 
 
@@ -38,15 +45,19 @@ class LinksResourceAttributes(Attributes):
         description="JSON API links object, pointing to a homepage URL for this implementation",
     )
 
+    link_type: Literal["child", "root", "external", "providers"] = Field(
+        ...,
+        description="The link type of the represented resource in relation to this implementation.",
+    )
+
 
 class LinksResource(EntryResource):
     """A Links endpoint resource object"""
 
     type: str = Field(
-        ...,
-        description='MUST be either "parent", "child", or "provider". '
-        "These objects are described in detail in sections Parent and Child Objects "
-        "and Provider Objects.",
+        "links",
+        const=True,
+        description="These objects are described in detail in the section Links Endpoint",
     )
 
     attributes: LinksResourceAttributes = Field(
@@ -55,34 +66,8 @@ class LinksResource(EntryResource):
         "entry's properties.",
     )
 
-    @validator("type")
-    def type_must_be_in_specific_set(cls, value):
-        if value not in {"parent", "child", "provider"}:
-            raise ValueError(
-                "name of Links endpoint resource MUST be either 'parent, 'child', or 'provider'"
-            )
-        return value
-
     @root_validator(pre=True)
     def relationships_must_not_be_present(cls, values):
         if values.get("relationships", None) is not None:
             raise ValueError('"relationships" is not allowed for links resources')
         return values
-
-
-class ChildResource(LinksResource):
-    """A child object representing a link to an implementation exactly one layer below the current implementation"""
-
-    type: str = Field("child", const=True)
-
-
-class ParentResource(LinksResource):
-    """A parent object representing a link to an implementation exactly one layer above the current implementation"""
-
-    type: str = Field("parent", const=True)
-
-
-class ProviderResource(LinksResource):
-    """A provider object representing a link to another index meta-database by another database provider"""
-
-    type: str = Field("provider", const=True)

--- a/optimade/models/links.py
+++ b/optimade/models/links.py
@@ -2,7 +2,6 @@
 from pydantic import (  # pylint: disable=no-name-in-module
     Field,
     AnyUrl,
-    validator,
     root_validator,
 )
 from typing import Union

--- a/optimade/models/links.py
+++ b/optimade/models/links.py
@@ -2,14 +2,10 @@
 from pydantic import (  # pylint: disable=no-name-in-module
     Field,
     AnyUrl,
+    validator,
     root_validator,
 )
 from typing import Union
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
 
 from .jsonapi import Link, Attributes
 from .entries import EntryResource
@@ -44,10 +40,18 @@ class LinksResourceAttributes(Attributes):
         description="JSON API links object, pointing to a homepage URL for this implementation",
     )
 
-    link_type: Literal["child", "root", "external", "providers"] = Field(
+    link_type: str = Field(
         ...,
-        description="The link type of the represented resource in relation to this implementation.",
+        description="The link type of the represented resource in relation to this implementation. MUST any of these values: 'child', 'root', 'external', 'providers'.",
     )
+
+    @validator("link_type")
+    def link_type_must_be_in_specific_set(cls, value):
+        if value not in {"child", "root", "external", "providers"}:
+            raise ValueError(
+                "link_type MUST be either 'child, 'root', 'external', or 'providers'"
+            )
+        return value
 
 
 class LinksResource(EntryResource):

--- a/optimade/models/links.py
+++ b/optimade/models/links.py
@@ -42,7 +42,7 @@ class LinksResourceAttributes(Attributes):
 
     link_type: str = Field(
         ...,
-        description="The link type of the represented resource in relation to this implementation. MUST any of these values: 'child', 'root', 'external', 'providers'.",
+        description="The link type of the represented resource in relation to this implementation. MUST be one of these values: 'child', 'root', 'external', 'providers'.",
     )
 
     @validator("link_type")

--- a/optimade/server/data/test_links.json
+++ b/optimade/server/data/test_links.json
@@ -4,10 +4,11 @@
       "$oid": "696e646578706172656e7430"
     },
     "id": "index",
-    "type": "parent",
+    "type": "links",
     "name": "Index meta-database",
     "description": "Index for example's OPTIMADE databases",
     "base_url": "http://localhost:5001",
-    "homepage": "https://example.com"
+    "homepage": "https://example.com",
+    "link_type": "root"
   }
 ]

--- a/optimade/server/index_links.json
+++ b/optimade/server/index_links.json
@@ -1,10 +1,11 @@
 [
   {
     "id": "test_server",
-    "type": "child",
+    "type": "links",
     "name": "OPTIMADE API",
     "description": "The [Open Databases Integration for Materials Design (OPTIMADE) consortium](https://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.",
     "base_url": "http://localhost:5000",
-    "homepage": "https://example.com"
+    "homepage": "https://example.com",
+    "link_type": "child"
   }
 ]

--- a/optimade/server/routers/index_info.py
+++ b/optimade/server/routers/index_info.py
@@ -10,6 +10,7 @@ from optimade.models import (
     IndexInfoAttributes,
     IndexInfoResource,
     IndexRelationship,
+    RelatedLinksResource,
 )
 
 from optimade.server.config import CONFIG
@@ -47,7 +48,12 @@ def get_info(request: Request):
             ),
             relationships={
                 "default": IndexRelationship(
-                    data={"type": "child", "id": CONFIG.default_db}
+                    data={
+                        "type": RelatedLinksResource.schema()["properties"]["type"][
+                            "const"
+                        ],
+                        "id": CONFIG.default_db,
+                    }
                 )
             },
         ),

--- a/optimade/validator/validator.py
+++ b/optimade/validator/validator.py
@@ -620,15 +620,12 @@ class ImplementationValidator:
         response = self.client.get(request_str)
 
         if response.status_code != 200:
-            error_titles = [
-                error.get("title", "") for error in response.json().get("errors", [])
-            ]
-            error_details = [
-                error.get("detail", "") for error in response.json().get("errors", [])
-            ]
-            message = f"Request to '{request_str}' returned HTTP code {response.status_code}. Errors:\n"
-            for error_title, error_detail in zip(error_titles, error_details):
-                message += f"{error_title}: {error_details}"
+            message = (
+                f"Request to '{request_str}' returned HTTP code {response.status_code}."
+            )
+            message += "\nError(s):"
+            for error in response.json().get("errors", []):
+                message += f'\n  {error.get("title", "N/A")}: {error.get("detail", "N/A")} ({error.get("source", {}).get("pointer", "N/A")})'
             raise ResponseError(message)
 
         return response, "request successful."

--- a/tests/server/test_query_params.py
+++ b/tests/server/test_query_params.py
@@ -196,7 +196,7 @@ class ResponseFieldTests(SetClient, unittest.TestCase):
         illegal_top_level_field = "relationships"
         non_used_top_level_fields = {"links"}
         non_used_top_level_fields.add(illegal_top_level_field)
-        expected_fields = {"homepage", "base_url"}
+        expected_fields = {"homepage", "base_url", "link_type"}
         self.required_fields_test_helper(
             endpoint, non_used_top_level_fields, expected_fields
         )


### PR DESCRIPTION
Fixes #299

This PR implements the upcoming changes to the `LinksResource`, updating the OpenAPIs from the pydantic models as well as the related tests.

`ChildResource`, `ParentResource`, and `ProviderResource` has all been removed. They were not used in any case, and the new `link_type` has gotten the `Literal` type to "validate" the value.

Note: This PR will fail until providers.optimade.org updates their links resources to the new schema, and changes may still occur, since the update has not yet been merged into the OPTIMADE API specification.