### PR TITLE
Use optimade-validator-action v2

### DIFF
--- a/.github/workflows/deps_lint.yml
+++ b/.github/workflows/deps_lint.yml
@@ -106,7 +106,7 @@ jobs:
         sleep 15
 
     - name: Test server, including OPTIONAL base URLs
-      uses: Materials-Consortia/optimade-validator-action@v1
+      uses: Materials-Consortia/optimade-validator-action@v2
       with:
         port: 3213
         path: /
@@ -120,7 +120,7 @@ jobs:
         sleep 15
 
     - name: Test index server, including OPTIONAL base URLs
-      uses: Materials-Consortia/optimade-validator-action@v1
+      uses: Materials-Consortia/optimade-validator-action@v2
       with:
         port: 3214
         path: /


### PR DESCRIPTION
Update to using the OPTIMADE Validator Action v2.

This is currently blocked, since v2 has not yet been released (but soon will be).