### PR TITLE
Set implementation version in config by default

### DIFF
--- a/optimade/server/config.py
+++ b/optimade/server/config.py
@@ -9,7 +9,7 @@ except ImportError:
     from typing_extensions import Literal
 from pathlib import Path
 
-from pydantic import BaseSettings, Field, root_validator, AnyHttpUrl
+from pydantic import BaseSettings, Field, root_validator, AnyHttpUrl, validator  # pylint: disable=no-name-in-module
 
 from optimade import __version__
 from optimade.models import Implementation, Provider
@@ -112,6 +112,31 @@ class ServerConfig(BaseSettings):
         Path(__file__).parent.joinpath("index_links.json"),
         description="Absolute path to a JSON file containing the MongoDB collection of /links resources for the index meta-database",
     )
+
+    @validator("implementation", pre=True)
+    def set_implementation_defaults(cls, v):
+        """Set defaults and modify by passed value(s)"""
+        res = {
+            "name": "Optimade Python Tools",
+            "version": __version__,
+            "source_url": "https://github.com/Materials-Consortia/optimade-python-tools",
+            "maintainer": {"email": "dev@optimade.org"},
+        }
+        res.update(v)
+        return res
+
+    @validator("provider", pre=True)
+    def set_provider_defaults(cls, v):
+        """Set defaults and modify by passed value(s)"""
+        res = {
+            "prefix": "exmpl",
+            "name": "Example provider",
+            "description": "Provider used for examples, not to be assigned to a real database",
+            "homepage": "https://example.com",
+            "index_base_url": "http://localhost:5001",
+        }
+        res.update(v)
+        return res
 
     @root_validator(pre=True)
     def load_default_settings(cls, values):  # pylint: disable=no-self-argument

--- a/optimade/server/config.py
+++ b/optimade/server/config.py
@@ -9,7 +9,13 @@ except ImportError:
     from typing_extensions import Literal
 from pathlib import Path
 
-from pydantic import BaseSettings, Field, root_validator, AnyHttpUrl, validator  # pylint: disable=no-name-in-module
+from pydantic import (  # pylint: disable=no-name-in-module
+    BaseSettings,
+    Field,
+    root_validator,
+    AnyHttpUrl,
+    validator,
+)
 
 from optimade import __version__
 from optimade.models import Implementation, Provider
@@ -114,27 +120,9 @@ class ServerConfig(BaseSettings):
     )
 
     @validator("implementation", pre=True)
-    def set_implementation_defaults(cls, v):
+    def set_implementation_version(cls, v):
         """Set defaults and modify by passed value(s)"""
-        res = {
-            "name": "Optimade Python Tools",
-            "version": __version__,
-            "source_url": "https://github.com/Materials-Consortia/optimade-python-tools",
-            "maintainer": {"email": "dev@optimade.org"},
-        }
-        res.update(v)
-        return res
-
-    @validator("provider", pre=True)
-    def set_provider_defaults(cls, v):
-        """Set defaults and modify by passed value(s)"""
-        res = {
-            "prefix": "exmpl",
-            "name": "Example provider",
-            "description": "Provider used for examples, not to be assigned to a real database",
-            "homepage": "https://example.com",
-            "index_base_url": "http://localhost:5001",
-        }
+        res = {"version": __version__}
         res.update(v)
         return res
 


### PR DESCRIPTION
Set config defaults for `provider` and `implementation`.
This ensures that the `version` field is set for `implementation`.

---

Maybe all of this is not needed?
But it's important to get the `version` sub-field automated here.