### PR TITLE
Temporarily run AiiDA tests on Python 3.8 only

### DIFF
--- a/.github/workflows/deps_lint.yml
+++ b/.github/workflows/deps_lint.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.7
 
@@ -42,7 +42,7 @@ jobs:
         submodules: true
 
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.7
 
@@ -65,7 +65,7 @@ jobs:
         submodules: true
 
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.7
 
@@ -159,7 +159,7 @@ jobs:
         submodules: true
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -182,21 +182,24 @@ jobs:
         OPTIMADE_CI_FORCE_MONGO: 0
 
     - name: Install adapter conversion dependencies
+      if: matrix.python-version == 3.8
       run: |
         pip install -r requirements-client.txt
         # AiiDA-specific
         reentry scan
 
     - name: Setup up environment for AiiDA
+      if: matrix.python-version == 3.8
       env:
         AIIDA_TEST_BACKEND: django
       run: .github/aiida/setup_aiida.sh
 
     - name: Run previously skipped tests for adapter conversion
+      if: matrix.python-version == 3.8
       run: pytest -rs --cov=./optimade/ --cov-report=xml --cov-append tests/adapters/
 
     - name: Upload coverage to Codecov
-      if: matrix.python-version == 3.7 && github.repository == 'Materials-Consortia/optimade-python-tools'
+      if: matrix.python-version == 3.8 && github.repository == 'Materials-Consortia/optimade-python-tools'
       uses: codecov/codecov-action@v1
       with:
         file: ./coverage.xml
@@ -210,7 +213,7 @@ jobs:
       with:
         submodules: true
 
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v2
       with:
         python-version: 3.8
 
@@ -232,7 +235,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.7
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ mongo_deps = ["pymongo~=3.10", "mongomock~=3.19"]
 server_deps = ["uvicorn~=0.11.5", "Jinja2~=2.11"] + mongo_deps
 
 # Client minded
-aiida_deps = ["aiida-core~=1.2"]
+aiida_deps = ["aiida-core~=1.3"]
 ase_deps = ["ase~=3.19"]
 cif_deps = ["numpy~=1.19"]
 pdb_deps = cif_deps


### PR DESCRIPTION
Following the discussion in #395, and also in https://github.com/actions/setup-python/issues/107, easiest thing for us to do for now is to run the AiiDA tests on Python 3.8 only, then relax the requirement on future versions.