### PR TITLE
Fix some validator-specific crashes

### DIFF
--- a/optimade/models/entries.py
+++ b/optimade/models/entries.py
@@ -20,7 +20,11 @@ class TypedRelationship(Relationship):
     # This may be updated when moving to Python 3.8
     @validator("data")
     def check_rel_type(cls, data):
-        if hasattr(cls, "_req_type") and any(obj.type != cls._req_type for obj in data):
+        if not isinstance(data, list):
+            raise ValueError("`data` key in a relationship must always store a list.")
+        if hasattr(cls, "_req_type") and any(
+            getattr(obj, "type", None) != cls._req_type for obj in data
+        ):
             raise ValueError("Object stored in relationship data has wrong type")
         return data
 

--- a/optimade/models/entries.py
+++ b/optimade/models/entries.py
@@ -21,6 +21,8 @@ class TypedRelationship(Relationship):
     @validator("data")
     def check_rel_type(cls, data):
         if not isinstance(data, list):
+            # All relationships at this point are empty-to-many relationships in JSON:API:
+            # https://jsonapi.org/format/1.0/#document-resource-object-linkage
             raise ValueError("`data` key in a relationship must always store a list.")
         if hasattr(cls, "_req_type") and any(
             getattr(obj, "type", None) != cls._req_type for obj in data

--- a/optimade/validator/__init__.py
+++ b/optimade/validator/__init__.py
@@ -61,6 +61,21 @@ def validate():
             "Flag for whether the specified OPTIMADE implementation is an Index meta-database or not. [default=False]"
         ),
     )
+    parser.add_argument(
+        "--skip_optional",
+        action="store_true",
+        default=False,
+        help=(
+            "Flag for whether the skip the tests of optional features. [default=False]"
+        ),
+    )
+
+    parser.add_argument(
+        "--fail_fast",
+        action="store_true",
+        default=False,
+        help=("Whether to exit on first test failure."),
+    )
 
     args = vars(parser.parse_args())
 
@@ -88,6 +103,8 @@ def validate():
         verbosity=args["verbosity"],
         as_type=args["as_type"],
         index=args["index"],
+        run_optional_tests=not args["skip_optional"],
+        fail_fast=args["fail_fast"],
     )
 
     try:

--- a/optimade/validator/__init__.py
+++ b/optimade/validator/__init__.py
@@ -12,20 +12,20 @@ def validate():
     import traceback
 
     parser = argparse.ArgumentParser(
-        prog="optimade_validator",
+        prog="optimade-validator",
         description="""Tests OPTIMADE implementations for compliance with the optimade-python-tools models.
 
     - To test an entire implementation (at say example.com/optimade/v1) for all required/available endpoints:
 
-        $ optimade_validator http://example.com/optimade/v1
+        $ optimade-validator http://example.com/optimade/v1
 
     - To test a particular response of an implementation against a particular model:
 
-        $ optimade_validator http://example.com/optimade/v1/structures/id=1234 --as-type structure
+        $ optimade-validator http://example.com/optimade/v1/structures/id=1234 --as-type structure
 
     - To test a particular response of an implementation against a particular model:
 
-        $ optimade_validator http://example.com/optimade/v1/structures --as-type structures
+        $ optimade-validator http://example.com/optimade/v1/structures --as-type structures
         """,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -51,7 +51,7 @@ def validate():
         type=str,
         help=(
             "Validate the request URL with the provided type, rather than scanning the entire implementation e.g. "
-            "optimade_validator `http://example.com/optimade/v1/structures/0 --as-type structure`"
+            "optimade-validator `http://example.com/optimade/v1/structures/0 --as-type structure`"
         ),
     )
     parser.add_argument(

--- a/optimade/validator/__init__.py
+++ b/optimade/validator/__init__.py
@@ -39,7 +39,11 @@ def validate():
         ),
     )
     parser.add_argument(
-        "--verbosity", "-v", type=int, default=0, help="The verbosity of the output"
+        "--verbosity",
+        "-v",
+        type=int,
+        default=0,
+        help="""The verbosity of the output [default=0]. 0 (SUMMARY), 1 (INFO), 2 (DEBUG).""",
     )
     parser.add_argument(
         "--as_type",

--- a/optimade/validator/__init__.py
+++ b/optimade/validator/__init__.py
@@ -39,15 +39,15 @@ def validate():
         ),
     )
     parser.add_argument(
-        "--verbosity",
         "-v",
+        "--verbosity",
         action="count",
         default=0,
         help="""Increase the verbosity of the output.""",
     )
     parser.add_argument(
+        "-t",
         "--as-type",
-        "-a",
         type=str,
         help=(
             "Validate the request URL with the provided type, rather than scanning the entire implementation e.g. "

--- a/optimade/validator/__init__.py
+++ b/optimade/validator/__init__.py
@@ -21,11 +21,11 @@ def validate():
 
     - To test a particular response of an implementation against a particular model:
 
-        $ optimade_validator http://example.com/optimade/v1/structures/id=1234 --as_type structure
+        $ optimade_validator http://example.com/optimade/v1/structures/id=1234 --as-type structure
 
     - To test a particular response of an implementation against a particular model:
 
-        $ optimade_validator http://example.com/optimade/v1/structures --as_type structures
+        $ optimade_validator http://example.com/optimade/v1/structures --as-type structures
         """,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -41,40 +41,36 @@ def validate():
     parser.add_argument(
         "--verbosity",
         "-v",
-        type=int,
+        action="count",
         default=0,
-        help="""The verbosity of the output [default=0]. 0 (SUMMARY), 1 (INFO), 2 (DEBUG).""",
+        help="""Increase the verbosity of the output.""",
     )
     parser.add_argument(
-        "--as_type",
+        "--as-type",
         "-a",
         type=str,
         help=(
             "Validate the request URL with the provided type, rather than scanning the entire implementation e.g. "
-            "optimade_validator `http://example.com/optimade/v1/structures/0 --as_type structure`"
+            "optimade_validator `http://example.com/optimade/v1/structures/0 --as-type structure`"
         ),
     )
     parser.add_argument(
         "--index",
         action="store_true",
         help=(
-            "Flag for whether the specified OPTIMADE implementation is an Index meta-database or not. [default=False]"
+            "Flag for whether the specified OPTIMADE implementation is an Index meta-database or not."
         ),
     )
     parser.add_argument(
-        "--skip_optional",
+        "--skip-optional",
         action="store_true",
-        default=False,
-        help=(
-            "Flag for whether the skip the tests of optional features. [default=False]"
-        ),
+        help=("Flag for whether the skip the tests of optional features."),
     )
 
     parser.add_argument(
-        "--fail_fast",
+        "--fail-fast",
         action="store_true",
-        default=False,
-        help=("Whether to exit on first test failure."),
+        help="Whether to exit on first test failure.",
     )
 
     args = vars(parser.parse_args())

--- a/optimade/validator/data/filters.txt
+++ b/optimade/validator/data/filters.txt
@@ -1,3 +1,4 @@
+_exmpl1_bandgap<2.0 OR _exmpl2_bandgap<2.5
 NOT ( chemical_formula_anonymous = "A" OR chemical_formula_anonymous = "H2O" )
 nelements > 3
 chemical_formula_anonymous CONTAINS "C2" AND chemical_formula_anonymous STARTS WITH "A2"

--- a/optimade/validator/data/filters.txt
+++ b/optimade/validator/data/filters.txt
@@ -1,33 +1,7 @@
-_exmpl1_bandgap<2.0 OR _exmpl2_bandgap<2.5
-NOT ( chemical_formula_hill = "Al" AND chemical_formula_anonymous = "A" OR chemical_formula_anonymous = "H2O" AND NOT chemical_formula_hill = "Ti" )
+NOT ( chemical_formula_anonymous = "A" OR chemical_formula_anonymous = "H2O" )
 nelements > 3
-chemical_formula_hill = "H2O" AND chemical_formula_anonymous != "AB"
-_exmpl_aax <= +.1e8 OR nelements >= 10 AND NOT ( _exmpl_x != "Some string" OR NOT _exmpl_a = 7)
-_exmpl_spacegroup="P2"
-_exmpl_cell_volume<100.0
-_exmpl_bandgap > 5.0 AND _exmpl_molecular_weight < 350
-_exmpl_melting_point<300 AND nelements=4 AND elements="Si,O2"
-_exmpl_some_string_property = 42
-5 < _exmpl_a
-identifier CONTAINS x
-identifier STARTS WITH x
-identifier ENDS WITH x
 chemical_formula_anonymous CONTAINS "C2" AND chemical_formula_anonymous STARTS WITH "A2"
 chemical_formula_anonymous STARTS "B2" AND chemical_formula_anonymous ENDS WITH "D2"
-list HAS value
-list HAS ALL values
-list HAS ANY values
-list LENGTH value
-NOT list HAS inverse
-calculations.id HAS "calc-id-96"
-authors.lastname HAS "Schmit"
-identifier IS UNKNOWN
-NOT identifier IS KNOWN
-chemical_formula_hill IS KNOWN AND NOT chemical_formula_anonymous IS UNKNOWN
-NOT a > b OR c = 100 AND f = "C2 H6"
-(NOT (a > b)) OR ( (c = 100) AND (f = "C2 H6") )
-a >= 0 AND NOT b < c OR c = 0
-((a >= 0) AND (NOT (b < c))) OR (c = 0)
 elements HAS ALL "Si", "Al", "O"
 elements HAS ALL "Si", "Al", "O" AND elements LENGTH 3
 nelements=4
@@ -35,7 +9,6 @@ nelements>=2 AND nelements<=7
 chemical_formula_descriptive="(H2O)2 Na"
 chemical_formula_descriptive CONTAINS "H2O"
 chemical_formula_reduced="H2NaO"
-chemical_formula_hill="H2O2"
 chemical_formula_anonymous="A2B"
 nsites=4
 nsites>=2 AND nsites<=7

--- a/optimade/validator/validator.py
+++ b/optimade/validator/validator.py
@@ -630,7 +630,10 @@ class ImplementationValidator:
                 deserialized.data[0].id,
             )
         else:
-            raise ResponseError("No entries found under endpoint to scrape ID from.")
+            raise ResponseError(
+                "No entries found under endpoint to scrape ID from. "
+                "This may be caused by previous errors, if e.g. the endpoint failed deserialization."
+            )
         return (
             self.test_id_by_type[deserialized.data[0].type],
             f"successfully scraped test ID from {deserialized.data[0].type} endpoint",

--- a/optimade/validator/validator_model_patches.py
+++ b/optimade/validator/validator_model_patches.py
@@ -27,13 +27,13 @@ class ValidatorLinksResponse(Success):
 class ValidatorEntryResponseOne(Success):
     meta: ResponseMeta = Field(...)
     data: EntryResource = Field(...)
-    included: Optional[List[Dict[str, Any]]] = Field(...)
+    included: Optional[List[Dict[str, Any]]] = Field(None)
 
 
 class ValidatorEntryResponseMany(Success):
     meta: ResponseMeta = Field(...)
     data: List[EntryResource] = Field(...)
-    included: Optional[List[Dict[str, Any]]] = Field(...)
+    included: Optional[List[Dict[str, Any]]] = Field(None)
 
 
 class ValidatorReferenceResponseOne(ValidatorEntryResponseOne):

--- a/setup.py
+++ b/setup.py
@@ -115,6 +115,6 @@ setup(
         "jarvis": jarvis_deps,
     },
     entry_points={
-        "console_scripts": ["optimade_validator=optimade.validator:validate"]
+        "console_scripts": ["optimade-validator=optimade.validator:validate"]
     },
 )


### PR DESCRIPTION
This PR aims to fix some *crashes* of the validator, caused either by validator-specific code (cf50cf3) or by crashes internal to the pydantic validator (2b4c3bd). It also adds a few niceties to the validator, including the separation of "internal errors" from expected validation errors, as listed below. Importantly, this PR does not update any of the models that are currently causing validation errors, these should be addressed in another PR. 

The commits can all be reviewed separately, 8e92308 dominates the diff but is mostly just piping code without any "business logic".

Changes:
- cf50cf3 Fixed another occurrence of an optional field without a default value (my fault). I can't spot any more in the codebase (using the slightly convoluted grep below) (closes #393):
    ```bash
    $ grep "Optional.*Field(" -r . -A 1 -h | grep -v "\-\-" | grep -v Field | grep -v None | grep -v default | grep -v "ok"
    ```
- 2b4c3bd Fixed issue where passing a dict to pydantic when it was expecting a list was causing a crash with a huge traceback (closes #397)
- 442a407 Improved help string for `--verbosity` (closes #396).
- 8e92308 Added internal error handling to prevent all future crashes. These get reported separately to validation errors.
- 3a917aa Added a couple of self-explanatory quality of life flags, `--fail_fast` and `--skip_optional`.
- ced32ba  Allow for links objects to be passed to validation in pagination test (rather than just strings) and enforce a maximum pagination recursion depth when validating responses (5)
- 84ab0b1 Pending improvements to the queries we try as validation, I've reduced the set of queries tested from the spec examples to only those that appear mandatory. What remains is still very useful for validating the responses format.
- Several changes to validator CLI flags, and renamed script as `optimade-validator`.