### PR TITLE
Fix /vMAJOR/info in index server

### DIFF
--- a/optimade/server/main_index.py
+++ b/optimade/server/main_index.py
@@ -81,7 +81,7 @@ for endpoint in (index_info, links, versions):
 def add_major_version_base_url(app: FastAPI):
     """ Add mandatory endpoints to `/vMAJOR` base URL. """
     for endpoint in (index_info, links):
-        app.include_router(links.router, prefix=BASE_URL_PREFIXES["major"])
+        app.include_router(endpoint.router, prefix=BASE_URL_PREFIXES["major"])
 
 
 def add_optional_versioned_base_urls(app: FastAPI):

--- a/tests/server/utils.py
+++ b/tests/server/utils.py
@@ -43,13 +43,13 @@ class OptimadeTestClient(TestClient):
         )
         if version:
             if not version.startswith("v"):
-                version = f"v{version}"
+                version = f"/v{version}"
             if re.match(r"v[0-9](.[0-9]){0,2}", version) is None:
                 warnings.warn(
                     f"Invalid version passed to client: '{version}'. "
                     f"Will use the default: 'v{__api_version__.split('.')[0]}'"
                 )
-                version = f"v{__api_version__.split('.')[0]}"
+                version = f"/v{__api_version__.split('.')[0]}"
         self.version = version
 
     def request(  # pylint: disable=too-many-locals
@@ -77,7 +77,7 @@ class OptimadeTestClient(TestClient):
         ):
             while url.startswith("/"):
                 url = url[1:]
-            url = f"/{self.version}{url}"
+            url = f"{self.version}/{url}"
         return super(OptimadeTestClient, self).request(
             method=method,
             url=url,


### PR DESCRIPTION
It seems the `/info` endpoint was not initiated for `/vMAJOR`.

Test all versioned base URLs' routers return status code 200.

~Locally, I still can't reach `/v1/info` for the index meta-database implementation in the test. I am unsure what the exact issue is now.~ With a small break and a reinstall it seems fine... weird.

Finally, I tried to originally add the landing router as well, but there seems to be some issues with Jinja2 templates and middleware for the Starlette `TestClient`.
See the issues encode/starlette#472 and tiangolo/fastapi#806.
I will leave this for a later point, perhaps an issue of our own to decide on what approach to take, since there are a few work-arounds.