### PR TITLE
Another fix for release pipeline

### DIFF
--- a/.github/workflows/publish-on-pypi.yml
+++ b/.github/workflows/publish-on-pypi.yml
@@ -76,7 +76,7 @@ jobs:
         access-token: ${{ secrets.OPTIMADE_PYTHON_TOOLS_RELEASE_TOKEN }}
         owner: benjefferies
         enforce_admins: true
-        branch: maste
+        branch: master
 
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-on-pypi.yml
+++ b/.github/workflows/publish-on-pypi.yml
@@ -55,11 +55,28 @@ jobs:
         echo "::set-env name=push::0"
         git commit -m 'Release Updates' && echo "::set-env name=push::1" || echo "No changes to CHANGELOG.md"
 
+    - name: Temporarily disable "include administrators" branch protection
+      uses: benjefferies/branch-protection-bot@master
+      if: env.push == 1
+      with:
+        access-token: ${{ secrets.OPTIMADE_PYTHON_TOOLS_RELEASE_TOKEN }}
+        branch: master
+        enforce_admins: false
+
     - name: Push changes
       if: env.push == 1
       uses: ad-m/github-push-action@master
       with:
         github_token: ${{ secrets.OPTIMADE_PYTHON_TOOLS_RELEASE_TOKEN }}
+
+    - name: Enable "include administrators" branch protection
+      uses: benjefferies/branch-protection-bot@master
+      if: always()  # Force to always run this step to ensure "include administrators" is always turned back on
+      with:
+        access-token: ${{ secrets.OPTIMADE_PYTHON_TOOLS_RELEASE_TOKEN }}
+        owner: benjefferies
+        enforce_admins: true
+        branch: maste
 
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds in a temp branch unprotect/reprotect steps to enable pushing release changes to the repo. 
