### PR TITLE
Make the example for --as_type more similar to a real use case

### DIFF
--- a/optimade/validator/__init__.py
+++ b/optimade/validator/__init__.py
@@ -47,7 +47,7 @@ def validate():
         type=str,
         help=(
             "Validate the request URL with the provided type, rather than scanning the entire implementation e.g. "
-            "optimade_validator `http://example.com/optimade/v1/structures/0 --as_type structures`"
+            "optimade_validator `http://example.com/optimade/v1/structures/0 --as_type structure`"
         ),
     )
     parser.add_argument(


### PR DESCRIPTION
This PR attempts to provide more "real-world" usage example of `--as_type`: single entry response should be validated as such. Prior to this change, single entry response was shown to be validated as a collection, what would definitely fail.