### PR TITLE
Provider list fallback and list of providers in both servers' `/links`-endpoints

### DIFF
--- a/.github/workflows/update_docs.sh
+++ b/.github/workflows/update_docs.sh
@@ -19,7 +19,7 @@ echo "\n-o- Commit update - API Reference -o-"
 git add docs/api_reference
 git commit -m "Release ${GITHUB_REF#refs/tags/} - API Reference"
 
-echo "-o- Update version -o-"
+echo "\n-o- Update version -o-"
 invoke setver -v ${GITHUB_REF#refs/tags/}
 
 echo "\n-o- Generate changelog -o-"

--- a/optimade/server/main.py
+++ b/optimade/server/main.py
@@ -68,6 +68,7 @@ This specification is generated using [`optimade-python-tools`](https://github.c
 
 if not CONFIG.use_real_mongo:
     import bson.json_util
+    from bson.objectid import ObjectId
     import optimade.server.data as data
     from optimade.server.routers import ENTRY_COLLECTIONS
     from optimade.server.routers.utils import get_providers
@@ -81,9 +82,11 @@ if not CONFIG.use_real_mongo:
                 "  Adding Materials-Consortia providers to links from optimade.org"
             )
             providers = get_providers()
-            if providers:
-                endpoint_collection.collection.insert_many(
-                    bson.json_util.loads(bson.json_util.dumps(providers))
+            for doc in providers:
+                endpoint_collection.collection.replace_one(
+                    filter={"_id": ObjectId(doc["_id"]["$oid"])},
+                    replacement=bson.json_util.loads(bson.json_util.dumps(doc)),
+                    upsert=True,
                 )
         LOGGER.debug("Done inserting test %s!", endpoint_name)
 

--- a/optimade/server/main_index.py
+++ b/optimade/server/main_index.py
@@ -61,24 +61,33 @@ This specification is generated using [`optimade-python-tools`](https://github.c
 
 if not CONFIG.use_real_mongo and CONFIG.index_links_path.exists():
     import bson.json_util
-    from .routers.links import links_coll
-    from .routers.utils import mongo_id_for_database
+    from optimade.server.routers.links import links_coll
+    from optimade.server.routers.utils import mongo_id_for_database, get_providers
 
     LOGGER.debug("Loading index links...")
     with open(CONFIG.index_links_path) as f:
         data = json.load(f)
 
-        processed = []
+    processed = []
+    for db in data:
+        db["_id"] = {"$oid": mongo_id_for_database(db["id"], db["type"])}
+        processed.append(db)
 
-        for db in data:
-            db["_id"] = {"$oid": mongo_id_for_database(db["id"], db["type"])}
-            processed.append(db)
+    LOGGER.debug(
+        "  Inserting index links into collection from %s...", CONFIG.index_links_path
+    )
+    links_coll.collection.insert_many(
+        bson.json_util.loads(bson.json_util.dumps(processed))
+    )
 
-        LOGGER.debug("Inserting index links into collection...")
+    LOGGER.debug("  Adding Materials-Consortia providers to links from optimade.org...")
+    providers = get_providers()
+    if providers:
         links_coll.collection.insert_many(
-            bson.json_util.loads(bson.json_util.dumps(processed))
+            bson.json_util.loads(bson.json_util.dumps(providers))
         )
-        LOGGER.debug("Done inserting index links...")
+
+    LOGGER.debug("Done inserting index links!")
 
 
 # Add various middleware

--- a/optimade/server/main_index.py
+++ b/optimade/server/main_index.py
@@ -61,6 +61,7 @@ This specification is generated using [`optimade-python-tools`](https://github.c
 
 if not CONFIG.use_real_mongo and CONFIG.index_links_path.exists():
     import bson.json_util
+    from bson.objectid import ObjectId
     from optimade.server.routers.links import links_coll
     from optimade.server.routers.utils import mongo_id_for_database, get_providers
 
@@ -82,9 +83,11 @@ if not CONFIG.use_real_mongo and CONFIG.index_links_path.exists():
 
     LOGGER.debug("  Adding Materials-Consortia providers to links from optimade.org...")
     providers = get_providers()
-    if providers:
-        links_coll.collection.insert_many(
-            bson.json_util.loads(bson.json_util.dumps(providers))
+    for doc in providers:
+        links_coll.collection.replace_one(
+            filter={"_id": ObjectId(doc["_id"]["$oid"])},
+            replacement=bson.json_util.loads(bson.json_util.dumps(doc)),
+            upsert=True,
         )
 
     LOGGER.debug("Done inserting index links!")

--- a/optimade/server/routers/utils.py
+++ b/optimade/server/routers/utils.py
@@ -318,7 +318,8 @@ def get_providers() -> list:
     Fallback order if providers.optimade.org is not available:
 
     1. Try Materials-Consortia/providers on GitHub.
-    2. Log warning that providers list from Materials-Consortia is not included in the
+    2. Try submodule `providers`' list of providers.
+    3. Log warning that providers list from Materials-Consortia is not included in the
        `/links`-endpoint.
 
     Returns:
@@ -350,20 +351,23 @@ def get_providers() -> list:
         else:
             break
     else:
-        from optimade.server.logger import LOGGER
+        try:
+            from optimade.server.data import providers
+        except ImportError:
+            from optimade.server.logger import LOGGER
 
-        LOGGER.warning(
-            """Could not retrieve a list of providers!
+            LOGGER.warning(
+                """Could not retrieve a list of providers!
 
     Tried the following resources:
 
 {}
     The list of providers will not be included in the `/links`-endpoint.
 """.format(
-                "".join([f"    * {_}\n" for _ in provider_list_urls])
+                    "".join([f"    * {_}\n" for _ in provider_list_urls])
+                )
             )
-        )
-        return []
+            return []
 
     providers_list = []
     for provider in providers.get("data", []):

--- a/optimade/server/routers/utils.py
+++ b/optimade/server/routers/utils.py
@@ -375,7 +375,7 @@ def get_providers() -> list:
         if provider["id"] == "exmpl":
             continue
 
-        provider.update(provider.pop("attributes"))
+        provider.update(provider.pop("attributes", {}))
 
         # Add MongoDB ObjectId
         provider["_id"] = {

--- a/optimade/server/routers/utils.py
+++ b/optimade/server/routers/utils.py
@@ -312,32 +312,58 @@ def mongo_id_for_database(database_id: str, database_type: str) -> str:
     return str(ObjectId(oid.encode("UTF-8")))
 
 
-def get_providers():
-    """Retrieve Materials-Consortia providers (from https://providers.optimade.org/v1/links)"""
+def get_providers() -> list:
+    """Retrieve Materials-Consortia providers (from https://providers.optimade.org/v1/links).
+
+    Fallback order if providers.optimade.org is not available:
+
+    1. Try Materials-Consortia/providers on GitHub.
+    2. Log warning that providers list from Materials-Consortia is not included in the
+       `/links`-endpoint.
+
+    Returns:
+        List of raw JSON-decoded providers including MongoDB object IDs.
+
+    """
     import requests
 
     try:
-        from optimade.server.data import providers
+        import simplejson as json
     except ImportError:
-        providers = None
+        import json
 
-    if providers is None:
-        try:
-            import simplejson as json
-        except ImportError:
-            import json
+    provider_list_urls = [
+        "https://providers.optimade.org/v1/links",
+        "https://raw.githubusercontent.com/Materials-Consortia/providers"
+        "/master/src/links/v1/providers.json",
+    ]
 
+    for provider_list_url in provider_list_urls:
         try:
-            providers = requests.get("https://providers.optimade.org/v1/links").json()
+            providers = requests.get(provider_list_url).json()
         except (
             requests.exceptions.ConnectionError,
             requests.exceptions.ConnectTimeout,
             json.JSONDecodeError,
         ):
-            raise BadRequest(
-                status_code=500,
-                detail="Could not retrieve providers list from https://providers.optimade.org",
+            pass
+        else:
+            break
+    else:
+        from optimade.server.logger import LOGGER
+
+        LOGGER.warning(
+            """Could not retrieve a list of providers!
+
+    Tried the following resources:
+
+{}
+    The list of providers will not be included in the `/links`-endpoint.
+""".format(
+                "".join([f"    * {_}\n" for _ in provider_list_urls])
             )
+        )
+        return []
 
     providers_list = []
     for provider in providers.get("data", []):

--- a/tasks.py
+++ b/tasks.py
@@ -25,18 +25,6 @@ def update_file(filename: str, sub_line: Tuple[str, str], strip: str = None):
         handle.write("\n")
 
 
-def purge_mongomock_db():
-    """Utility function for generating Open API JSON files
-
-    Since the `/links`-endpoint data overlap, there is a need to purge the
-    local in-memory MongoMock database, since similar named collections are used.
-    """
-    from optimade.server.routers import ENTRY_COLLECTIONS
-
-    for collection in ENTRY_COLLECTIONS.values():
-        collection.collection.delete_many({"_id": {"$exists": True}})
-
-
 @task
 def generate_openapi(_):
     """Update OpenAPI schema in file 'local_openapi.json'"""
@@ -47,8 +35,6 @@ def generate_openapi(_):
     with open(TOP_DIR.joinpath("openapi/local_openapi.json"), "w") as f:
         json.dump(app.openapi(), f, indent=2)
         print("", file=f)  # Empty EOL
-
-    purge_mongomock_db()
 
 
 @task
@@ -61,8 +47,6 @@ def generate_index_openapi(_):
     with open(TOP_DIR.joinpath("openapi/local_index_openapi.json"), "w") as f:
         json.dump(app_index.openapi(), f, indent=2)
         print("", file=f)  # Empty EOL
-
-    purge_mongomock_db()
 
 
 @task(pre=[generate_openapi, generate_index_openapi])

--- a/tasks.py
+++ b/tasks.py
@@ -25,6 +25,18 @@ def update_file(filename: str, sub_line: Tuple[str, str], strip: str = None):
         handle.write("\n")
 
 
+def purge_mongomock_db():
+    """Utility function for generating Open API JSON files
+
+    Since the `/links`-endpoint data overlap, there is a need to purge the
+    local in-memory MongoMock database, since similar named collections are used.
+    """
+    from optimade.server.routers import ENTRY_COLLECTIONS
+
+    for collection in ENTRY_COLLECTIONS.values():
+        collection.collection.delete_many({"_id": {"$exists": True}})
+
+
 @task
 def generate_openapi(_):
     """Update OpenAPI schema in file 'local_openapi.json'"""
@@ -35,6 +47,8 @@ def generate_openapi(_):
     with open(TOP_DIR.joinpath("openapi/local_openapi.json"), "w") as f:
         json.dump(app.openapi(), f, indent=2)
         print("", file=f)  # Empty EOL
+
+    purge_mongomock_db()
 
 
 @task
@@ -47,6 +61,8 @@ def generate_index_openapi(_):
     with open(TOP_DIR.joinpath("openapi/local_index_openapi.json"), "w") as f:
         json.dump(app_index.openapi(), f, indent=2)
         print("", file=f)  # Empty EOL
+
+    purge_mongomock_db()
 
 
 @task(pre=[generate_openapi, generate_index_openapi])

--- a/tests/server/routers/test_utils.py
+++ b/tests/server/routers/test_utils.py
@@ -1,0 +1,123 @@
+"""Tests specifically for optimade.servers.routers.utils."""
+from typing import Mapping, Optional, Tuple, Union
+from unittest import mock
+
+from requests.exceptions import ConnectionError
+
+import pytest
+
+
+def mocked_providers_list_response(
+    url: Union[str, bytes] = "",
+    param: Optional[Union[Mapping[str, str], Tuple[str, str]]] = None,
+    **kwargs,
+):
+    """This function will be used to mock requests.get
+
+    It will _always_ return a successful response, returning the submodule's provider.json.
+
+    NOTE: This function is loosely inspired by the stackoverflow response here:
+        https://stackoverflow.com/questions/15753390/how-can-i-mock-requests-and-the-response
+    """
+    try:
+        from optimade.server.data import providers
+    except ImportError:
+        pytest.fail(
+            "Cannot import providers from optimade.server.data, "
+            "please initialize the `providers` submodule!"
+        )
+
+    class MockResponse:
+        def __init__(self, data: Union[list, dict], status_code: int):
+            self.data = data
+            self.status_code = status_code
+
+        def json(self) -> Union[list, dict]:
+            return self.data
+
+    return MockResponse(providers, 200)
+
+
+def test_get_providers():
+    """Make sure valid responses are handled as expected."""
+    try:
+        from optimade.server.data import providers
+    except ImportError:
+        pytest.fail(
+            "Cannot import providers from optimade.server.data, "
+            "please initialize the `providers` submodule!"
+        )
+
+    from optimade.server.routers.utils import get_providers, mongo_id_for_database
+
+    side_effects = [
+        mocked_providers_list_response,
+        ConnectionError,
+    ]
+
+    for side_effect in side_effects:
+        with mock.patch("requests.get", side_effect=side_effect):
+            providers_list = [
+                _ for _ in providers.get("data", []) if _["id"] != "exmpl"
+            ]
+            for provider in providers_list:
+                provider.update(
+                    {
+                        "_id": {
+                            "$oid": mongo_id_for_database(
+                                provider["id"], provider["type"]
+                            )
+                        }
+                    }
+                )
+            assert get_providers() == providers_list
+
+
+def test_get_providers_warning(caplog, top_dir):
+    """Make sure a warning is logged as a last resort."""
+    from optimade.server.routers.utils import get_providers
+
+    providers_symlink = top_dir.joinpath("optimade/server/data/providers.json")
+    provider_list_urls = [
+        "https://providers.optimade.org/v1/links",
+        "https://raw.githubusercontent.com/Materials-Consortia/providers"
+        "/master/src/links/v1/providers.json",
+    ]
+
+    try:
+        if providers_symlink.exists():
+            providers_symlink.rename(
+                top_dir.joinpath("optimade/server/data/providers_test.json")
+            )
+
+        list_of_data_files = [_.name for _ in providers_symlink.parent.glob("*")]
+        assert "providers.json" not in list_of_data_files
+        assert "providers_test.json" in list_of_data_files
+
+        caplog.clear()
+        with mock.patch("requests.get", side_effect=ConnectionError):
+            assert get_providers() == []
+
+            warning_message = """Could not retrieve a list of providers!
+
+    Tried the following resources:
+
+{}
+    The list of providers will not be included in the `/links`-endpoint.
+""".format(
+                "".join([f"    * {_}\n" for _ in provider_list_urls])
+            )
+            assert warning_message in caplog.messages
+
+    finally:
+        providers_symlink_test = top_dir.joinpath(
+            "optimade/server/data/providers_test.json"
+        )
+        if providers_symlink_test.exists():
+            providers_symlink_test.rename(
+                top_dir.joinpath("optimade/server/data/providers.json")
+            )
+
+        list_of_data_files = [_.name for _ in providers_symlink_test.parent.glob("*")]
+        assert "providers.json" in list_of_data_files
+        assert "providers_test.json" not in list_of_data_files


### PR DESCRIPTION
Fixes #450
Fixes #454

We experienced that providers.optimade.org was down for some time, hence this will make sure to use some fallback's to try and retrieve the list of providers.

Another thing is fixed in this PR. Namely that the list of providers was not included for the index meta-database.
There was a good reason why: The same links MongoDB collection was used in-memory when starting both servers within the same environment.
This has been fixed by the use of `replace_one`/`replaceOne` thanks to some help from @shyamd.