### PR TITLE
Represent the datetime objects as UTC in RFC3339 format

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -41,7 +41,7 @@ conda create -n optimade python=3.7
 conda activate optimade
 
 # Install package and dependencies in editable mode (including "dev" requirements).
-pip install -e .[dev]
+pip install -e ".[dev]"
 
 # Run the tests with pytest
 py.test

--- a/optimade/models/jsonapi.py
+++ b/optimade/models/jsonapi.py
@@ -1,6 +1,7 @@
 """This module should reproduce JSON API v1.0 https://jsonapi.org/format/1.0/"""
 # pylint: disable=no-self-argument
 from typing import Optional, Union, List
+from datetime import datetime, timezone
 from pydantic import (  # pylint: disable=no-name-in-module
     BaseModel,
     AnyUrl,
@@ -286,3 +287,10 @@ class Response(BaseModel):
                 f"At least one of {required_fields} MUST be specified in the top-level response"
             )
         return values
+
+    class Config:
+        json_encoders = {
+            datetime: lambda v: v.astimezone(timezone.utc).strftime(
+                "%Y-%m-%dT%H:%M:%SZ"
+            ),
+        }

--- a/optimade/run.py
+++ b/optimade/run.py
@@ -1,0 +1,9 @@
+from optimade.server.main import app
+from optimade.server.config import CONFIG
+
+if __name__ == "__main__":
+    import uvicorn
+
+    CONFIG.debug = True
+
+    uvicorn.run(app, host="0.0.0.0", port=5000)

--- a/optimade/run.py
+++ b/optimade/run.py
@@ -1,9 +1,0 @@
-from optimade.server.main import app
-from optimade.server.config import CONFIG
-
-if __name__ == "__main__":
-    import uvicorn
-
-    CONFIG.debug = True
-
-    uvicorn.run(app, host="0.0.0.0", port=5000)

--- a/optimade/server/routers/utils.py
+++ b/optimade/server/routers/utils.py
@@ -56,7 +56,7 @@ def meta_values(
     return ResponseMeta(
         query=ResponseMetaQuery(representation=f"{url_path}?{parse_result.query}"),
         api_version=f"v{__api_version__}",
-        time_stamp=datetime.utcnow(),
+        time_stamp=datetime.now(),
         data_returned=data_returned,
         more_data_available=more_data_available,
         provider=CONFIG.provider,


### PR DESCRIPTION
Fixing #288 

According to the conversation in the issue, the response always returns with the UTC time in RFC3339 format even if it is not aligned to the actual timezone where the API is running.
