### PR TITLE
Retrieve providers list if no submodule is found

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "providers"]
 	path = providers
-	url = git@github.com:Materials-Consortia/providers.git
+	url = https://github.com/Materials-Consortia/providers.git

--- a/optimade/server/data/__init__.py
+++ b/optimade/server/data/__init__.py
@@ -12,5 +12,9 @@ data_paths = {
 
 
 for var, path in data_paths.items():
-    with open(Path(__file__).parent / path) as f:
-        globals()[var] = bson.json_util.loads(f.read())
+    try:
+        with open(Path(__file__).parent / path) as f:
+            globals()[var] = bson.json_util.loads(f.read())
+    except FileNotFoundError:
+        if var != "providers":
+            raise

--- a/optimade/server/routers/utils.py
+++ b/optimade/server/routers/utils.py
@@ -306,7 +306,7 @@ def mongo_id_for_database(database_id: str, database_type: str) -> str:
 
 
 def get_providers():
-    """Retrieve Materials-Consortia providers (from https://providers.optimade.org/providers.json)"""
+    """Retrieve Materials-Consortia providers (from https://providers.optimade.org/v1/links)"""
     import requests
 
     try:

--- a/optimade/server/routers/utils.py
+++ b/optimade/server/routers/utils.py
@@ -22,7 +22,6 @@ from optimade.server.config import CONFIG
 from optimade.server.entry_collections import EntryCollection
 from optimade.server.exceptions import BadRequest
 from optimade.server.query_params import EntryListingQueryParams, SingleEntryQueryParams
-from optimade.server.data import providers
 
 ENTRY_INFO_SCHEMAS = {
     "structures": StructureResource.schema,
@@ -308,6 +307,31 @@ def mongo_id_for_database(database_id: str, database_type: str) -> str:
 
 def get_providers():
     """Retrieve Materials-Consortia providers (from https://providers.optimade.org/providers.json)"""
+    import requests
+
+    try:
+        from optimade.server.data import providers
+    except ImportError:
+        providers = None
+
+    if providers is None:
+        try:
+            import simplejson as json
+        except ImportError:
+            import json
+
+        try:
+            providers = requests.get("https://providers.optimade.org/v1/links").json()
+        except (
+            requests.exceptions.ConnectionError,
+            requests.exceptions.ConnectTimeout,
+            json.JSONDecodeError,
+        ):
+            raise BadRequest(
+                status_code=500,
+                detail="Could not retrieve providers list from https://providers.optimade.org",
+            )
+
     providers_list = []
     for provider in providers.get("data", []):
         # Remove/skip "exmpl"


### PR DESCRIPTION
Fixes #373 

The logic is now:
1. Try to fetch providers from `optimade.server.data:providers.json`.
2. If not found, try to fetch providers from https://providers.optimade.org/v1/links.
3. If not found, raise.