### PR TITLE
Minor CI updates

### DIFF
--- a/.github/workflows/deps_lint.yml
+++ b/.github/workflows/deps_lint.yml
@@ -184,20 +184,20 @@ jobs:
         OPTIMADE_CI_FORCE_MONGO: 0
 
     - name: Install adapter conversion dependencies
-      if: matrix.python-version == 3.8
+      if: matrix.python-version != 3.7
       run: |
         pip install -r requirements-client.txt
         # AiiDA-specific
         reentry scan
 
     - name: Setup up environment for AiiDA
-      if: matrix.python-version == 3.8
+      if: matrix.python-version != 3.7
       env:
         AIIDA_TEST_BACKEND: django
       run: .github/aiida/setup_aiida.sh
 
     - name: Run previously skipped tests for adapter conversion
-      if: matrix.python-version == 3.8
+      if: matrix.python-version != 3.7
       run: pytest -rs -vvv --cov=./optimade/ --cov-report=xml --cov-append tests/adapters/
 
     - name: Upload coverage to Codecov

--- a/.github/workflows/deps_lint.yml
+++ b/.github/workflows/deps_lint.yml
@@ -178,8 +178,8 @@ jobs:
       env:
         OPTIMADE_CI_FORCE_MONGO: 1
 
-    - name: Run tests only for index meta-db (using `mongomock`)
-      run: pytest -rs -vvv --cov=./optimade/ --cov-report=xml --cov-append tests/server/test_middleware.py tests/server/test_server_validation.py tests/server/test_config.py
+    - name: Run all tests (using `mongomock`)
+      run: pytest -rs -vvv --cov=./optimade/ --cov-report=xml --cov-append tests/
       env:
         OPTIMADE_CI_FORCE_MONGO: 0
 

--- a/.github/workflows/deps_lint.yml
+++ b/.github/workflows/deps_lint.yml
@@ -128,7 +128,7 @@ jobs:
         index: yes
         validator version: ${{ github.sha }}  # This ensures the head of a PR or latest push commit is tested
 
-  deps_static:
+  pytest:
     runs-on: ubuntu-latest
 
     strategy:
@@ -174,12 +174,12 @@ jobs:
         pip install -e .
 
     - name: Run all tests (using a real MongoDB)
-      run: pytest -rs --cov=./optimade/ --cov-report=xml tests/
+      run: pytest -rs -vvv --cov=./optimade/ --cov-report=xml tests/
       env:
         OPTIMADE_CI_FORCE_MONGO: 1
 
     - name: Run tests only for index meta-db (using `mongomock`)
-      run: pytest -rs --cov=./optimade/ --cov-report=xml --cov-append tests/server/test_middleware.py tests/server/test_server_validation.py tests/server/test_config.py
+      run: pytest -rs -vvv --cov=./optimade/ --cov-report=xml --cov-append tests/server/test_middleware.py tests/server/test_server_validation.py tests/server/test_config.py
       env:
         OPTIMADE_CI_FORCE_MONGO: 0
 
@@ -198,7 +198,7 @@ jobs:
 
     - name: Run previously skipped tests for adapter conversion
       if: matrix.python-version == 3.8
-      run: pytest -rs --cov=./optimade/ --cov-report=xml --cov-append tests/adapters/
+      run: pytest -rs -vvv --cov=./optimade/ --cov-report=xml --cov-append tests/adapters/
 
     - name: Upload coverage to Codecov
       if: matrix.python-version == 3.8 && github.repository == 'Materials-Consortia/optimade-python-tools'

--- a/.github/workflows/publish-on-pypi.yml
+++ b/.github/workflows/publish-on-pypi.yml
@@ -31,7 +31,7 @@ jobs:
         pip install -U -e .[all]
 
     - name: Update version, generate changelog, and update '${{ env.PUBLISH_UPDATE_BRANCH }}'
-      uses: CasperWA/push-protected@master
+      uses: CasperWA/push-protected@v1
       with:
         token: ${{ secrets.RELEASE_PAT_CASPER }}
         repository: ${{ github.repository }}


### PR DESCRIPTION
Changes:
- Rename `deps_static` to `pytest`.
- Run `adapters` tests for any Python version except 3.7 (see #401 for more info).
- Run `pytest` for all tests with and without a real MongoDB.
  The old CI doesn't make sense anymore, since we no longer distinguish between "regular" and "index" servers. This is rather done directly in the tests themselves where needed.
- Use `v1` for `CasperWA/push-protected` action.
- Use high verbosity for all `pytest` runs, i.e., add a `-vvv` option.