### PR TITLE
Fix publish workflow - final(TM) fix

### DIFF
--- a/.github/workflows/publish-on-pypi.yml
+++ b/.github/workflows/publish-on-pypi.yml
@@ -38,6 +38,22 @@ jobs:
         branch: ${{ env.PUBLISH_UPDATE_BRANCH }}
         changes: .github/workflows/update_changelog.sh
         unprotect_reviews: true
+        sleep: 15
+
+    - name: Update tag to latest commit (getting the newest version locally)
+      run: |
+        git config --local user.email "dev@optimade.org"
+        git config --local user.name "OPTIMADE Developers"
+
+        git fetch origin
+        git branch ${{ env.PUBLISH_UPDATE_BRANCH }} origin/${{ env.PUBLISH_UPDATE_BRANCH }}
+        git checkout ${{ env.PUBLISH_UPDATE_BRANCH }}
+
+        TAG_MSG=.github/workflows/release_tag_msg.txt
+        sed -i "s|TAG_NAME|${GITHUB_REF#refs/tags/}|" "${TAG_MSG}"
+
+        git tag -af -F "${TAG_MSG}" ${GITHUB_REF#refs/tags/}
+        git push -f --tags
 
     - name: Build source distribution
       run: python ./setup.py sdist
@@ -47,19 +63,6 @@ jobs:
       with:
         user: __token__
         password: ${{ secrets.PYPI_PASSWORD }}
-
-    - name: Update tag to latest commit
-      run: |
-        git config --local user.email "dev@optimade.org"
-        git config --local user.name "OPTIMADE Developers"
-
-        git fetch origin
-
-        TAG_MSG=.github/workflows/release_tag_msg.txt
-        sed -i "s|TAG_NAME|${GITHUB_REF#refs/tags/}|" "${TAG_MSG}"
-
-        git tag -af -F "${TAG_MSG}" ${GITHUB_REF#refs/tags/} origin/${{ env.PUBLISH_UPDATE_BRANCH }}
-        git push -f --tags
 
     - name: Build docs
       run: mkdocs build

--- a/.gitignore
+++ b/.gitignore
@@ -4,33 +4,16 @@ __pycache__/
 *.py[cod]
 *$py.class
 
-# C extensions
-*.so
-
 # Distribution / packaging
-.Python
 build/
-develop-eggs/
 dist/
-downloads/
 eggs/
 .eggs/
-lib/
-lib64/
-parts/
 sdist/
-var/
 wheels/
 *.egg-info/
-.installed.cfg
 *.egg
 MANIFEST
-
-# PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.manifest
-*.spec
 
 # Installer logs
 pip-log.txt
@@ -38,18 +21,10 @@ pip-delete-this-directory.txt
 
 # Unit test / coverage reports
 htmlcov/
-.tox/
 .coverage
 .coverage.*
 .cache
-nosetests.xml
 coverage.xml
-*.cover
-.hypothesis/
-
-# Translations
-*.mo
-*.pot
 
 # Django stuff:
 *.log
@@ -57,30 +32,8 @@ coverage.xml
 .media/
 local_settings.py
 
-# Flask stuff:
-instance/
-.webassets-cache
-
-# Scrapy stuff:
-.scrapy
-
-# Sphinx documentation
-docs/_build/
-
-# PyBuilder
-target/
-
-# Jupyter Notebook
-.ipynb_checkpoints
-
 # pyenv
 .python-version
-
-# celery beat schedule file
-celerybeat-schedule
-
-# SageMath parsed files
-*.sage.py
 
 # Environments
 .env
@@ -95,25 +48,19 @@ venv.bak/
 .spyderproject
 .spyproject
 
-# Rope project settings
-.ropeproject
-
 # VSCode project settings
 .vscode
 
 # mkdocs documentation
 /site
 
-# mypy
-.mypy_cache/
-
 # pytest
 .pytest_cache/
 
+# Mac
 .DS_Store
 .idea/
 
-Untitled.ipynb
+# Package-specific
 local_openapi.json
 local_index_openapi.json
-server.cfg


### PR DESCRIPTION
So it seems the new publish workflow [sort of worked](https://github.com/Materials-Consortia/optimade-python-tools/runs/811937882?check_suite_focus=true) - only it didn't actually publish correctly on PyPI.
This was due to the fact that the local checked out version was wrong, and still the original one prior to updating the version, changelog and all.
This fix moves the step, where the tag is force pushed to the newest commit up before the creation of the source distribution and subsequent publishing on PyPI. This will automatically checkout the newly created commit as well.

Also, up the pre-sleep time before "waiting" in the new Action publish workflow to 15 seconds (default is 5 seconds).

This also shaves down the `.gitignore` file, trying to remove all the unrelevant lines.