### PR TITLE
Update dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,10 @@ updates:
   target-branch: master
   labels:
   - providers_updates
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+  target-branch: master
+  labels:
+  - CI

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,9 @@ updates:
 - package-ecosystem: pip
   directory: "/"
   schedule:
-    interval: monthly
-  open-pull-requests-limit: 10
+    interval: weekly
+  # Needs to be larger than the number of total requirements (currently 31)
+  open-pull-requests-limit: 50
   target-branch: master
   labels:
   - dependency_updates
@@ -12,7 +13,6 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-  open-pull-requests-limit: 10
   target-branch: master
   labels:
   - providers_updates

--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -1,5 +1,5 @@
 aiida-core==1.3.0
-ase==3.19.2
+ase==3.20.1
 numpy==1.19.1
 pymatgen==2020.7.18
 jarvis-tools==2020.7.25

--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -1,5 +1,5 @@
 aiida-core==1.3.0
 ase==3.20.1
 numpy==1.19.1
-pymatgen==2020.7.18
+pymatgen==2020.8.13
 jarvis-tools==2020.7.25

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,9 @@
-pytest==5.4.3
+pytest==6.0.1
 pytest-cov==2.10.0
-codecov==2.1.8
+codecov==2.1.9
 openapi-spec-validator==0.2.9
 jsondiff==1.2.0
-pylint==2.5.3
+pylint==2.6.0
 black==19.10b0
-pre-commit==2.6.0
+pre-commit==2.7.1
 invoke==1.4.1

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -2,4 +2,4 @@ mkdocs==1.1.2
 mkdocs-awesome-pages-plugin==2.2.1
 mkdocs-material==5.5.2
 mkdocs-minify-plugin==0.3.0
-mkdocstrings==0.12.2
+mkdocstrings==0.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
-fastapi==0.60.1
+fastapi==0.61.0
 lark-parser==0.9.0
 pydantic==1.6.1
 email_validator==1.1.1
 requests==2.24.0
 uvicorn==0.11.8
 pymongo==3.11.0
-mongomock==3.19.0
+mongomock==3.20.0
 django==3.0.8
 elasticsearch-dsl==7.2.1
 Jinja2==2.11.2
-typing-extensions==3.7.4.2
+typing-extensions==3.7.4.3

--- a/setup.py
+++ b/setup.py
@@ -19,15 +19,15 @@ with open(module_dir.joinpath("optimade/__init__.py")) as version_file:
 # Server minded
 django_deps = ["django>=2.2.9,<4.0"]
 elastic_deps = ["elasticsearch-dsl>=6.4,<8.0"]
-mongo_deps = ["pymongo~=3.11", "mongomock~=3.19"]
+mongo_deps = ["pymongo~=3.11", "mongomock~=3.20"]
 server_deps = ["uvicorn~=0.11.8", "Jinja2~=2.11"] + mongo_deps
 
 # Client minded
 aiida_deps = ["aiida-core~=1.3"]
-ase_deps = ["ase~=3.19"]
+ase_deps = ["ase~=3.20"]
 cif_deps = ["numpy~=1.19"]
 pdb_deps = cif_deps
-pymatgen_deps = ["pymatgen==2020.7.18"]
+pymatgen_deps = ["pymatgen==2020.8.13"]
 jarvis_deps = ["jarvis-tools==2020.7.25"]
 client_deps = cif_deps
 
@@ -37,17 +37,17 @@ docs_deps = [
     "mkdocs-awesome-pages-plugin~=2.2",
     "mkdocs-material~=5.5",
     "mkdocs-minify-plugin~=0.3.0",
-    "mkdocstrings~=0.12.1",
+    "mkdocstrings~=0.13.0",
 ]
 testing_deps = [
-    "pytest~=5.4",
+    "pytest~=6.0",
     "pytest-cov~=2.10",
     "codecov~=2.1",
     "openapi-spec-validator~=0.2.9",
     "jsondiff~=1.2",
 ] + server_deps
 dev_deps = (
-    ["pylint~=2.5", "black~=19.10b0", "pre-commit~=2.6", "invoke~=1.4"]
+    ["pylint~=2.6", "black~=19.10b0", "pre-commit~=2.7", "invoke~=1.4"]
     + docs_deps
     + testing_deps
     + client_deps
@@ -89,7 +89,7 @@ setup(
     python_requires=">=3.6",
     install_requires=[
         "lark-parser~=0.9.0",
-        "fastapi~=0.60.1",
+        "fastapi~=0.61.0",
         "pydantic~=1.6",
         "email_validator~=1.1",
         "requests~=2.24",

--- a/tests/server/query_params/test_filter.py
+++ b/tests/server/query_params/test_filter.py
@@ -1,26 +1,4 @@
 """Make sure response_fields is handled correctly"""
-import pytest
-
-
-def valid_mongomock_version() -> dict:
-    """Based on CI_FORCE_MONGO and whether or not to use a real MongoDB, return valid mongomock version"""
-    from optimade.server.config import CONFIG
-    from optimade.server.entry_collections import CI_FORCE_MONGO
-
-    MONGOMOCK_OLD = False
-    MONGOMOCK_MSG = ""
-    if not CI_FORCE_MONGO and not CONFIG.use_real_mongo:
-        import mongomock
-
-        MONGOMOCK_OLD = tuple(
-            int(val) for val in mongomock.__version__.split(".")[0:3]
-        ) <= (3, 19, 0)
-        MONGOMOCK_MSG = f"mongomock version {mongomock.__version__}<=3.19.0 is too old for this test, skipping..."
-
-    return {
-        "condition": MONGOMOCK_OLD,
-        "reason": MONGOMOCK_MSG,
-    }
 
 
 def test_custom_field(check_response):
@@ -169,16 +147,8 @@ def test_list_length(check_response, check_error_response):
     )
 
 
-@pytest.mark.skipif(**valid_mongomock_version())
 def test_list_has_only(check_response):
-    """ Test HAS ONLY query on elements.
-
-    This test fails with mongomock<=3.19.0 when $size is 1, but works with a real mongo.
-
-    TODO: this text and skip condition should be removed once mongomock>3.19.0 has been released, which should
-    contain the bugfix for this: https://github.com/mongomock/mongomock/pull/597.
-
-    """
+    """ Test HAS ONLY query on elements. """
     request = '/structures?filter=elements HAS ONLY "Ac", "Mg"'
     expected_ids = ["mpf_23"]
     check_response(request, expected_ids)


### PR DESCRIPTION
Octopus merge of new dependencies as found by @dependabot.

Again, also updated `setup.py` with said dependencies, where needed.

I have furthermore tuned `dependabot.yml` to search for `pip` dependencies weekly (instead of monthly). I wanted bi-weekly, but since this is not an option, weekly will have to do.
I think monthly is simply too long of a time-span. The default is now then to search for new dependencies every Monday morning.
Also, I have extended the number of PRs it's allowed to open to 50. This needs to be equal to or more than the total number of requirements in our `requirements*.txt` files to be effective, otherwise we will see what we have now, only updating 10 dependencies.

Finally, I have added `github-actions` to the `dependabot.yml`. It's setup similarly to `gitsubmodules`, but using the `CI` label. Let's see if it acknowledges just using the major versions of actions, or it will insist on using full versions. If the latter is the case, I suggest to remove it again.

EDIT by @ml-evs: This PR closes #207 as mongomock is one of the update dependencies.