### PR TITLE
Sorting on unknown properties: returning Bad Request when appropriate

### DIFF
--- a/optimade/server/entry_collections/entry_collections.py
+++ b/optimade/server/entry_collections/entry_collections.py
@@ -11,7 +11,7 @@ from optimade.server.config import CONFIG
 from optimade.server.exceptions import BadRequest, Forbidden
 from optimade.server.mappers import BaseResourceMapper
 from optimade.server.query_params import EntryListingQueryParams, SingleEntryQueryParams
-from optimade.server.warnings import FieldNotRecognised
+from optimade.server.warnings import FieldNotRecognized
 
 
 class EntryCollection(ABC):
@@ -220,7 +220,7 @@ class EntryCollection(ABC):
                 )
                 for field in unknown_fields
             ):
-                warnings.warn(error_detail, FieldNotRecognised)
+                warnings.warn(error_detail, FieldNotRecognized)
 
             # Otherwise, if all fields are unknown, or some fields are unknown and do not
             # have other provider prefixes, then return 400: Bad Request

--- a/optimade/server/entry_collections/entry_collections.py
+++ b/optimade/server/entry_collections/entry_collections.py
@@ -14,7 +14,8 @@ from optimade.server.warnings import FieldNotRecognised
 
 
 class EntryCollection(ABC):
-    """ Backend-agnostic base class for collections of [`EntryResource`][optimade.models.EntryResource]s. """
+    """ Backend-agnostic base class for querying collections of
+    `EntryResource`. """
 
     def __init__(
         self,
@@ -23,6 +24,19 @@ class EntryCollection(ABC):
         resource_mapper: BaseResourceMapper,
         transformer: Transformer,
     ):
+        """ Initialize the collection for the given parameters.
+
+        Parameters:
+            collection: The backend-specific collection.
+            resource_cls (EntryResource): The `EntryResource` model
+                that is stored by the collection.
+            resource_mapper (BaseResourceMapper): A resource mapper
+                object that handles aliases and format changes between
+                deserialization and response.
+            transformer (Transformer): The Lark `Transformer` used to
+                interpret the filter.
+
+        """
         self.collection = collection
         self.parser = LarkParser()
         self.resource_cls = resource_cls
@@ -38,8 +52,8 @@ class EntryCollection(ABC):
         """ Returns the number of entries matching the query specified
         by the keyword arguments.
 
-    Args:
-        kwargs (dict): Query parameters as keyword arguments.
+        Parameters:
+            kwargs (dict): Query parameters as keyword arguments.
 
         """
 
@@ -52,15 +66,11 @@ class EntryCollection(ABC):
 
         Also gives the total number of data available in the absence of [`page_limit`][optimade.server.query_params.EntryListingQueryParams.page_limit].
 
-        Args:
+        Parameters:
             params (EntryListingQueryParams): entry listing URL query params
 
         Returns:
-<<<<<<< Updated upstream
             Tuple[List[EntryResource], int, bool, set]: (`results`, `data_returned`, `more_data_available`, `fields`).
-=======
-            Tuple[List[Entry], int, bool, set, List[OptimadeWarnings]: (results, data_returned, more_data_available, fields)
->>>>>>> Stashed changes
 
         """
 
@@ -113,7 +123,8 @@ class EntryCollection(ABC):
         """ Parse and interpret the backend-agnostic query parameter models into a dictionary
         that can be used by the specific backend.
 
-        !!! note Currently returns the pymongo interpretation of the parameters,
+        Note:
+            Currently this method returns the pymongo interpretation of the parameters,
             which will need modification for modified for other backends.
 
         Parameters:
@@ -176,9 +187,8 @@ class EntryCollection(ABC):
             BadRequest: if an invalid sort is requested.
 
         Returns:
-            List[Tuple[str, int]]: A list of tuples containing the
-                aliased field name and sort direction encoded as
-                1 (ascending) or -1 (descending).
+            A list of tuples containing the aliased field name and
+            sort direction encoded as 1 (ascending) or -1 (descending).
 
         """
         sort_spec = []

--- a/optimade/server/entry_collections/entry_collections.py
+++ b/optimade/server/entry_collections/entry_collections.py
@@ -11,7 +11,7 @@ from optimade.server.config import CONFIG
 from optimade.server.exceptions import BadRequest
 from optimade.server.mappers import BaseResourceMapper
 from optimade.server.query_params import EntryListingQueryParams, SingleEntryQueryParams
-from optimade.server.warnings import OptimadeWarning
+from optimade.server.warnings import FieldNotRecognised
 
 
 class EntryCollection(ABC):
@@ -211,7 +211,7 @@ class EntryCollection(ABC):
                 )
                 for field in unknown_fields
             ):
-                warnings.warn(error_detail, OptimadeWarning)
+                warnings.warn(error_detail, FieldNotRecognised)
 
             # Otherwise, if all fields are unknown, or some fields are unknown and do not
             # have other provider prefixes, then return 400: Bad Request

--- a/optimade/server/entry_collections/entry_collections.py
+++ b/optimade/server/entry_collections/entry_collections.py
@@ -1,6 +1,7 @@
 from abc import abstractmethod, ABC
 from typing import Tuple, List, Union
 import warnings
+import re
 
 from lark import Transformer
 
@@ -214,7 +215,7 @@ class EntryCollection(ABC):
             # If all unknown fields are "other" provider-specific, then only provide a warning
             if all(
                 (
-                    field.startswith("_")
+                    re.match(r"_[a-z_0-9]+_[a-z_0-9]*", field)
                     and not field.startswith(f"_{self.provider_prefix}_")
                 )
                 for field in unknown_fields

--- a/optimade/server/entry_collections/entry_collections.py
+++ b/optimade/server/entry_collections/entry_collections.py
@@ -16,7 +16,7 @@ from optimade.server.warnings import FieldNotRecognized
 
 class EntryCollection(ABC):
     """ Backend-agnostic base class for querying collections of
-    `EntryResource`. """
+    [`EntryResource`][optimade.models.EntryResource]s. """
 
     def __init__(
         self,
@@ -65,13 +65,14 @@ class EntryCollection(ABC):
         """
         Fetches results and indicates if more data is available.
 
-        Also gives the total number of data available in the absence of [`page_limit`][optimade.server.query_params.EntryListingQueryParams.page_limit].
+        Also gives the total number of data available in the absence of
+        [`page_limit`][optimade.server.query_params.EntryListingQueryParams.page_limit].
 
         Parameters:
             params (EntryListingQueryParams): entry listing URL query params
 
         Returns:
-            Tuple[List[EntryResource], int, bool, set]: (`results`, `data_returned`, `more_data_available`, `fields`).
+            (`results`, `data_returned`, `more_data_available`, `fields`).
 
         """
 

--- a/optimade/server/entry_collections/entry_collections.py
+++ b/optimade/server/entry_collections/entry_collections.py
@@ -13,7 +13,7 @@ from optimade.server.query_params import EntryListingQueryParams, SingleEntryQue
 
 
 class EntryCollection(ABC):
-    """ Backend agnostic base class for collections of EntryResources. """
+    """ Backend-agnostic base class for collections of [`EntryResource`][optimade.models.EntryResource]s. """
 
     def __init__(
         self,
@@ -30,12 +30,15 @@ class EntryCollection(ABC):
 
     @abstractmethod
     def __len__(self) -> int:
-        """ Returns the overall number of entries in the collection. """
+        """ Returns the total number of entries in the collection. """
 
     @abstractmethod
     def count(self, **kwargs) -> int:
         """ Returns the number of entries matching the query specified
         by the keyword arguments.
+
+    Args:
+        kwargs (dict): Query parameters as keyword arguments.
 
         """
 
@@ -46,13 +49,13 @@ class EntryCollection(ABC):
         """
         Fetches results and indicates if more data is available.
 
-        Also gives the total number of data available in the absence of page_limit.
+        Also gives the total number of data available in the absence of [`page_limit`][optimade.server.query_params.EntryListingQueryParams.page_limit].
 
         Args:
             params (EntryListingQueryParams): entry listing URL query params
 
         Returns:
-            Tuple[List[Entry], int, bool, set]: (results, data_returned, more_data_available, fields)
+            Tuple[List[EntryResource], int, bool, set]: (`results`, `data_returned`, `more_data_available`, `fields`).
 
         """
 
@@ -61,6 +64,9 @@ class EntryCollection(ABC):
         """ Get the set of all fields handled in this collection, from
         attribute fields in the schema, provider fields and top-level
         OPTIMADE fields.
+
+    Returns:
+        set: All fields handled in this collection.
 
         """
         # All OPTIMADE fields
@@ -79,7 +85,7 @@ class EntryCollection(ABC):
         resource class, resolving references along the way.
 
         Returns:
-            the set of property names.
+            set: Property names.
 
         """
         schema = self.resource_cls.schema()
@@ -99,21 +105,22 @@ class EntryCollection(ABC):
     def handle_query_params(
         self, params: Union[EntryListingQueryParams, SingleEntryQueryParams]
     ) -> dict:
-        """ Parse and interpret the backend agnostic query parameter models into a dictionary
-        that can be used by the specific backend. Currently returns the pymongo
-        interpretation of the parameters, which will need modification for modified
-        for other backends.
+        """ Parse and interpret the backend-agnostic query parameter models into a dictionary
+        that can be used by the specific backend.
+        
+        !!! note Currently returns the pymongo interpretation of the parameters,
+            which will need modification for modified for other backends.
 
         Parameters:
-            params: the initialized query parameter model from the server.
+            params (Union[EntryListingQueryParams, SingleEntryQueryParams]): The initialized query parameter model from the server.
 
         Raises:
-            HTTPException: if too large a page limit is provided.
-            BadRequest: if an invalid request is made, e.g. with incorrect fields
+            HTTPException: If too large of a page limit is provided.
+            BadRequest: If an invalid request is made, e.g., with incorrect fields
                 or response format.
 
         Returns:
-            dict: a dictionary representation of the query parameters, ready to be used
+            dict: A dictionary representation of the query parameters, ready to be used
                 by pymongo.
 
         """
@@ -165,7 +172,7 @@ class EntryCollection(ABC):
             BadRequest: if an invalid sort is requested.
 
         Returns:
-            List[Tuple[str, int]]: a list of tuples containing the
+            List[Tuple[str, int]]: A list of tuples containing the
                 aliased field name and sort direction encoded as
                 1 (ascending) or -1 (descending).
 
@@ -199,7 +206,7 @@ class EntryCollection(ABC):
                 ),
             )
 
-        # if at least one valid field has been provided for sorting, then use that
+        # If at least one valid field has been provided for sorting, then use that
         sort_spec = tuple(
             (field, sort_dir)
             for field, sort_dir in sort_spec

--- a/optimade/server/entry_collections/mongo.py
+++ b/optimade/server/entry_collections/mongo.py
@@ -77,7 +77,7 @@ class MongoCollection(EntryCollection):
         and pagination of the output.
 
         Returns:
-            a list of entry resource objects, the number of returned entries,
+            Tuple[List[EntryResource], int, bool, set]: A list of entry resource objects, the number of returned entries,
             whether more are available with pagination, fields.
 
         """

--- a/optimade/server/entry_collections/mongo.py
+++ b/optimade/server/entry_collections/mongo.py
@@ -32,7 +32,10 @@ else:
 
 
 class MongoCollection(EntryCollection):
-    """ Collection class for MongoDB backends, using pymongo. """
+    """ Class for querying MongoDB collections (implemented by either pymongo or mongomock)
+    containing serialized [`EntryResource`][optimade.models.EntryResource]s objects.
+
+    """
 
     def __init__(
         self,
@@ -42,6 +45,18 @@ class MongoCollection(EntryCollection):
         resource_cls: EntryResource,
         resource_mapper: BaseResourceMapper,
     ):
+        """ Initialize the MongoCollection for the given parameters.
+
+        Parameters:
+            collection (Union[pymongo.collection.Collection, mongomock.collection.Collection]):
+                The backend-specific collection.
+            resource_cls (EntryResource): The `EntryResource` model
+                that is stored by the collection.
+            resource_mapper (BaseResourceMapper): A resource mapper
+                object that handles aliases and format changes between
+                deserialization and response.
+
+        """
         super().__init__(
             collection,
             resource_cls,
@@ -63,6 +78,15 @@ class MongoCollection(EntryCollection):
         return self.collection.estimated_document_count()
 
     def count(self, **kwargs) -> int:
+        """ Returns the number of entries matching the query specified
+        by the keyword arguments.
+
+        Parameters:
+            kwargs (dict): Query parameters as keyword arguments. The keys
+                'filter', 'skip', 'limit', 'hint' and 'maxTimeMS' will be passed
+                to the `pymongo.collection.Collection.count_documents` method.
+
+        """
         for k in list(kwargs.keys()):
             if k not in ("filter", "skip", "limit", "hint", "maxTimeMS"):
                 del kwargs[k]

--- a/optimade/server/exceptions.py
+++ b/optimade/server/exceptions.py
@@ -27,3 +27,17 @@ class VersionNotSupported(HTTPException):
     ) -> None:
         super().__init__(status_code=status_code, detail=detail, headers=headers)
         self.title = title
+
+
+class Forbidden(HTTPException):
+    """403 Forbidden"""
+
+    def __init__(
+        self,
+        status_code: int = 403,
+        detail: str = None,
+        headers: dict = None,
+        title: str = "Forbidden",
+    ) -> None:
+        super().__init__(status_code=status_code, detail=detail, headers=headers)
+        self.title = title

--- a/optimade/server/mappers/entries.py
+++ b/optimade/server/mappers/entries.py
@@ -95,6 +95,17 @@ class BaseResourceMapper:
         return field
 
     @classmethod
+    def alias_of(cls, field: str) -> str:
+        """ Return de-aliased field name, if it exists,
+        otherwise return the input field name.
+
+        """
+        split = field.split(".")
+        return {alias: real for real, alias in cls.all_aliases()}.get(
+            split[0], split[0]
+        )
+
+    @classmethod
     def get_required_fields(cls) -> set:
         """Return set REQUIRED response fields"""
         res = cls.TOP_LEVEL_NON_ATTRIBUTES_FIELDS.copy()

--- a/optimade/server/mappers/entries.py
+++ b/optimade/server/mappers/entries.py
@@ -99,6 +99,12 @@ class BaseResourceMapper:
         """ Return de-aliased field name, if it exists,
         otherwise return the input field name.
 
+    Args:
+        field (str): Field name to be de-aliased.
+
+    Returns:
+        str: De-aliased field name, falling back to returning `field`.
+
         """
         split = field.split(".")
         return {alias: real for real, alias in cls.all_aliases()}.get(

--- a/optimade/server/mappers/entries.py
+++ b/optimade/server/mappers/entries.py
@@ -99,11 +99,11 @@ class BaseResourceMapper:
         """ Return de-aliased field name, if it exists,
         otherwise return the input field name.
 
-    Args:
-        field (str): Field name to be de-aliased.
+        Args:
+            field (str): Field name to be de-aliased.
 
-    Returns:
-        str: De-aliased field name, falling back to returning `field`.
+        Returns:
+            str: De-aliased field name, falling back to returning `field`.
 
         """
         field = field.split(".")[0]

--- a/optimade/server/mappers/entries.py
+++ b/optimade/server/mappers/entries.py
@@ -106,9 +106,9 @@ class BaseResourceMapper:
         str: De-aliased field name, falling back to returning `field`.
 
         """
-        split = field.split(".")
+        field = field.split(".")[0]
         return {alias: real for real, alias in cls.all_aliases()}.get(
-            split[0], split[0]
+            field, field
         )
 
     @classmethod

--- a/optimade/server/mappers/entries.py
+++ b/optimade/server/mappers/entries.py
@@ -107,9 +107,7 @@ class BaseResourceMapper:
 
         """
         field = field.split(".")[0]
-        return {alias: real for real, alias in cls.all_aliases()}.get(
-            field, field
-        )
+        return {alias: real for real, alias in cls.all_aliases()}.get(field, field)
 
     @classmethod
     def get_required_fields(cls) -> set:

--- a/optimade/server/warnings.py
+++ b/optimade/server/warnings.py
@@ -35,5 +35,5 @@ class UnmatchedValues(OptimadeWarning):
     """Values of the same field or resource differ, where they should be equal"""
 
 
-class FieldNotRecognised(OptimadeWarning):
+class FieldNotRecognized(OptimadeWarning):
     """A field used in the request is not recognised by this implementation."""

--- a/optimade/server/warnings.py
+++ b/optimade/server/warnings.py
@@ -33,3 +33,7 @@ class FieldNotCreated(OptimadeWarning):
 
 class UnmatchedValues(OptimadeWarning):
     """Values of the same field or resource differ, where they should be equal"""
+
+
+class FieldNotRecognised(OptimadeWarning):
+    """A field used in the request is not recognised by this implementation."""

--- a/tests/server/query_params/test_filter.py
+++ b/tests/server/query_params/test_filter.py
@@ -84,7 +84,7 @@ def test_page_limit_max(check_error_response):
     check_error_response(
         request,
         expected_status=403,
-        expected_title="HTTPException",
+        expected_title="Forbidden",
         expected_detail=f"Max allowed page_limit is {CONFIG.page_limit_max}, you requested {CONFIG.page_limit_max + 1}",
     )
 

--- a/tests/server/query_params/test_sort.py
+++ b/tests/server/query_params/test_sort.py
@@ -102,7 +102,7 @@ def test_datetime_desc(get_good_response, structures):
     assert last_modified_list == expected_last_modified
 
 
-def test_unknown_field_errors(check_error_response, structures):
+def test_unknown_field_errors(check_error_response):
     """ If any completely unknown field is provided, check 400: Bad Request is returned. """
     limit = 5
     request = f"/structures?sort=field_that_does_not_exist&page_limit={limit}"
@@ -145,13 +145,13 @@ def test_unknown_field_prefixed(get_good_response, structures):
     request = f"/structures?sort=_exmpl3_field_that_does_not_exist,nelements&page_limit={limit}"
     data = structures.collection.find(sort=[("nelements", 1)], limit=limit)
     expected_nelements = [_["nelements"] for _ in data]
-
-    with pytest.warns(FieldNotRecognized):
-        response = get_good_response(request)
-
     expected_detail = (
         "Unable to sort on unknown field '_exmpl3_field_that_does_not_exist'"
     )
+
+    with pytest.warns(FieldNotRecognized, match=expected_detail):
+        response = get_good_response(request)
+
     assert len(response["meta"]["warnings"]) == 1
     assert response["meta"]["warnings"][0]["detail"] == expected_detail
     assert response["meta"]["warnings"][0]["title"] == "FieldNotRecognized"
@@ -163,10 +163,11 @@ def test_unknown_field_prefixed(get_good_response, structures):
 
     # case 5: only prefixed fields
     request = f"/structures?sort=-_exmpl2_field_that_does_not_exist,_exmpl3_other_field&page_limit={limit}"
-    with pytest.warns(FieldNotRecognized):
+    expected_detail = "Unable to sort on unknown fields '_exmpl2_field_that_does_not_exist', '_exmpl3_other_field'"
+
+    with pytest.warns(FieldNotRecognized, match=expected_detail):
         response = get_good_response(request)
 
-    expected_detail = "Unable to sort on unknown fields '_exmpl2_field_that_does_not_exist', '_exmpl3_other_field'"
     assert len(response["meta"]["warnings"]) == 1
     assert response["meta"]["warnings"][0]["detail"] == expected_detail
     assert response["meta"]["warnings"][0]["title"] == "FieldNotRecognized"

--- a/tests/server/query_params/test_sort.py
+++ b/tests/server/query_params/test_sort.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 
 import pytest
 
-from optimade.server.warnings import FieldNotRecognised
+from optimade.server.warnings import FieldNotRecognized
 
 
 @pytest.fixture(scope="module")
@@ -146,7 +146,7 @@ def test_unknown_field_prefixed(get_good_response, structures):
     data = structures.collection.find(sort=[("nelements", 1)], limit=limit)
     expected_nelements = [_["nelements"] for _ in data]
 
-    with pytest.warns(FieldNotRecognised):
+    with pytest.warns(FieldNotRecognized):
         response = get_good_response(request)
 
     expected_detail = (
@@ -154,7 +154,7 @@ def test_unknown_field_prefixed(get_good_response, structures):
     )
     assert len(response["meta"]["warnings"]) == 1
     assert response["meta"]["warnings"][0]["detail"] == expected_detail
-    assert response["meta"]["warnings"][0]["title"] == "FieldNotRecognised"
+    assert response["meta"]["warnings"][0]["title"] == "FieldNotRecognized"
 
     nelements_list = [
         struct.get("attributes", {}).get("nelements") for struct in response["data"]
@@ -163,10 +163,10 @@ def test_unknown_field_prefixed(get_good_response, structures):
 
     # case 5: only prefixed fields
     request = f"/structures?sort=-_exmpl2_field_that_does_not_exist,_exmpl3_other_field&page_limit={limit}"
-    with pytest.warns(FieldNotRecognised):
+    with pytest.warns(FieldNotRecognized):
         response = get_good_response(request)
 
     expected_detail = "Unable to sort on unknown fields '_exmpl2_field_that_does_not_exist', '_exmpl3_other_field'"
     assert len(response["meta"]["warnings"]) == 1
     assert response["meta"]["warnings"][0]["detail"] == expected_detail
-    assert response["meta"]["warnings"][0]["title"] == "FieldNotRecognised"
+    assert response["meta"]["warnings"][0]["title"] == "FieldNotRecognized"

--- a/tests/server/query_params/test_sort.py
+++ b/tests/server/query_params/test_sort.py
@@ -100,7 +100,7 @@ def test_datetime_desc(get_good_response, structures):
     assert last_modified_list == expected_last_modified
 
 
-def test_unknown_fields(get_good_response, check_error_response):
+def test_unknown_fields(get_good_response, check_error_response, structures):
     """Sorting with one valid field and many other *implementation-specific* fields should return only
     sorted data on the valid field.
 
@@ -132,7 +132,7 @@ def test_unknown_fields(get_good_response, check_error_response):
 
     # case 3: prefixed field and a valid field should be fine
     request = f"/structures?sort=_exmpl_field_that_does_not_exist,nelements&page_limit={limit}"
-    data = structures_coll.collection.find(sort=[("nelements", 1)], limit=limit)
+    data = structures.collection.find(sort=[("nelements", 1)], limit=limit)
     expected_nelements = [_["nelements"] for _ in data]
 
     response = get_good_response(request)

--- a/tests/server/test_mappers.py
+++ b/tests/server/test_mappers.py
@@ -33,6 +33,11 @@ def test_property_aliases(mapper):
     assert mapper.length_alias_for("test_field") is None
     assert mapper.alias_for("test_field") == "test_field"
 
+    assert mapper.alias_of("dft_parameters") == "_exmpl_dft_parameters"
+    assert mapper.alias_of("test_field") == "_exmpl_test_field"
+    assert mapper.alias_of("completely_different_field") == "field"
+    assert mapper.alias_of("nonexistent_field") == "nonexistent_field"
+
     # nested properties
     assert (
         mapper.alias_for("_exmpl_dft_parameters.nested.property")


### PR DESCRIPTION
This PR enables `400: Bad Request`s to be returned when requesting unknown fields. The specification provides a little bit of flexibility here, so I'll illustrate my approach with a few cases, with three classes of fields: known, unknown and "other provider" (those prefixed by `_` with no known alias):

1. User requests sorting on exclusively unknown fields -> Bad Request. e.g. `sort=foo,bar`.
2. User requests sorting on exclusively "other provider" fields -> Warning, e.g. `sort=_exmpl_foo,_exmpl_bar`.
3. User requests sorting on known field and unknown field -> Bad Request, e.g. `sort=nelements,foo`.
4. User requests sorting on known field and "other provider" field -> sort on known field only. e.g. `sort=nelements,_exmpl_foo`.

Closes #276. 

To-do:

- [x] Turn case 2/ above into a warning