### PR TITLE
Update models, endpoints and responses to 1.0.0

### DIFF
--- a/default_config.json
+++ b/default_config.json
@@ -21,9 +21,9 @@
         "name": "Example provider",
         "description": "Provider used for examples, not to be assigned to a real database",
         "prefix": "exmpl",
-        "homepage": "https://example.com",
-        "index_base_url": "http://localhost:5001"
+        "homepage": "https://example.com"
     },
+    "index_base_url": "http://localhost:5001",
     "provider_fields": {},
     "aliases": {},
     "length_aliases": {},

--- a/example_config.json
+++ b/example_config.json
@@ -17,9 +17,9 @@
         "name": "Example provider",
         "description": "Provider used for examples, not to be assigned to a real database",
         "prefix": "exmpl",
-        "homepage": "https://example.com",
-        "index_base_url": "https://example.com/index"
+        "homepage": "https://example.com"
     },
+    "index_base_url": "http://localhost:5001",
     "provider_fields": {
         "structures": [
             "band_gap",

--- a/openapi/index_openapi.json
+++ b/openapi/index_openapi.json
@@ -1256,25 +1256,6 @@
               }
             ],
             "description": "a [JSON API links object](http://jsonapi.org/format/1.0#document-links) pointing to homepage of the database provider, either directly as a string, or as a link object."
-          },
-          "index_base_url": {
-            "title": "Index Base Url",
-            "anyOf": [
-              {
-                "type": "string",
-                "minLength": 1,
-                "maxLength": 65536,
-                "format": "uri"
-              },
-              {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/Link"
-                  }
-                ]
-              }
-            ],
-            "description": "a [JSON API links object](http://jsonapi.org/format/1.0#document-links) pointing to the base URL for the `index` meta-database as specified in Appendix 1, either directly as a string, or as a link object."
           }
         },
         "description": "Information on the database provider of the implementation."

--- a/openapi/index_openapi.json
+++ b/openapi/index_openapi.json
@@ -228,6 +228,29 @@
           }
         }
       }
+    },
+    "/versions": {
+      "get": {
+        "tags": [
+          "Versions"
+        ],
+        "summary": "Get Versions",
+        "description": "Respond with the text/csv representation for the served versions.",
+        "operationId": "get_versions_versions_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              },
+              "text/csv": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {

--- a/openapi/index_openapi.json
+++ b/openapi/index_openapi.json
@@ -241,11 +241,10 @@
           "200": {
             "description": "Successful Response",
             "content": {
-              "application/json": {
-                "schema": {}
-              },
               "text/csv": {
-                "schema": {}
+                "schema": {
+                  "type": "string"
+                }
               }
             }
           }
@@ -1606,7 +1605,7 @@
           "representation": {
             "title": "Representation",
             "type": "string",
-            "description": "A string with the part of the URL following the versioned or unversioned base URL that serves the API.\nQuery parameters that have not been used in processing the request MAY be omitted.\nIn particular, if no query parameters have been involved in processing the request, the query pary of the URL MAY be excluded.\nExample: `/structures?filter=nelements=2`"
+            "description": "A string with the part of the URL following the versioned or unversioned base URL that serves the API.\nQuery parameters that have not been used in processing the request MAY be omitted.\nIn particular, if no query parameters have been involved in processing the request, the query part of the URL MAY be excluded.\nExample: `/structures?filter=nelements=2`"
           }
         },
         "description": "Information on the query that was requested. "

--- a/openapi/index_openapi.json
+++ b/openapi/index_openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "OPTIMADE API - Index meta-database",
     "description": "The [Open Databases Integration for Materials Design (OPTIMADE) consortium](https://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.\nThis is the \"special\" index meta-database.\n\nThis specification is generated using [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools/tree/v0.9.7) v0.9.7.",
-    "version": "1.0.0-rc.2"
+    "version": "1.0.0"
   },
   "paths": {
     "/info": {
@@ -282,7 +282,7 @@
             "title": "Version",
             "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "type": "string",
-            "description": "A string containing the full version number of the API served at that versioned base URL. The version number string MUST NOT be prefixed by, e.g., 'v'."
+            "description": "A string containing the full version number of the API served at that versioned base URL.\nThe version number string MUST NOT be prefixed by, e.g., 'v'.\nExamples: `1.0.0`, `1.0.0-rc.2`."
           }
         },
         "description": "A JSON object containing information about an available API version"
@@ -524,6 +524,7 @@
       "ErrorResponse": {
         "title": "ErrorResponse",
         "required": [
+          "meta",
           "errors"
         ],
         "type": "object",
@@ -640,13 +641,43 @@
             "type": "string",
             "description": "version string of the current implementation"
           },
+          "homepage": {
+            "title": "Homepage",
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 65536,
+                "format": "uri"
+              },
+              {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Link"
+                  }
+                ]
+              }
+            ],
+            "description": "A [JSON API links object](http://jsonapi.org/format/1.0/#document-links) pointing to the homepage of the implementation."
+          },
           "source_url": {
             "title": "Source Url",
-            "maxLength": 65536,
-            "minLength": 1,
-            "type": "string",
-            "description": "URL of the implementation source, either downloadable archive or version control system",
-            "format": "uri"
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 65536,
+                "format": "uri"
+              },
+              {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Link"
+                  }
+                ]
+              }
+            ],
+            "description": "A [JSON API links object](http://jsonapi.org/format/1.0/#document-links) pointing to the implementation source, either downloadable archive or version control system."
           },
           "maintainer": {
             "title": "Maintainer",
@@ -690,7 +721,7 @@
             "title": "Api Version",
             "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "type": "string",
-            "description": "Presently used version of the OPTIMADE API"
+            "description": "Presently used full version of the OPTIMADE API.\nThe version number string MUST NOT be prefixed by, e.g., \"v\".\nExamples: `1.0.0`, `1.0.0-rc.2`."
           },
           "available_api_versions": {
             "title": "Available Api Versions",
@@ -789,7 +820,8 @@
       "IndexInfoResponse": {
         "title": "IndexInfoResponse",
         "required": [
-          "data"
+          "data",
+          "meta"
         ],
         "type": "object",
         "properties": {
@@ -1066,7 +1098,8 @@
       "LinksResponse": {
         "title": "LinksResponse",
         "required": [
-          "data"
+          "data",
+          "meta"
         ],
         "type": "object",
         "properties": {
@@ -1236,7 +1269,7 @@
           "prefix": {
             "title": "Prefix",
             "type": "string",
-            "description": "database-provider-specific prefix as found in Appendix 1."
+            "description": "database-provider-specific prefix as found in section Database-Provider-Specific Namespace Prefixes."
           },
           "homepage": {
             "title": "Homepage",
@@ -1463,10 +1496,7 @@
         "required": [
           "query",
           "api_version",
-          "time_stamp",
-          "data_returned",
-          "more_data_available",
-          "provider"
+          "more_data_available"
         ],
         "type": "object",
         "properties": {
@@ -1483,7 +1513,31 @@
             "title": "Api Version",
             "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "type": "string",
-            "description": "A string containing the version of the API implementation."
+            "description": "Presently used full version of the OPTIMADE API.\nThe version number string MUST NOT be prefixed by, e.g., \"v\".\nExamples: `1.0.0`, `1.0.0-rc.2`."
+          },
+          "more_data_available": {
+            "title": "More Data Available",
+            "type": "boolean",
+            "description": "`false` if the response contains all data for the request (e.g., a request issued to a single entry endpoint, or a `filter` query at the last page of a paginated response) and `true` if the response is incomplete in the sense that multiple objects match the request, and not all of them have been included in the response (e.g., a query with multiple pages that is not at the last page)."
+          },
+          "schema": {
+            "title": "Schema",
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 65536,
+                "format": "uri"
+              },
+              {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Link"
+                  }
+                ]
+              }
+            ],
+            "description": "A [JSON API links object](http://jsonapi.org/format/1.0/#document-links) that points to a schema for the response.\nIf it is a string, or a dictionary containing no `meta` field, the provided URL MUST point at an [OpenAPI](https://swagger.io/specification/) schema.\nIt is possible that future versions of this specification allows for alternative schema types.\nHence, if the `meta` field of the JSON API links object is provided and contains a field `schema_type` that is not equal to the string `OpenAPI` the client MUST not handle failures to parse the schema or to validate the response against the schema as errors."
           },
           "time_stamp": {
             "title": "Time Stamp",
@@ -1496,11 +1550,6 @@
             "minimum": 0.0,
             "type": "integer",
             "description": "An integer containing the total number of data resource objects returned for the current `filter` query, independent of pagination."
-          },
-          "more_data_available": {
-            "title": "More Data Available",
-            "type": "boolean",
-            "description": "`false` if all data resource objects for this `filter` query have been returned in the response or if it is the last page of a paginated response, and `true` otherwise."
           },
           "provider": {
             "title": "Provider",
@@ -1557,7 +1606,7 @@
           "representation": {
             "title": "Representation",
             "type": "string",
-            "description": "a string with the part of the URL that follows the base URL. Example: '/structures?'"
+            "description": "A string with the part of the URL following the versioned or unversioned base URL that serves the API.\nQuery parameters that have not been used in processing the request MAY be omitted.\nIn particular, if no query parameters have been involved in processing the request, the query pary of the URL MAY be excluded.\nExample: `/structures?filter=nelements=2`"
           }
         },
         "description": "Information on the query that was requested. "

--- a/openapi/index_openapi.json
+++ b/openapi/index_openapi.json
@@ -6,20 +6,20 @@
     "version": "1.0.0-rc.2"
   },
   "paths": {
-    "/v1/info": {
+    "/info": {
       "get": {
         "tags": [
           "Info"
         ],
         "summary": "Get Info",
-        "operationId": "get_info_v1_info_get",
+        "operationId": "get_info_info_get",
         "responses": {
           "200": {
             "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Response Get Info V1 Info Get",
+                  "title": "Response Get Info Info Get",
                   "anyOf": [
                     {
                       "$ref": "#/components/schemas/IndexInfoResponse"
@@ -35,13 +35,13 @@
         }
       }
     },
-    "/v1/links": {
+    "/links": {
       "get": {
         "tags": [
           "Links"
         ],
         "summary": "Get Links",
-        "operationId": "get_links_v1_links_get",
+        "operationId": "get_links_links_get",
         "parameters": [
           {
             "description": "A filter string, in the format described in section API Filtering Format Specification of the specification.",
@@ -203,7 +203,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Response Get Links V1 Links Get",
+                  "title": "Response Get Links Links Get",
                   "anyOf": [
                     {
                       "$ref": "#/components/schemas/LinksResponse"

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -2075,25 +2075,6 @@
               }
             ],
             "description": "a [JSON API links object](http://jsonapi.org/format/1.0#document-links) pointing to homepage of the database provider, either directly as a string, or as a link object."
-          },
-          "index_base_url": {
-            "title": "Index Base Url",
-            "anyOf": [
-              {
-                "type": "string",
-                "minLength": 1,
-                "maxLength": 65536,
-                "format": "uri"
-              },
-              {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/Link"
-                  }
-                ]
-              }
-            ],
-            "description": "a [JSON API links object](http://jsonapi.org/format/1.0#document-links) pointing to the base URL for the `index` meta-database as specified in Appendix 1, either directly as a string, or as a link object."
           }
         },
         "description": "Information on the database provider of the implementation."

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "OPTIMADE API",
     "description": "The [Open Databases Integration for Materials Design (OPTIMADE) consortium](https://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.\n\nThis specification is generated using [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools/tree/v0.9.7) v0.9.7.",
-    "version": "1.0.0-rc.2"
+    "version": "1.0.0"
   },
   "paths": {
     "/info": {
@@ -950,7 +950,7 @@
             "title": "Version",
             "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "type": "string",
-            "description": "A string containing the full version number of the API served at that versioned base URL. The version number string MUST NOT be prefixed by, e.g., 'v'."
+            "description": "A string containing the full version number of the API served at that versioned base URL.\nThe version number string MUST NOT be prefixed by, e.g., 'v'.\nExamples: `1.0.0`, `1.0.0-rc.2`."
           }
         },
         "description": "A JSON object containing information about an available API version"
@@ -969,7 +969,7 @@
             "title": "Api Version",
             "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "type": "string",
-            "description": "Presently used version of the OPTIMADE API"
+            "description": "Presently used full version of the OPTIMADE API.\nThe version number string MUST NOT be prefixed by, e.g., \"v\".\nExamples: `1.0.0`, `1.0.0-rc.2`."
           },
           "available_api_versions": {
             "title": "Available Api Versions",
@@ -1126,7 +1126,7 @@
           "unit": {
             "title": "Unit",
             "type": "string",
-            "description": "The physical unit of the entry property.\nIt is RECOMMENDED that non-standard (non-SI) units are described in the description for the property."
+            "description": "The physical unit of the entry property.\nThis MUST be a valid representation of units according to version 2.1 of [The Unified Code for Units of Measure](https://unitsofmeasure.org/ucum.html).\nIt is RECOMMENDED that non-standard (non-SI) units are described in the description for the property."
           },
           "sortable": {
             "title": "Sortable",
@@ -1196,7 +1196,8 @@
       "EntryInfoResponse": {
         "title": "EntryInfoResponse",
         "required": [
-          "data"
+          "data",
+          "meta"
         ],
         "type": "object",
         "properties": {
@@ -1449,6 +1450,7 @@
       "ErrorResponse": {
         "title": "ErrorResponse",
         "required": [
+          "meta",
           "errors"
         ],
         "type": "object",
@@ -1565,13 +1567,43 @@
             "type": "string",
             "description": "version string of the current implementation"
           },
+          "homepage": {
+            "title": "Homepage",
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 65536,
+                "format": "uri"
+              },
+              {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Link"
+                  }
+                ]
+              }
+            ],
+            "description": "A [JSON API links object](http://jsonapi.org/format/1.0/#document-links) pointing to the homepage of the implementation."
+          },
           "source_url": {
             "title": "Source Url",
-            "maxLength": 65536,
-            "minLength": 1,
-            "type": "string",
-            "description": "URL of the implementation source, either downloadable archive or version control system",
-            "format": "uri"
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 65536,
+                "format": "uri"
+              },
+              {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Link"
+                  }
+                ]
+              }
+            ],
+            "description": "A [JSON API links object](http://jsonapi.org/format/1.0/#document-links) pointing to the implementation source, either downloadable archive or version control system."
           },
           "maintainer": {
             "title": "Maintainer",
@@ -1604,7 +1636,8 @@
       "InfoResponse": {
         "title": "InfoResponse",
         "required": [
-          "data"
+          "data",
+          "meta"
         ],
         "type": "object",
         "properties": {
@@ -1862,7 +1895,8 @@
       "LinksResponse": {
         "title": "LinksResponse",
         "required": [
-          "data"
+          "data",
+          "meta"
         ],
         "type": "object",
         "properties": {
@@ -2055,7 +2089,7 @@
           "prefix": {
             "title": "Prefix",
             "type": "string",
-            "description": "database-provider-specific prefix as found in Appendix 1."
+            "description": "database-provider-specific prefix as found in section Database-Provider-Specific Namespace Prefixes."
           },
           "homepage": {
             "title": "Homepage",
@@ -2338,7 +2372,8 @@
       "ReferenceResponseMany": {
         "title": "ReferenceResponseMany",
         "required": [
-          "data"
+          "data",
+          "meta"
         ],
         "type": "object",
         "properties": {
@@ -2421,7 +2456,8 @@
       "ReferenceResponseOne": {
         "title": "ReferenceResponseOne",
         "required": [
-          "data"
+          "data",
+          "meta"
         ],
         "type": "object",
         "properties": {
@@ -2637,10 +2673,7 @@
         "required": [
           "query",
           "api_version",
-          "time_stamp",
-          "data_returned",
-          "more_data_available",
-          "provider"
+          "more_data_available"
         ],
         "type": "object",
         "properties": {
@@ -2657,7 +2690,31 @@
             "title": "Api Version",
             "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "type": "string",
-            "description": "A string containing the version of the API implementation."
+            "description": "Presently used full version of the OPTIMADE API.\nThe version number string MUST NOT be prefixed by, e.g., \"v\".\nExamples: `1.0.0`, `1.0.0-rc.2`."
+          },
+          "more_data_available": {
+            "title": "More Data Available",
+            "type": "boolean",
+            "description": "`false` if the response contains all data for the request (e.g., a request issued to a single entry endpoint, or a `filter` query at the last page of a paginated response) and `true` if the response is incomplete in the sense that multiple objects match the request, and not all of them have been included in the response (e.g., a query with multiple pages that is not at the last page)."
+          },
+          "schema": {
+            "title": "Schema",
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 65536,
+                "format": "uri"
+              },
+              {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Link"
+                  }
+                ]
+              }
+            ],
+            "description": "A [JSON API links object](http://jsonapi.org/format/1.0/#document-links) that points to a schema for the response.\nIf it is a string, or a dictionary containing no `meta` field, the provided URL MUST point at an [OpenAPI](https://swagger.io/specification/) schema.\nIt is possible that future versions of this specification allows for alternative schema types.\nHence, if the `meta` field of the JSON API links object is provided and contains a field `schema_type` that is not equal to the string `OpenAPI` the client MUST not handle failures to parse the schema or to validate the response against the schema as errors."
           },
           "time_stamp": {
             "title": "Time Stamp",
@@ -2670,11 +2727,6 @@
             "minimum": 0.0,
             "type": "integer",
             "description": "An integer containing the total number of data resource objects returned for the current `filter` query, independent of pagination."
-          },
-          "more_data_available": {
-            "title": "More Data Available",
-            "type": "boolean",
-            "description": "`false` if all data resource objects for this `filter` query have been returned in the response or if it is the last page of a paginated response, and `true` otherwise."
           },
           "provider": {
             "title": "Provider",
@@ -2731,7 +2783,7 @@
           "representation": {
             "title": "Representation",
             "type": "string",
-            "description": "a string with the part of the URL that follows the base URL. Example: '/structures?'"
+            "description": "A string with the part of the URL following the versioned or unversioned base URL that serves the API.\nQuery parameters that have not been used in processing the request MAY be omitted.\nIn particular, if no query parameters have been involved in processing the request, the query pary of the URL MAY be excluded.\nExample: `/structures?filter=nelements=2`"
           }
         },
         "description": "Information on the query that was requested. "
@@ -3110,7 +3162,8 @@
       "StructureResponseMany": {
         "title": "StructureResponseMany",
         "required": [
-          "data"
+          "data",
+          "meta"
         ],
         "type": "object",
         "properties": {
@@ -3193,7 +3246,8 @@
       "StructureResponseOne": {
         "title": "StructureResponseOne",
         "required": [
-          "data"
+          "data",
+          "meta"
         ],
         "type": "object",
         "properties": {

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -879,11 +879,10 @@
           "200": {
             "description": "Successful Response",
             "content": {
-              "application/json": {
-                "schema": {}
-              },
               "text/csv": {
-                "schema": {}
+                "schema": {
+                  "type": "string"
+                }
               }
             }
           }
@@ -2783,7 +2782,7 @@
           "representation": {
             "title": "Representation",
             "type": "string",
-            "description": "A string with the part of the URL following the versioned or unversioned base URL that serves the API.\nQuery parameters that have not been used in processing the request MAY be omitted.\nIn particular, if no query parameters have been involved in processing the request, the query pary of the URL MAY be excluded.\nExample: `/structures?filter=nelements=2`"
+            "description": "A string with the part of the URL following the versioned or unversioned base URL that serves the API.\nQuery parameters that have not been used in processing the request MAY be omitted.\nIn particular, if no query parameters have been involved in processing the request, the query part of the URL MAY be excluded.\nExample: `/structures?filter=nelements=2`"
           }
         },
         "description": "Information on the query that was requested. "

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -6,20 +6,20 @@
     "version": "1.0.0-rc.2"
   },
   "paths": {
-    "/v1/info": {
+    "/info": {
       "get": {
         "tags": [
           "Info"
         ],
         "summary": "Get Info",
-        "operationId": "get_info_v1_info_get",
+        "operationId": "get_info_info_get",
         "responses": {
           "200": {
             "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Response Get Info V1 Info Get",
+                  "title": "Response Get Info Info Get",
                   "anyOf": [
                     {
                       "$ref": "#/components/schemas/InfoResponse"
@@ -35,13 +35,13 @@
         }
       }
     },
-    "/v1/info/{entry}": {
+    "/info/{entry}": {
       "get": {
         "tags": [
           "Info"
         ],
         "summary": "Get Entry Info",
-        "operationId": "get_entry_info_v1_info__entry__get",
+        "operationId": "get_entry_info_info__entry__get",
         "parameters": [
           {
             "required": true,
@@ -59,7 +59,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Response Get Entry Info V1 Info  Entry  Get",
+                  "title": "Response Get Entry Info Info  Entry  Get",
                   "anyOf": [
                     {
                       "$ref": "#/components/schemas/EntryInfoResponse"
@@ -85,13 +85,13 @@
         }
       }
     },
-    "/v1/links": {
+    "/links": {
       "get": {
         "tags": [
           "Links"
         ],
         "summary": "Get Links",
-        "operationId": "get_links_v1_links_get",
+        "operationId": "get_links_links_get",
         "parameters": [
           {
             "description": "A filter string, in the format described in section API Filtering Format Specification of the specification.",
@@ -253,7 +253,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Response Get Links V1 Links Get",
+                  "title": "Response Get Links Links Get",
                   "anyOf": [
                     {
                       "$ref": "#/components/schemas/LinksResponse"
@@ -279,13 +279,13 @@
         }
       }
     },
-    "/v1/references": {
+    "/references": {
       "get": {
         "tags": [
           "References"
         ],
         "summary": "Get References",
-        "operationId": "get_references_v1_references_get",
+        "operationId": "get_references_references_get",
         "parameters": [
           {
             "description": "A filter string, in the format described in section API Filtering Format Specification of the specification.",
@@ -447,7 +447,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Response Get References V1 References Get",
+                  "title": "Response Get References References Get",
                   "anyOf": [
                     {
                       "$ref": "#/components/schemas/ReferenceResponseMany"
@@ -473,13 +473,13 @@
         }
       }
     },
-    "/v1/references/{entry_id}": {
+    "/references/{entry_id}": {
       "get": {
         "tags": [
           "References"
         ],
         "summary": "Get Single Reference",
-        "operationId": "get_single_reference_v1_references__entry_id__get",
+        "operationId": "get_single_reference_references__entry_id__get",
         "parameters": [
           {
             "required": true,
@@ -547,7 +547,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Response Get Single Reference V1 References  Entry Id  Get",
+                  "title": "Response Get Single Reference References  Entry Id  Get",
                   "anyOf": [
                     {
                       "$ref": "#/components/schemas/ReferenceResponseOne"
@@ -573,13 +573,13 @@
         }
       }
     },
-    "/v1/structures": {
+    "/structures": {
       "get": {
         "tags": [
           "Structures"
         ],
         "summary": "Get Structures",
-        "operationId": "get_structures_v1_structures_get",
+        "operationId": "get_structures_structures_get",
         "parameters": [
           {
             "description": "A filter string, in the format described in section API Filtering Format Specification of the specification.",
@@ -741,7 +741,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Response Get Structures V1 Structures Get",
+                  "title": "Response Get Structures Structures Get",
                   "anyOf": [
                     {
                       "$ref": "#/components/schemas/StructureResponseMany"
@@ -767,13 +767,13 @@
         }
       }
     },
-    "/v1/structures/{entry_id}": {
+    "/structures/{entry_id}": {
       "get": {
         "tags": [
           "Structures"
         ],
         "summary": "Get Single Structure",
-        "operationId": "get_single_structure_v1_structures__entry_id__get",
+        "operationId": "get_single_structure_structures__entry_id__get",
         "parameters": [
           {
             "required": true,
@@ -841,7 +841,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Response Get Single Structure V1 Structures  Entry Id  Get",
+                  "title": "Response Get Single Structure Structures  Entry Id  Get",
                   "anyOf": [
                     {
                       "$ref": "#/components/schemas/StructureResponseOne"

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -866,6 +866,29 @@
           }
         }
       }
+    },
+    "/versions": {
+      "get": {
+        "tags": [
+          "Versions"
+        ],
+        "summary": "Get Versions",
+        "description": "Respond with the text/csv representation for the served versions.",
+        "operationId": "get_versions_versions_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              },
+              "text/csv": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {

--- a/optimade/__init__.py
+++ b/optimade/__init__.py
@@ -1,2 +1,2 @@
 __version__ = "0.9.7"
-__api_version__ = "1.0.0-rc.2"
+__api_version__ = "1.0.0"

--- a/optimade/models/baseinfo.py
+++ b/optimade/models/baseinfo.py
@@ -22,8 +22,9 @@ class AvailableApiVersion(BaseModel):
 
     version: SemanticVersion = Field(
         ...,
-        description="A string containing the full version number of the API served at that versioned base URL. "
-        "The version number string MUST NOT be prefixed by, e.g., 'v'.",
+        description="""A string containing the full version number of the API served at that versioned base URL.
+The version number string MUST NOT be prefixed by, e.g., 'v'.
+Examples: `1.0.0`, `1.0.0-rc.2`.""",
     )
 
     @validator("url")
@@ -59,7 +60,10 @@ class BaseInfoAttributes(BaseModel):
     """Attributes for Base URL Info endpoint"""
 
     api_version: SemanticVersion = Field(
-        ..., description="Presently used version of the OPTIMADE API"
+        ...,
+        description="""Presently used full version of the OPTIMADE API.
+The version number string MUST NOT be prefixed by, e.g., "v".
+Examples: `1.0.0`, `1.0.0-rc.2`.""",
     )
     available_api_versions: List[AvailableApiVersion] = Field(
         ...,

--- a/optimade/models/entries.py
+++ b/optimade/models/entries.py
@@ -139,6 +139,7 @@ class EntryInfoProperty(BaseModel):
     unit: Optional[str] = Field(
         None,
         description="""The physical unit of the entry property.
+This MUST be a valid representation of units according to version 2.1 of [The Unified Code for Units of Measure](https://unitsofmeasure.org/ucum.html).
 It is RECOMMENDED that non-standard (non-SI) units are described in the description for the property.""",
     )
 

--- a/optimade/models/optimade_json.py
+++ b/optimade/models/optimade_json.py
@@ -183,14 +183,6 @@ class Provider(BaseModel):
         "directly as a string, or as a link object.",
     )
 
-    index_base_url: Optional[Union[AnyHttpUrl, jsonapi.Link]] = Field(
-        None,
-        description="a [JSON API links object](http://jsonapi.org/format/1.0#document-links) "
-        "pointing to the base URL for the `index` meta-database as "
-        "specified in Appendix 1, either directly as a string, or "
-        "as a link object.",
-    )
-
 
 class ImplementationMaintainer(BaseModel):
     """Details about the maintainer of the implementation"""

--- a/optimade/models/optimade_json.py
+++ b/optimade/models/optimade_json.py
@@ -161,7 +161,7 @@ class ResponseMetaQuery(BaseModel):
         ...,
         description="""A string with the part of the URL following the versioned or unversioned base URL that serves the API.
 Query parameters that have not been used in processing the request MAY be omitted.
-In particular, if no query parameters have been involved in processing the request, the query pary of the URL MAY be excluded.
+In particular, if no query parameters have been involved in processing the request, the query part of the URL MAY be excluded.
 Example: `/structures?filter=nelements=2`""",
     )
 

--- a/optimade/models/responses.py
+++ b/optimade/models/responses.py
@@ -31,8 +31,8 @@ __all__ = (
 class ErrorResponse(Response):
     """errors MUST be present and data MUST be skipped"""
 
-    meta: Optional[ResponseMeta] = Field(
-        None, description="A meta object containing non-standard information"
+    meta: ResponseMeta = Field(
+        ..., description="A meta object containing non-standard information"
     )
     errors: List[OptimadeError] = Field(
         ...,

--- a/optimade/server/config.py
+++ b/optimade/server/config.py
@@ -9,7 +9,7 @@ except ImportError:
     from typing_extensions import Literal
 from pathlib import Path
 
-from pydantic import BaseSettings, Field, root_validator
+from pydantic import BaseSettings, Field, root_validator, AnyHttpUrl
 
 from optimade import __version__
 from optimade.models import Implementation, Provider
@@ -73,13 +73,16 @@ class ServerConfig(BaseSettings):
         ),
         description="Introspective information about this OPTIMADE implementation",
     )
+    index_base_url: Optional[AnyHttpUrl] = Field(
+        None,
+        description="An optional link to the base URL for the index meta-database of the provider.",
+    )
     provider: Provider = Field(
         Provider(
             prefix="exmpl",
             name="Example provider",
             description="Provider used for examples, not to be assigned to a real database",
             homepage="https://example.com",
-            index_base_url="http://localhost:5001",
         ),
         description="General information about the provider of this OPTIMADE implementation",
     )

--- a/optimade/server/main.py
+++ b/optimade/server/main.py
@@ -13,7 +13,7 @@ import optimade.server.exception_handlers as exc_handlers
 from .entry_collections import MongoCollection
 from .config import CONFIG
 from .middleware import EnsureQueryParamIntegrity
-from .routers import info, links, references, structures, landing
+from .routers import info, links, references, structures, landing, versions
 from .routers.utils import get_providers, BASE_URL_PREFIXES
 
 
@@ -71,7 +71,7 @@ app.add_exception_handler(NotImplementedError, exc_handlers.not_implemented_hand
 app.add_exception_handler(Exception, exc_handlers.general_exception_handler)
 
 # Add various endpoints to unversioned URL
-for endpoint in (info, links, references, structures, landing):
+for endpoint in (info, links, references, structures, landing, versions):
     app.include_router(endpoint.router)
 
 

--- a/optimade/server/main.py
+++ b/optimade/server/main.py
@@ -70,17 +70,15 @@ app.add_exception_handler(VisitError, exc_handlers.grammar_not_implemented_handl
 app.add_exception_handler(NotImplementedError, exc_handlers.not_implemented_handler)
 app.add_exception_handler(Exception, exc_handlers.general_exception_handler)
 
-
-# Add various endpoints to `/vMAJOR`
-app.include_router(info.router, prefix=BASE_URL_PREFIXES["major"])
-app.include_router(links.router, prefix=BASE_URL_PREFIXES["major"])
-app.include_router(references.router, prefix=BASE_URL_PREFIXES["major"])
-app.include_router(structures.router, prefix=BASE_URL_PREFIXES["major"])
+# Add various endpoints to unversioned URL
+for endpoint in (info, links, references, structures, landing):
+    app.include_router(endpoint.router)
 
 
-# Add the router for the landing page for all prefixes
-app.include_router(landing.router)
-app.include_router(landing.router, prefix=BASE_URL_PREFIXES["major"])
+def add_major_version_base_url(app: FastAPI):
+    """ Add mandatory vMajor endpoints, i.e. all except versions. """
+    for endpoint in (info, links, references, structures, landing):
+        app.include_router(endpoint.router, prefix=BASE_URL_PREFIXES["major"])
 
 
 def add_optional_versioned_base_urls(app: FastAPI):
@@ -91,14 +89,13 @@ def add_optional_versioned_base_urls(app: FastAPI):
     ```
     """
     for version in ("minor", "patch"):
-        app.include_router(info.router, prefix=BASE_URL_PREFIXES[version])
-        app.include_router(links.router, prefix=BASE_URL_PREFIXES[version])
-        app.include_router(references.router, prefix=BASE_URL_PREFIXES[version])
-        app.include_router(structures.router, prefix=BASE_URL_PREFIXES[version])
-        app.include_router(landing.router, prefix=BASE_URL_PREFIXES[version])
+        for endpoint in (info, links, references, structures, landing):
+            app.include_router(endpoint.router, prefix=BASE_URL_PREFIXES[version])
 
 
 @app.on_event("startup")
 async def startup_event():
+    # Add API endpoints for MANDATORY base URL `/vMAJOR`
+    add_major_version_base_url(app)
     # Add API endpoints for OPTIONAL base URLs `/vMAJOR.MINOR` and `/vMAJOR.MINOR.PATCH`
     add_optional_versioned_base_urls(app)

--- a/optimade/server/main_index.py
+++ b/optimade/server/main_index.py
@@ -73,9 +73,15 @@ app.add_exception_handler(VisitError, exc_handlers.grammar_not_implemented_handl
 app.add_exception_handler(Exception, exc_handlers.general_exception_handler)
 
 
-# Add various endpoints to `/vMAJOR`
-app.include_router(index_info.router, prefix=BASE_URL_PREFIXES["major"])
-app.include_router(links.router, prefix=BASE_URL_PREFIXES["major"])
+# Add all endpoints to unversioned URL
+for endpoint in (index_info, links):
+    app.include_router(endpoint.router)
+
+
+def add_major_version_base_url(app: FastAPI):
+    """ Add mandatory endpoints to `/vMAJOR` base URL. """
+    for endpoint in (index_info, links):
+        app.include_router(links.router, prefix=BASE_URL_PREFIXES["major"])
 
 
 def add_optional_versioned_base_urls(app: FastAPI):
@@ -92,5 +98,7 @@ def add_optional_versioned_base_urls(app: FastAPI):
 
 @app.on_event("startup")
 async def startup_event():
+    # Add API endpoints for MANDATORY base URL `/vMAJOR`
+    add_major_version_base_url(app)
     # Add API endpoints for OPTIONAL base URLs `/vMAJOR.MINOR` and `/vMAJOR.MINOR.PATCH`
     add_optional_versioned_base_urls(app)

--- a/optimade/server/main_index.py
+++ b/optimade/server/main_index.py
@@ -13,7 +13,7 @@ import optimade.server.exception_handlers as exc_handlers
 
 from .config import CONFIG
 from .middleware import EnsureQueryParamIntegrity
-from .routers import index_info, links
+from .routers import index_info, links, versions
 from .routers.utils import BASE_URL_PREFIXES
 
 
@@ -74,7 +74,7 @@ app.add_exception_handler(Exception, exc_handlers.general_exception_handler)
 
 
 # Add all endpoints to unversioned URL
-for endpoint in (index_info, links):
+for endpoint in (index_info, links, versions):
     app.include_router(endpoint.router)
 
 

--- a/optimade/server/routers/index_info.py
+++ b/optimade/server/routers/index_info.py
@@ -16,7 +16,7 @@ from optimade.models import (
 
 from optimade.server.config import CONFIG
 
-from .utils import meta_values, get_base_url
+from optimade.server.routers.utils import meta_values, get_base_url
 
 
 router = APIRouter(redirect_slashes=True)

--- a/optimade/server/routers/index_info.py
+++ b/optimade/server/routers/index_info.py
@@ -1,3 +1,4 @@
+import urllib
 from typing import Union
 
 from fastapi import APIRouter, Request
@@ -15,7 +16,7 @@ from optimade.models import (
 
 from optimade.server.config import CONFIG
 
-from .utils import meta_values
+from .utils import meta_values, get_base_url
 
 
 router = APIRouter(redirect_slashes=True)
@@ -28,6 +29,10 @@ router = APIRouter(redirect_slashes=True)
     tags=["Info"],
 )
 def get_info(request: Request):
+
+    parse_result = urllib.parse.urlparse(str(request.url))
+    base_url = get_base_url(parse_result)
+
     return IndexInfoResponse(
         meta=meta_values(str(request.url), 1, 1, more_data_available=False),
         data=IndexInfoResource(
@@ -37,7 +42,7 @@ def get_info(request: Request):
                 api_version=f"{__api_version__}",
                 available_api_versions=[
                     {
-                        "url": f"{CONFIG.provider.index_base_url}/v{__api_version__.split('.')[0]}/",
+                        "url": f"{base_url}/v{__api_version__.split('.')[0]}/",
                         "version": f"{__api_version__}",
                     }
                 ],

--- a/optimade/server/routers/landing.py
+++ b/optimade/server/routers/landing.py
@@ -5,8 +5,8 @@ from fastapi.templating import Jinja2Templates
 from starlette.routing import Router, Route
 from optimade import __api_version__
 
-from . import ENTRY_COLLECTIONS
-from .utils import meta_values
+from optimade.server.routers import ENTRY_COLLECTIONS
+from optimade.server.routers.utils import meta_values
 from optimade.server.config import CONFIG
 
 template_dir = Path(__file__).parent.joinpath("static").resolve()

--- a/optimade/server/routers/landing.py
+++ b/optimade/server/routers/landing.py
@@ -7,6 +7,7 @@ from optimade import __api_version__
 
 from . import ENTRY_COLLECTIONS
 from .utils import meta_values
+from optimade.server.config import CONFIG
 
 template_dir = Path(__file__).parent.joinpath("static").resolve()
 TEMPLATES = Jinja2Templates(directory=[template_dir])
@@ -31,6 +32,7 @@ async def landing(request):
         "implementation": meta.implementation,
         "versioned_url": versioned_url,
         "provider": meta.provider,
+        "index_base_url": CONFIG.index_base_url,
         "endpoints": list(ENTRY_COLLECTIONS.keys()) + ["info"],
     }
 

--- a/optimade/server/routers/static/landing_page.html
+++ b/optimade/server/routers/static/landing_page.html
@@ -35,8 +35,10 @@
         {{ '<li><a href="{}{}">{}{}</a></li>'.format(versioned_url, endpoint, versioned_url, endpoint) | safe }}
         {% endfor %}
         </ul>
-        <h3>Index base URL:</h3>
-        <p><a href={{ provider.index_base_url }}>{{ provider.index_base_url }}</a></p>
+        {% if index_base_url != None %}
+            <h3>Index base URL:</h3>
+            <p><a href={{ index_base_url }}>{{ index_base_url }}</a></p>
+        {% endif %}
     </body>
     <footer>
         <div class="footer_text">

--- a/optimade/server/routers/versions.py
+++ b/optimade/server/routers/versions.py
@@ -6,20 +6,15 @@ from .utils import BASE_URL_PREFIXES
 router = APIRouter(redirect_slashes=True)
 
 
+class CsvResponse(Response):
+    media_type = "text/csv"
+
+
 @router.get(
-    "/versions",
-    tags=["Versions"],
-    responses={
-        200: {
-            "description": "Successful Response",
-            "content": {"text/csv": {"schema": {}}},
-        }
-    },
+    "/versions", tags=["Versions"], response_class=CsvResponse,
 )
 def get_versions(request: Request):
     """Respond with the text/csv representation for the served versions."""
     version = BASE_URL_PREFIXES["major"].replace("/v", "")
     response = f"version\n{version}"
-    return Response(
-        content=response, media_type="text/csv", headers={"header": "present"}
-    )
+    return CsvResponse(content=response, headers={"header": "present"})

--- a/optimade/server/routers/versions.py
+++ b/optimade/server/routers/versions.py
@@ -1,0 +1,25 @@
+from fastapi import Request, APIRouter
+from fastapi.responses import Response
+
+from .utils import BASE_URL_PREFIXES
+
+router = APIRouter(redirect_slashes=True)
+
+
+@router.get(
+    "/versions",
+    tags=["Versions"],
+    responses={
+        200: {
+            "description": "Successful Response",
+            "content": {"text/csv": {"schema": {}}},
+        }
+    },
+)
+def get_versions(request: Request):
+    """Respond with the text/csv representation for the served versions."""
+    version = BASE_URL_PREFIXES["major"].replace("/v", "")
+    response = f"version\n{version}"
+    return Response(
+        content=response, media_type="text/csv", headers={"header": "present"}
+    )

--- a/tests/server/routers/test_versions.py
+++ b/tests/server/routers/test_versions.py
@@ -1,0 +1,18 @@
+import unittest
+
+from optimade import __api_version__
+from ..utils import SimpleEndpointTestsMixin
+
+
+class VersionsEndpointTests(SimpleEndpointTestsMixin, unittest.TestCase):
+
+    request_str = "/versions"
+    response_cls = str
+
+    def test_versions_endpoint(self):
+        self.assertEqual(
+            self.response.text,
+            f"version\n{__api_version__.replace('v', '').split('.')[0]}",
+        )
+        self.assertEqual(self.response.headers.get("header"), "present")
+        self.assertTrue("text/csv" in self.response.headers.get("content-type"))

--- a/tests/server/test_server_validation.py
+++ b/tests/server/test_server_validation.py
@@ -3,7 +3,6 @@ import os
 import unittest
 from traceback import print_exc
 
-from optimade import __api_version__
 from optimade.validator import ImplementationValidator
 
 from .utils import SetClient
@@ -60,14 +59,13 @@ class AsTypeTestsWithValidator(SetClient, unittest.TestCase):
 
     def test_as_type_with_validator(self):
 
-        base_url = f"http://example.org/v{__api_version__.split('.')[0]}"
         test_urls = {
-            f"{base_url}/structures": "structures",
-            f"{base_url}/structures/mpf_1": "structure",
-            f"{base_url}/references": "references",
-            f"{base_url}/references/dijkstra1968": "reference",
-            f"{base_url}/info": "info",
-            f"{base_url}/links": "links",
+            f"{self.client.base_url}/structures": "structures",
+            f"{self.client.base_url}/structures/mpf_1": "structure",
+            f"{self.client.base_url}/references": "references",
+            f"{self.client.base_url}/references/dijkstra1968": "reference",
+            f"{self.client.base_url}/info": "info",
+            f"{self.client.base_url}/links": "links",
         }
         with unittest.mock.patch(
             "requests.get", unittest.mock.Mock(side_effect=self.client.get)

--- a/tests/server/utils.py
+++ b/tests/server/utils.py
@@ -134,3 +134,21 @@ class EndpointTestsMixin(SetClient):
                 key in response_subset,
                 msg="{} missing from response {}".format(key, response_subset),
             )
+
+
+class SimpleEndpointTestsMixin(SetClient):
+    """ A simplified mixin class for tests on non-JSON endpoints. """
+
+    server: str = "regular"
+    request_str: str = None
+    response_cls = None
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.response = self.client.get(self.request_str)
+        self.assertEqual(
+            self.response.status_code,
+            200,
+            msg=f"Request failed: {self.response.content}",
+        )

--- a/tests/server/utils.py
+++ b/tests/server/utils.py
@@ -16,11 +16,8 @@ def get_regular_client() -> TestClient:
     from optimade.server.main import app
     from optimade.server.routers import info, links, references, structures
 
-    # We need to remove the version prefixes in order to have the tests run correctly.
-    app.include_router(info.router, prefix=VERSION_PREFIX)
-    app.include_router(links.router, prefix=VERSION_PREFIX)
-    app.include_router(references.router, prefix=VERSION_PREFIX)
-    app.include_router(structures.router, prefix=VERSION_PREFIX)
+    for endpoint in (info, links, references, structures):
+        app.include_router(endpoint.router, prefix=VERSION_PREFIX)
     # need to explicitly set base_url, as the default "http://testserver"
     # does not validate as pydantic AnyUrl model
     return TestClient(app, base_url=f"http://example.org{VERSION_PREFIX}")
@@ -31,7 +28,6 @@ def get_index_client() -> TestClient:
     from optimade.server.main_index import app
     from optimade.server.routers import index_info, links
 
-    # # We need to remove the version prefixes in order to have the tests run correctly.
     app.include_router(index_info.router, prefix=VERSION_PREFIX)
     app.include_router(links.router, prefix=VERSION_PREFIX)
     # need to explicitly set base_url, as the default "http://testserver"

--- a/tests/server/utils.py
+++ b/tests/server/utils.py
@@ -6,6 +6,10 @@ from pydantic import BaseModel
 
 from fastapi.testclient import TestClient
 
+from optimade import __api_version__
+
+VERSION_PREFIX = f"/v{__api_version__.split('.')[0]}"
+
 
 def get_regular_client() -> TestClient:
     """Return TestClient for regular OPTIMADE server"""
@@ -13,13 +17,13 @@ def get_regular_client() -> TestClient:
     from optimade.server.routers import info, links, references, structures
 
     # We need to remove the version prefixes in order to have the tests run correctly.
-    app.include_router(info.router)
-    app.include_router(links.router)
-    app.include_router(references.router)
-    app.include_router(structures.router)
+    app.include_router(info.router, prefix=VERSION_PREFIX)
+    app.include_router(links.router, prefix=VERSION_PREFIX)
+    app.include_router(references.router, prefix=VERSION_PREFIX)
+    app.include_router(structures.router, prefix=VERSION_PREFIX)
     # need to explicitly set base_url, as the default "http://testserver"
     # does not validate as pydantic AnyUrl model
-    return TestClient(app, base_url="http://example.org/v0")
+    return TestClient(app, base_url=f"http://example.org{VERSION_PREFIX}")
 
 
 def get_index_client() -> TestClient:
@@ -28,11 +32,11 @@ def get_index_client() -> TestClient:
     from optimade.server.routers import index_info, links
 
     # # We need to remove the version prefixes in order to have the tests run correctly.
-    app.include_router(index_info.router)
-    app.include_router(links.router)
+    app.include_router(index_info.router, prefix=VERSION_PREFIX)
+    app.include_router(links.router, prefix=VERSION_PREFIX)
     # need to explicitly set base_url, as the default "http://testserver"
     # does not validate as pydantic UrlStr model
-    return TestClient(app, base_url="http://example.org/v0")
+    return TestClient(app, base_url=f"http://example.org{VERSION_PREFIX}")
 
 
 class SetClient(abc.ABC):

--- a/tests/test_config.json
+++ b/tests/test_config.json
@@ -11,9 +11,9 @@
         "name": "Example provider",
         "description": "Provider used for examples, not to be assigned to a real database",
         "prefix": "exmpl",
-        "homepage": "https://example.com",
-        "index_base_url": "http://localhost:5001"
+        "homepage": "https://example.com"
     },
+    "index_base_url": "http://localhost:5001",
     "provider_fields": {
         "structures": [
             "band_gap",


### PR DESCRIPTION
This PR brings our models, responses and endpoints up to date with newly released 1.0.0 of the specification.

I've split this up into 4 commits, which should each individually pass the tests:

1. Enabled serving the API at the unversioned base URL and moved the `vMajor` router addition to a separate function. This means the generated schemas no longer contain version numbers, as desired.
2. Added the `/versions` endpoint from the unversioned base URL for both index and regular db's. This should now have the correct schema response (matching the released version).
3. Removed the `index_base_url` field, as it has been from the schema. I've moved the original config option we had for this to the top-level, and had to adjust our tests accordingly.
4. Updated all the models according to the final changes since 1.0.0-rc.2, e.g.
    - `meta` now being mandatory, but several sub-fields becoming optional,
    - consistency in how we represent links (i.e. `Union[jsonapi.Links, AnyUrl]`).
    - descriptions for `version`/`api_version` numbers
    - fixed some other descriptions, e.g. typos, broken internal links and missing newlines.