### PR TITLE
Implement 553 Version Not Supported

### DIFF
--- a/optimade/server/exceptions.py
+++ b/optimade/server/exceptions.py
@@ -16,11 +16,11 @@ class BadRequest(HTTPException):
 
 
 class VersionNotSupported(HTTPException):
-    """533 Version Not Supported"""
+    """553 Version Not Supported"""
 
     def __init__(
         self,
-        status_code: int = 533,
+        status_code: int = 553,
         detail: str = None,
         headers: dict = None,
         title: str = "Version Not Supported",

--- a/optimade/server/exceptions.py
+++ b/optimade/server/exceptions.py
@@ -13,3 +13,17 @@ class BadRequest(HTTPException):
     ) -> None:
         super().__init__(status_code=status_code, detail=detail, headers=headers)
         self.title = title
+
+
+class VersionNotSupported(HTTPException):
+    """533 Version Not Supported"""
+
+    def __init__(
+        self,
+        status_code: int = 533,
+        detail: str = None,
+        headers: dict = None,
+        title: str = "Version Not Supported",
+    ) -> None:
+        super().__init__(status_code=status_code, detail=detail, headers=headers)
+        self.title = title

--- a/optimade/server/main.py
+++ b/optimade/server/main.py
@@ -12,7 +12,7 @@ import optimade.server.exception_handlers as exc_handlers
 
 from .entry_collections import MongoCollection
 from .config import CONFIG
-from .middleware import EnsureQueryParamIntegrity
+from .middleware import EnsureQueryParamIntegrity, CheckWronglyVersionedBaseUrls
 from .routers import info, links, references, structures, landing, versions
 from .routers.utils import get_providers, BASE_URL_PREFIXES
 
@@ -58,6 +58,7 @@ if not CONFIG.use_real_mongo:
 # Add various middleware
 app.add_middleware(CORSMiddleware, allow_origins=["*"])
 app.add_middleware(EnsureQueryParamIntegrity)
+app.add_middleware(CheckWronglyVersionedBaseUrls)
 
 
 # Add various exception handlers

--- a/optimade/server/main_index.py
+++ b/optimade/server/main_index.py
@@ -11,10 +11,13 @@ from fastapi.middleware.cors import CORSMiddleware
 from optimade import __api_version__, __version__
 import optimade.server.exception_handlers as exc_handlers
 
-from .config import CONFIG
-from .middleware import EnsureQueryParamIntegrity
-from .routers import index_info, links, versions
-from .routers.utils import BASE_URL_PREFIXES
+from optimade.server.config import CONFIG
+from optimade.server.middleware import (
+    EnsureQueryParamIntegrity,
+    CheckWronglyVersionedBaseUrls,
+)
+from optimade.server.routers import index_info, links, versions
+from optimade.server.routers.utils import BASE_URL_PREFIXES
 
 
 if CONFIG.debug:  # pragma: no cover
@@ -61,6 +64,7 @@ if not CONFIG.use_real_mongo and CONFIG.index_links_path.exists():
 # Add various middleware
 app.add_middleware(CORSMiddleware, allow_origins=["*"])
 app.add_middleware(EnsureQueryParamIntegrity)
+app.add_middleware(CheckWronglyVersionedBaseUrls)
 
 
 # Add various exception handlers

--- a/optimade/server/middleware.py
+++ b/optimade/server/middleware.py
@@ -51,9 +51,7 @@ class CheckWronglyVersionedBaseUrls(BaseHTTPMiddleware):
                 if optimade_path.startswith(f"{version_prefix}/"):
                     break
             else:
-                version_prefix = re.findall(
-                    r"(/v[0-9]+(\.[0-9]+){0,2})", optimade_path
-                )
+                version_prefix = re.findall(r"(/v[0-9]+(\.[0-9]+){0,2})", optimade_path)
                 raise VersionNotSupported(
                     detail=(
                         f"The parsed versioned base URL {version_prefix[0][0]!r} from {urllib.parse.urlunparse(parsed_url)!r} is not supported by this implementation. "

--- a/optimade/server/middleware.py
+++ b/optimade/server/middleware.py
@@ -52,7 +52,7 @@ class CheckWronglyVersionedBaseUrls(BaseHTTPMiddleware):
                     break
             else:
                 version_prefix = re.findall(
-                    r"(/v[0-9]+(\.[0-9]+){0,2})/", optimade_path
+                    r"(/v[0-9]+(\.[0-9]+){0,2})", optimade_path
                 )
                 raise VersionNotSupported(
                     detail=(

--- a/optimade/server/middleware.py
+++ b/optimade/server/middleware.py
@@ -3,8 +3,6 @@ import urllib.parse
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 
-from optimade.server.exceptions import BadRequest
-
 
 class EnsureQueryParamIntegrity(BaseHTTPMiddleware):
     """Ensure all query parameters are followed by an equal sign (`=`)"""
@@ -12,6 +10,8 @@ class EnsureQueryParamIntegrity(BaseHTTPMiddleware):
     @staticmethod
     def check_url(url_query: str):
         """Check parsed URL query part for parameters not followed by `=`"""
+        from optimade.server.exceptions import BadRequest
+
         queries_amp = set(url_query.split("&"))
         queries = set()
         for query in queries_amp:
@@ -27,5 +27,43 @@ class EnsureQueryParamIntegrity(BaseHTTPMiddleware):
         parsed_url = urllib.parse.urlsplit(str(request.url))
         if parsed_url.query:
             self.check_url(parsed_url.query)
+        response = await call_next(request)
+        return response
+
+
+class CheckWronglyVersionedBaseUrls(BaseHTTPMiddleware):
+    """If a non-supported versioned base URL is supplied return `533 Version Not Supported`"""
+
+    @staticmethod
+    def check_url(parsed_url: urllib.parse.ParseResult):
+        """Check URL path for versioned part"""
+        import re
+
+        from optimade.server.exceptions import VersionNotSupported
+        from optimade.server.routers.utils import get_base_url, BASE_URL_PREFIXES
+
+        base_url = get_base_url(parsed_url)
+        optimade_path = f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}"[
+            len(base_url) :
+        ]
+        if re.match(r"^/v[0-9]+", optimade_path):
+            for version_prefix in BASE_URL_PREFIXES.values():
+                if optimade_path.startswith(f"{version_prefix}/"):
+                    break
+            else:
+                version_prefix = re.findall(
+                    r"(/v[0-9]+(\.[0-9]+){0,2})/", optimade_path
+                )
+                raise VersionNotSupported(
+                    detail=(
+                        f"The parsed versioned base URL {version_prefix[0][0]!r} from {urllib.parse.urlunparse(parsed_url)!r} is not supported by this implementation. "
+                        f"Supported versioned base URLs are: {', '.join(BASE_URL_PREFIXES.values())}"
+                    )
+                )
+
+    async def dispatch(self, request: Request, call_next):
+        parsed_url = urllib.parse.urlparse(str(request.url))
+        if parsed_url.path:
+            self.check_url(parsed_url)
         response = await call_next(request)
         return response

--- a/optimade/server/middleware.py
+++ b/optimade/server/middleware.py
@@ -32,7 +32,7 @@ class EnsureQueryParamIntegrity(BaseHTTPMiddleware):
 
 
 class CheckWronglyVersionedBaseUrls(BaseHTTPMiddleware):
-    """If a non-supported versioned base URL is supplied return `533 Version Not Supported`"""
+    """If a non-supported versioned base URL is supplied return `553 Version Not Supported`"""
 
     @staticmethod
     def check_url(parsed_url: urllib.parse.ParseResult):

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -1,6 +1,6 @@
-import pytest
+from typing import Union
 
-from optimade.server.config import CONFIG
+import pytest
 
 
 @pytest.fixture(scope="session")
@@ -59,6 +59,7 @@ def get_good_response(client, index_client):
 def check_response(get_good_response):
     """Fixture to check "good" response"""
     from typing import List
+    from optimade.server.config import CONFIG
 
     def inner(
         request: str,
@@ -91,23 +92,29 @@ def check_response(get_good_response):
 @pytest.fixture
 def check_error_response(client, index_client):
     """General method for testing expected erroneous response"""
+    from .utils import OptimadeTestClient
 
     def inner(
         request: str,
         expected_status: int = None,
         expected_title: str = None,
         expected_detail: str = None,
-        server: str = "regular",
+        server: Union[str, OptimadeTestClient] = "regular",
     ):
         response = None
-        if server == "regular":
-            used_client = client
-        elif server == "index":
-            used_client = index_client
+        if isinstance(server, str):
+            if server == "regular":
+                used_client = client
+            elif server == "index":
+                used_client = index_client
+            else:
+                pytest.fail(
+                    f"Wrong value for 'server': {server}. It must be either 'regular' or 'index'."
+                )
+        elif isinstance(server, OptimadeTestClient):
+            used_client = server
         else:
-            pytest.fail(
-                f"Wrong value for 'server': {server}. It must be either 'regular' or 'index'."
-            )
+            pytest.fail("'server' must be either a string or an OptimadeTestClient.")
 
         try:
             response = used_client.get(request)

--- a/tests/server/test_middleware.py
+++ b/tests/server/test_middleware.py
@@ -26,8 +26,7 @@ def test_preflight_CORS_request(both_clients):
         ), f"{response_header} header not found in response headers: {response.headers}"
 
 
-@pytest.mark.parametrize("server", ("regular", "index"))
-def test_wrong_html_form(check_error_response, server):
+def test_wrong_html_form(check_error_response, both_clients):
     """Using a parameter without equality sign `=` or values should result in a `400 Bad Request` response"""
     from optimade.server.query_params import EntryListingQueryParams
 
@@ -39,12 +38,11 @@ def test_wrong_html_form(check_error_response, server):
                 expected_status=400,
                 expected_title="Bad Request",
                 expected_detail="A query parameter without an equal sign (=) is not supported by this server",
-                server=server,
+                server=both_clients,
             )
 
 
-@pytest.mark.parametrize("server", ("regular", "index"))
-def test_wrong_html_form_one_wrong(check_error_response, server):
+def test_wrong_html_form_one_wrong(check_error_response, both_clients):
     """Using a parameter without equality sign `=` or values should result in a `400 Bad Request` response
 
     This should hold true, no matter the chosen (valid) parameter separator (either & or ;).
@@ -56,7 +54,7 @@ def test_wrong_html_form_one_wrong(check_error_response, server):
             expected_status=400,
             expected_title="Bad Request",
             expected_detail="A query parameter without an equal sign (=) is not supported by this server",
-            server=server,
+            server=both_clients,
         )
 
 
@@ -100,13 +98,11 @@ def test_wrong_version(both_clients):
         )
 
 
-@pytest.mark.parametrize("server", ("regular", "index"))
-def test_wrong_version_json_response(check_error_response, server):
+def test_wrong_version_json_response(check_error_response, both_clients):
     """If a non-supported versioned base URL is passed, `553 Version Not Supported` should be returned
 
     A specific JSON response should also occur.
     """
-    from optimade.server.config import CONFIG
     from optimade.server.routers.utils import BASE_URL_PREFIXES
 
     version = "/v0"
@@ -117,10 +113,10 @@ def test_wrong_version_json_response(check_error_response, server):
             expected_status=553,
             expected_title="Version Not Supported",
             expected_detail=(
-                f"The parsed versioned base URL {version!r} from '{CONFIG.base_url}{request}' is not supported by this implementation. "
+                f"The parsed versioned base URL {version!r} from '{both_clients.base_url}{request}' is not supported by this implementation. "
                 f"Supported versioned base URLs are: {', '.join(BASE_URL_PREFIXES.values())}"
             ),
-            server=server,
+            server=both_clients,
         )
 
 

--- a/tests/server/test_middleware.py
+++ b/tests/server/test_middleware.py
@@ -96,6 +96,13 @@ def test_wrong_version(both_clients):
         CheckWronglyVersionedBaseUrls(both_clients.app).check_url(
             urllib.parse.urlparse(url)
         )
+        
+    url = f"{CONFIG.base_url}{version}"
+
+    with pytest.raises(VersionNotSupported):
+        CheckWronglyVersionedBaseUrls(both_clients.app).check_url(
+            urllib.parse.urlparse(url)
+        )
 
 
 def test_wrong_version_json_response(check_error_response, both_clients):

--- a/tests/server/test_middleware.py
+++ b/tests/server/test_middleware.py
@@ -90,19 +90,16 @@ def test_wrong_version(both_clients):
     from optimade.server.middleware import CheckWronglyVersionedBaseUrls
 
     version = "/v0"
-    url = f"{CONFIG.base_url}{version}/info"
+    urls = (
+        f"{CONFIG.base_url}{version}/info",
+        f"{CONFIG.base_url}{version}",
+    )
 
-    with pytest.raises(VersionNotSupported):
-        CheckWronglyVersionedBaseUrls(both_clients.app).check_url(
-            urllib.parse.urlparse(url)
-        )
-        
-    url = f"{CONFIG.base_url}{version}"
-
-    with pytest.raises(VersionNotSupported):
-        CheckWronglyVersionedBaseUrls(both_clients.app).check_url(
-            urllib.parse.urlparse(url)
-        )
+    for url in urls:
+        with pytest.raises(VersionNotSupported):
+            CheckWronglyVersionedBaseUrls(both_clients.app).check_url(
+                urllib.parse.urlparse(url)
+            )
 
 
 def test_wrong_version_json_response(check_error_response, both_clients):

--- a/tests/server/test_middleware.py
+++ b/tests/server/test_middleware.py
@@ -109,7 +109,7 @@ def test_wrong_version_json_response(check_error_response, server):
     from optimade.server.config import CONFIG
     from optimade.server.routers.utils import BASE_URL_PREFIXES
 
-    version = "v0"
+    version = "/v0"
     request = f"{version}/info"
     with pytest.raises(VersionNotSupported):
         check_error_response(

--- a/tests/server/test_middleware.py
+++ b/tests/server/test_middleware.py
@@ -87,7 +87,7 @@ def test_empty_parameters(both_clients):
 
 
 def test_wrong_version(both_clients):
-    """If a non-supported versioned base URL is passed, `533 Version Not Supported` should be returned"""
+    """If a non-supported versioned base URL is passed, `553 Version Not Supported` should be returned"""
     from optimade.server.config import CONFIG
     from optimade.server.middleware import CheckWronglyVersionedBaseUrls
 
@@ -102,7 +102,7 @@ def test_wrong_version(both_clients):
 
 @pytest.mark.parametrize("server", ("regular", "index"))
 def test_wrong_version_json_response(check_error_response, server):
-    """If a non-supported versioned base URL is passed, `533 Version Not Supported` should be returned
+    """If a non-supported versioned base URL is passed, `553 Version Not Supported` should be returned
 
     A specific JSON response should also occur.
     """
@@ -114,7 +114,7 @@ def test_wrong_version_json_response(check_error_response, server):
     with pytest.raises(VersionNotSupported):
         check_error_response(
             request,
-            expected_status=533,
+            expected_status=553,
             expected_title="Version Not Supported",
             expected_detail=(
                 f"The parsed versioned base URL '/{version}' from '{CONFIG.base_url}{request}' is not supported by this implementation. "

--- a/tests/server/test_middleware.py
+++ b/tests/server/test_middleware.py
@@ -1,6 +1,7 @@
 import pytest
+import urllib
 
-from optimade.server.exceptions import BadRequest
+from optimade.server.exceptions import BadRequest, VersionNotSupported
 
 
 def test_regular_CORS_request(both_clients):
@@ -25,7 +26,8 @@ def test_preflight_CORS_request(both_clients):
         ), f"{response_header} header not found in response headers: {response.headers}"
 
 
-def test_wrong_html_form(check_error_response):
+@pytest.mark.parametrize("server", ("regular", "index"))
+def test_wrong_html_form(check_error_response, server):
     """Using a parameter without equality sign `=` or values should result in a `400 Bad Request` response"""
     from optimade.server.query_params import EntryListingQueryParams
 
@@ -37,10 +39,12 @@ def test_wrong_html_form(check_error_response):
                 expected_status=400,
                 expected_title="Bad Request",
                 expected_detail="A query parameter without an equal sign (=) is not supported by this server",
+                server=server,
             )
 
 
-def test_wrong_html_form_one_wrong(check_error_response):
+@pytest.mark.parametrize("server", ("regular", "index"))
+def test_wrong_html_form_one_wrong(check_error_response, server):
     """Using a parameter without equality sign `=` or values should result in a `400 Bad Request` response
 
     This should hold true, no matter the chosen (valid) parameter separator (either & or ;).
@@ -52,6 +56,7 @@ def test_wrong_html_form_one_wrong(check_error_response):
             expected_status=400,
             expected_title="Bad Request",
             expected_detail="A query parameter without an equal sign (=) is not supported by this server",
+            server=server,
         )
 
 
@@ -79,3 +84,70 @@ def test_empty_parameters(both_clients):
         query_part
     )
     assert expected_result == parsed_set_of_queries
+
+
+def test_wrong_version(both_clients):
+    """If a non-supported versioned base URL is passed, `533 Version Not Supported` should be returned"""
+    from optimade.server.config import CONFIG
+    from optimade.server.middleware import CheckWronglyVersionedBaseUrls
+
+    version = "/v0"
+    url = f"{CONFIG.base_url}{version}/info"
+
+    with pytest.raises(VersionNotSupported):
+        CheckWronglyVersionedBaseUrls(both_clients.app).check_url(
+            urllib.parse.urlparse(url)
+        )
+
+
+@pytest.mark.parametrize("server", ("regular", "index"))
+def test_wrong_version_json_response(check_error_response, server):
+    """If a non-supported versioned base URL is passed, `533 Version Not Supported` should be returned
+
+    A specific JSON response should also occur.
+    """
+    from optimade.server.config import CONFIG
+    from optimade.server.routers.utils import BASE_URL_PREFIXES
+
+    version = "v0"
+    request = f"{version}/info"
+    with pytest.raises(VersionNotSupported):
+        check_error_response(
+            request,
+            expected_status=533,
+            expected_title="Version Not Supported",
+            expected_detail=(
+                f"The parsed versioned base URL '/{version}' from '{CONFIG.base_url}{request}' is not supported by this implementation. "
+                f"Supported versioned base URLs are: {', '.join(BASE_URL_PREFIXES.values())}"
+            ),
+            server=server,
+        )
+
+
+def test_multiple_versions_in_path(both_clients):
+    """If another version is buried in the URL path, only the OPTIMADE versioned URL path part should be recognized."""
+    from optimade.server.config import CONFIG
+    from optimade.server.middleware import CheckWronglyVersionedBaseUrls
+    from optimade.server.routers.utils import BASE_URL_PREFIXES
+
+    non_valid_version = "/v0.5"
+    org_base_url = CONFIG.base_url
+
+    try:
+        CONFIG.base_url = f"https://example.org{non_valid_version}/my_database/optimade"
+
+        for valid_version_prefix in BASE_URL_PREFIXES.values():
+            url = f"{CONFIG.base_url}{valid_version_prefix}/info"
+            CheckWronglyVersionedBaseUrls(both_clients.app).check_url(
+                urllib.parse.urlparse(url)
+            )
+
+        # Test also that the a non-valid OPTIMADE version raises
+        url = f"{CONFIG.base_url}/v0/info"
+        with pytest.raises(VersionNotSupported):
+            CheckWronglyVersionedBaseUrls(both_clients.app).check_url(
+                urllib.parse.urlparse(url)
+            )
+    finally:
+        if org_base_url:
+            CONFIG.base_url = org_base_url

--- a/tests/server/test_middleware.py
+++ b/tests/server/test_middleware.py
@@ -117,7 +117,7 @@ def test_wrong_version_json_response(check_error_response, server):
             expected_status=553,
             expected_title="Version Not Supported",
             expected_detail=(
-                f"The parsed versioned base URL '/{version}' from '{CONFIG.base_url}{request}' is not supported by this implementation. "
+                f"The parsed versioned base URL {version!r} from '{CONFIG.base_url}{request}' is not supported by this implementation. "
                 f"Supported versioned base URLs are: {', '.join(BASE_URL_PREFIXES.values())}"
             ),
             server=server,

--- a/tests/server/test_server_validation.py
+++ b/tests/server/test_server_validation.py
@@ -42,12 +42,12 @@ def test_as_type_with_validator(client):
     import unittest
 
     test_urls = {
-        f"{client.base_url}structures": "structures",
-        f"{client.base_url}structures/mpf_1": "structure",
-        f"{client.base_url}references": "references",
-        f"{client.base_url}references/dijkstra1968": "reference",
-        f"{client.base_url}info": "info",
-        f"{client.base_url}links": "links",
+        f"{client.base_url}/structures": "structures",
+        f"{client.base_url}/structures/mpf_1": "structure",
+        f"{client.base_url}/references": "references",
+        f"{client.base_url}/references/dijkstra1968": "reference",
+        f"{client.base_url}/info": "info",
+        f"{client.base_url}/links": "links",
     }
     with unittest.mock.patch(
         "requests.get", unittest.mock.Mock(side_effect=client.get)

--- a/tests/server/utils.py
+++ b/tests/server/utils.py
@@ -213,9 +213,9 @@ def client_factory():
 
         if version:
             return OptimadeTestClient(
-                app, base_url="http://example.org/", version=version
+                app, base_url="http://example.org", version=version
             )
-        return OptimadeTestClient(app, base_url="http://example.org/")
+        return OptimadeTestClient(app, base_url="http://example.org")
 
     return inner
 

--- a/tests/server/utils.py
+++ b/tests/server/utils.py
@@ -42,12 +42,12 @@ class OptimadeTestClient(TestClient):
             root_path=root_path,
         )
         if version:
-            if not version.startswith("v"):
+            if not version.startswith("v") and not version.startswith("/v"):
                 version = f"/v{version}"
-            if re.match(r"v[0-9](.[0-9]){0,2}", version) is None:
+            if re.match(r"/v[0-9](.[0-9]){0,2}", version) is None:
                 warnings.warn(
-                    f"Invalid version passed to client: '{version}'. "
-                    f"Will use the default: 'v{__api_version__.split('.')[0]}'"
+                    f"Invalid version passed to client: {version!r}. "
+                    f"Will use the default: '/v{__api_version__.split('.')[0]}'"
                 )
                 version = f"/v{__api_version__.split('.')[0]}"
         self.version = version

--- a/tests/test_config.json
+++ b/tests/test_config.json
@@ -1,7 +1,7 @@
 {
     "debug": false,
     "default_db": "test_server",
-    "base_url": "http://localhost:5000",
+    "base_url": "http://example.org",
     "implementation": {
         "name": "Example implementation",
         "source_url": "https://github.com/Materials-Consortia/optimade-python-tools",


### PR DESCRIPTION
Closes #391 

New middleware to check whether versioned base URL (relating to the OPTIMADE server) is a valid version.
If it is _not_ a valid version, the middleware will raise, resulting in a `553 Version Not Supported` as required by the specification.

**Note**: This PR changes `test_config.json` to align the `base_url` configuration parameter with the used test client's.
This speaks to the fact that the `default_config.json` and `example_config.json` should be usable as proper configuration files for development of this package.

~This also updates a bit of CI now:~
~- Use `v1` of `CasperWA/push-protected` action.~
~- Change job name `deps_static` to `pytest`.~
~- Use a high verbosity for `pytest`, i.e., `-vvv`.~

**Edit**: These updates have been factored out into another PR, since they are out-of-scope for this PR. See #422.