### PR TITLE
New middleware to catch any `OptimadeWarning`s

### DIFF
--- a/optimade/adapters/structures/proteindatabank.py
+++ b/optimade/adapters/structures/proteindatabank.py
@@ -84,7 +84,7 @@ def get_pdbx_mmcif(  # pylint: disable=too-many-locals
                 cartesian_positions=attributes.cartesian_site_positions,
             )
 
-    # TODO: The following lines are perhaps needed to create a "valid" PDBx/mmCIF file.
+    # NOTE: The following lines are perhaps needed to create a "valid" PDBx/mmCIF file.
     # However, at the same time, the information here is "default" and will for all structures "at this moment in time"
     # be the same. I.e., no information is gained by adding this now.
     # If it is found that they indeed are needed to create a "valid" PDBx/mmCIF file, they should be included in the output.

--- a/optimade/server/exception_handlers.py
+++ b/optimade/server/exception_handlers.py
@@ -47,24 +47,16 @@ def general_exception(
     if errors is None:
         errors = [OptimadeError(detail=detail, status=http_response_code, title=title)]
 
-    try:
-        response = ErrorResponse(
-            meta=meta_values(
-                url=str(request.url),
-                data_returned=0,
-                data_available=0,
-                more_data_available=False,
-                **debug_info,
-            ),
-            errors=errors,
-        )
-    except Exception:
-        # This was introduced due to the original raise of an HTTPException if the
-        # path prefix could not be found, e.g., `/v0`.
-        # However, due to the testing, this error cannot be raised anymore.
-        # Instead, an OPTIMADE warning should be issued.
-        # Having this try and except is still good practice though.
-        response = ErrorResponse(errors=errors)
+    response = ErrorResponse(
+        meta=meta_values(
+            url=str(request.url),
+            data_returned=0,
+            data_available=0,
+            more_data_available=False,
+            **debug_info,
+        ),
+        errors=errors,
+    )
 
     return JSONResponse(
         status_code=http_response_code,

--- a/optimade/server/main.py
+++ b/optimade/server/main.py
@@ -12,7 +12,11 @@ import optimade.server.exception_handlers as exc_handlers
 
 from .entry_collections import MongoCollection
 from .config import CONFIG
-from .middleware import EnsureQueryParamIntegrity, CheckWronglyVersionedBaseUrls
+from .middleware import (
+    AddWarnings,
+    CheckWronglyVersionedBaseUrls,
+    EnsureQueryParamIntegrity,
+)
 from .routers import info, links, references, structures, landing, versions
 from .routers.utils import get_providers, BASE_URL_PREFIXES
 
@@ -56,6 +60,7 @@ if not CONFIG.use_real_mongo:
 
 
 # Add various middleware
+app.add_middleware(AddWarnings)
 app.add_middleware(CORSMiddleware, allow_origins=["*"])
 app.add_middleware(EnsureQueryParamIntegrity)
 app.add_middleware(CheckWronglyVersionedBaseUrls)

--- a/optimade/server/main_index.py
+++ b/optimade/server/main_index.py
@@ -13,8 +13,9 @@ import optimade.server.exception_handlers as exc_handlers
 
 from optimade.server.config import CONFIG
 from optimade.server.middleware import (
-    EnsureQueryParamIntegrity,
+    AddWarnings,
     CheckWronglyVersionedBaseUrls,
+    EnsureQueryParamIntegrity,
 )
 from optimade.server.routers import index_info, links, versions
 from optimade.server.routers.utils import BASE_URL_PREFIXES
@@ -62,6 +63,7 @@ if not CONFIG.use_real_mongo and CONFIG.index_links_path.exists():
 
 
 # Add various middleware
+app.add_middleware(AddWarnings)
 app.add_middleware(CORSMiddleware, allow_origins=["*"])
 app.add_middleware(EnsureQueryParamIntegrity)
 app.add_middleware(CheckWronglyVersionedBaseUrls)

--- a/optimade/server/middleware.py
+++ b/optimade/server/middleware.py
@@ -94,7 +94,8 @@ class AddWarnings(BaseHTTPMiddleware):
     chunks of the original response's chunk size.
 
     Attributes:
-        _warnings (list): List of warnings added through usages of `warnings.warn()`.
+        _warnings (List[Warnings]): List of [Warnings][optimade.models.optimade_json.Warnings]
+            added through usages of `warnings.warn()` via [showwarning][optimade.server.middleware.AddWarnings.showwarning].
 
     """
 

--- a/optimade/server/middleware.py
+++ b/optimade/server/middleware.py
@@ -95,6 +95,7 @@ class AddWarnings(BaseHTTPMiddleware):
             # If the Warning is not an OptimadeWarning or subclass thereof,
             # use the regular 'showwarning' function.
             warnings._showwarning_orig(message, category, filename, lineno, file, line)
+            return
 
         # Format warning
         try:
@@ -134,6 +135,11 @@ class AddWarnings(BaseHTTPMiddleware):
 
         # Add new warning to self._warnings
         self._warnings.append(new_warning.dict(exclude_unset=True))
+
+        # Show warning message as normal in sys.stdout
+        warnings._showwarnmsg_impl(
+            warnings.WarningMessage(message, category, filename, lineno, file, line)
+        )
 
     @staticmethod
     def chunk_it_up(content: str, chunk_size: int) -> Generator:

--- a/optimade/server/routers/utils.py
+++ b/optimade/server/routers/utils.py
@@ -144,8 +144,8 @@ def get_included_relationships(
             if entry_relationship is not None:
                 refs = entry_relationship.get("data", [])
                 for ref in refs:
-                    # could check here and raise a warning if any IDs clash
-                    endpoint_includes[entry_type][ref["id"]] = ref
+                    if ref["id"] not in endpoint_includes[entry_type]:
+                        endpoint_includes[entry_type][ref["id"]] = ref
 
     included = {}
     for entry_type in endpoint_includes:

--- a/optimade/server/warnings.py
+++ b/optimade/server/warnings.py
@@ -1,0 +1,30 @@
+class OptimadeWarning(Warning):
+    """Base Warning for the `optimade` package"""
+
+    def __init__(
+        self, detail: str = None, headers: dict = None, title: str = None, *args,
+    ) -> None:
+        super().__init__(detail, *args)
+        self.detail = detail
+        self.headers = headers
+        self.title = title
+
+    def __repr__(self) -> str:
+        attrs = {
+            "detail": repr(self.detail),
+            "headers": repr(self.headers),
+            "title": repr(self.title),
+        }
+        return "<{}({})>".format(
+            self.__class__.__name__,
+            " ".join(
+                [
+                    f"{attr}={value}"
+                    for attr, value in attrs.items()
+                    if value is not None
+                ]
+            ),
+        )
+
+    def __str__(self) -> str:
+        return self.detail if self.detail is not None else ""

--- a/optimade/server/warnings.py
+++ b/optimade/server/warnings.py
@@ -2,6 +2,7 @@ class OptimadeWarning(Warning):
     """Base Warning for the `optimade` package"""
 
     def __init__(self, detail: str = None, title: str = None, *args) -> None:
+        detail = detail if detail else ""
         super().__init__(detail, *args)
         self.detail = detail
         self.title = title if title else self.__class__.__name__

--- a/optimade/server/warnings.py
+++ b/optimade/server/warnings.py
@@ -1,25 +1,21 @@
 class OptimadeWarning(Warning):
     """Base Warning for the `optimade` package"""
 
-    def __init__(
-        self, detail: str = None, headers: dict = None, title: str = None, *args,
-    ) -> None:
+    def __init__(self, detail: str = None, title: str = None, *args) -> None:
         super().__init__(detail, *args)
         self.detail = detail
-        self.headers = headers
-        self.title = title
+        self.title = title if title else self.__class__.__name__
 
     def __repr__(self) -> str:
         attrs = {
-            "detail": repr(self.detail),
-            "headers": repr(self.headers),
-            "title": repr(self.title),
+            "detail": self.detail,
+            "title": self.title,
         }
-        return "<{}({})>".format(
+        return "<{:s}({:s})>".format(
             self.__class__.__name__,
             " ".join(
                 [
-                    f"{attr}={value}"
+                    f"{attr}={value!r}"
                     for attr, value in attrs.items()
                     if value is not None
                 ]

--- a/optimade/server/warnings.py
+++ b/optimade/server/warnings.py
@@ -2,7 +2,7 @@ class OptimadeWarning(Warning):
     """Base Warning for the `optimade` package"""
 
     def __init__(self, detail: str = None, title: str = None, *args) -> None:
-        detail = detail if detail else ""
+        detail = detail if detail else self.__doc__
         super().__init__(detail, *args)
         self.detail = detail
         self.title = title if title else self.__class__.__name__
@@ -25,3 +25,11 @@ class OptimadeWarning(Warning):
 
     def __str__(self) -> str:
         return self.detail if self.detail is not None else ""
+
+
+class FieldNotCreated(OptimadeWarning):
+    """A non-essential field could not be created"""
+
+
+class UnmatchedValues(OptimadeWarning):
+    """Values of the same field or resource differ, where they should be equal"""

--- a/tests/server/test_middleware.py
+++ b/tests/server/test_middleware.py
@@ -151,3 +151,68 @@ def test_multiple_versions_in_path(both_clients):
     finally:
         if org_base_url:
             CONFIG.base_url = org_base_url
+
+
+def test_showwarning_overload(both_clients):
+    """Make sure warnings.showwarning can be overloaded correctly"""
+    import warnings
+
+    from optimade.server.middleware import AddWarnings
+    from optimade.server.warnings import OptimadeWarning
+
+    add_warning_middleware = AddWarnings(both_clients.app)
+    add_warning_middleware._warnings = []
+
+    warnings.showwarning = add_warning_middleware.showwarning
+
+    warning_message = "It's all gone awry!"
+
+    warnings.warn(OptimadeWarning(detail=warning_message))
+
+    assert add_warning_middleware._warnings == [
+        {"title": OptimadeWarning.__name__, "detail": warning_message}
+    ]
+
+
+def test_showwarning_debug(both_clients):
+    """Make sure warnings.showwarning adds 'meta' field in DEBUG MODE"""
+    import warnings
+
+    from optimade.server.config import CONFIG
+    from optimade.server.middleware import AddWarnings
+    from optimade.server.warnings import OptimadeWarning
+
+    add_warning_middleware = AddWarnings(both_clients.app)
+    add_warning_middleware._warnings = []
+
+    warnings.showwarning = add_warning_middleware.showwarning
+
+    warning_message = "It's all gone awry!"
+
+    org_debug = CONFIG.debug
+    try:
+        CONFIG.debug = True
+
+        warnings.warn(OptimadeWarning(detail=warning_message))
+
+        assert add_warning_middleware._warnings != [
+            {"title": OptimadeWarning.__name__, "detail": warning_message}
+        ]
+        warning = add_warning_middleware._warnings[0]
+        assert "meta" in warning
+        for meta_field in ("filename", "lineno", "line"):
+            assert meta_field in warning["meta"]
+    finally:
+        CONFIG.debug = org_debug
+
+
+def test_chunk_it_up():
+    """Make sure all content is return from `chunk_it_up` generator"""
+    from optimade.server.middleware import AddWarnings
+
+    content = "Oh what a sad and tragic waste of a young attractive life!"
+    chunk_size = 16
+    assert len(content) % chunk_size != 0, "We want a rest bit, this isn't helpful!"
+
+    generator = AddWarnings.chunk_it_up(content, chunk_size)
+    assert "".join(generator) == content

--- a/tests/server/test_middleware.py
+++ b/tests/server/test_middleware.py
@@ -160,8 +160,6 @@ def test_showwarning_overload(both_clients, recwarn):
     from optimade.server.middleware import AddWarnings
     from optimade.server.warnings import OptimadeWarning
 
-    warnings.simplefilter("always")
-
     add_warning_middleware = AddWarnings(both_clients.app)
     # Set up things that are setup usually in `dispatch()`
     add_warning_middleware._warnings = []
@@ -184,7 +182,7 @@ def test_showwarning_overload(both_clients, recwarn):
     assert recwarn.pop(UserWarning)
 
 
-def test_showwarning_debug(both_clients):
+def test_showwarning_debug(both_clients, recwarn):
     """Make sure warnings.showwarning adds 'meta' field in DEBUG MODE"""
     import warnings
 
@@ -213,6 +211,8 @@ def test_showwarning_debug(both_clients):
         assert "meta" in warning
         for meta_field in ("filename", "lineno", "line"):
             assert meta_field in warning["meta"]
+        assert len(recwarn.list) == 1
+        assert recwarn.pop(OptimadeWarning)
     finally:
         CONFIG.debug = org_debug
 


### PR DESCRIPTION
This is put as the first added middleware, since the order in which middleware is added to the application matters.
See https://www.starlette.io/middleware/

The middleware is a bit hacky, since it's based on Starlette's `BaseHTTPMiddleware`, which uses the `call_next` function that creates a `StreamingResponse`.
This middleware will temporarily stitch the response back together, add the warnings, and chop up the response again, returning a new `StreamingResponse`.

Another thing that's a bit hacky about this is the way in which warnings are collected. I currently use an in-memory attribute from the middleware class, however, I am not sure if this is thread-safe.

Note, I have tested this by raising a simple warning in a router and it seemed to work :)

Closes #105

---

Missing:
- [x] Tests
- [x] Add in all "TODO" warnings littered around in the code.
- [x] Tests for ^these warnings.