### PR TITLE
Fix 'publish_TestPyPI' CI job

### DIFF
--- a/.github/workflows/deps_lint.yml
+++ b/.github/workflows/deps_lint.yml
@@ -215,7 +215,7 @@ jobs:
       run: mkdocs build
 
   publish_TestPyPI:
-    if: github.event == 'push'
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Fixes #331 

Use `github.event_name` instead of `github.event`.
See the difference [here](https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#github-context).

Tested this in my fork, it ran for a push to my `master` branch (which is the top CI run requirement), see the action run [here](https://github.com/CasperWA/optimade-python-tools/runs/765374990?check_suite_focus=true).
Never mind that it fails, this is due to my fork not having the correct secret.

The last two tests that this works lies in making sure that:
- [ ] The job 'publish_TestPyPI' is skipped for this PR, and
- [ ] The job is _not_ skipped when merging this in and that it succeeds (naturally).