### PR TITLE
Validate OpenAPI specification in CI

### DIFF
--- a/.github/workflows/deps_lint.yml
+++ b/.github/workflows/deps_lint.yml
@@ -200,6 +200,11 @@ jobs:
     - name: Run previously skipped tests for adapter conversion
       run: pytest -rs -vvv --cov=./optimade/ --cov-report=xml --cov-append tests/adapters/
 
+    - name: Pass generated OpenAPI schemas through validator.swagger.io
+      run: |
+        invoke run-swagger-validator-on-url --url raw.githubusercontent.com/${GITHUB_REPOSITORY}/${GITHUB_SHA}/openapi/openapi.json
+        invoke run-swagger-validator-on-url --url raw.githubusercontent.com/${GITHUB_REPOSITORY}/${GITHUB_SHA}/openapi/index_openapi.json
+
     - name: Upload coverage to Codecov
       if: matrix.python-version == 3.8 && github.repository == 'Materials-Consortia/optimade-python-tools'
       uses: codecov/codecov-action@v1

--- a/.github/workflows/deps_lint.yml
+++ b/.github/workflows/deps_lint.yml
@@ -78,12 +78,11 @@ jobs:
         pip install -r requirements.txt
         pip install -r requirements-dev.txt
         pip install -e .
-        docker pull quen2404/openapi-diff
 
-    - name: Validate OpenAPI specifications
+    - name: Pass generated OpenAPI schemas through validator.swagger.io
       run: |
-        openapi-spec-validator openapi/openapi.json
-        openapi-spec-validator openapi/index_openapi.json
+        invoke run-swagger-validator openapi/openapi.json
+        invoke run-swagger-validator openapi/index_openapi.json
 
     - name: Check OpenAPI Schemas have not changed
       run: invoke check-openapi-diff
@@ -199,11 +198,6 @@ jobs:
 
     - name: Run previously skipped tests for adapter conversion
       run: pytest -rs -vvv --cov=./optimade/ --cov-report=xml --cov-append tests/adapters/
-
-    - name: Pass generated OpenAPI schemas through validator.swagger.io
-      run: |
-        invoke run-swagger-validator openapi/openapi.json
-        invoke run-swagger-validator openapi/index_openapi.json
 
     - name: Upload coverage to Codecov
       if: matrix.python-version == 3.8 && github.repository == 'Materials-Consortia/optimade-python-tools'

--- a/.github/workflows/deps_lint.yml
+++ b/.github/workflows/deps_lint.yml
@@ -81,8 +81,8 @@ jobs:
 
     - name: Pass generated OpenAPI schemas through validator.swagger.io
       run: |
-        invoke run-swagger-validator openapi/openapi.json
-        invoke run-swagger-validator openapi/index_openapi.json
+        invoke swagger-validator openapi/openapi.json
+        invoke swagger-validator openapi/index_openapi.json
 
     - name: Check OpenAPI Schemas have not changed
       run: invoke check-openapi-diff

--- a/.github/workflows/deps_lint.yml
+++ b/.github/workflows/deps_lint.yml
@@ -202,8 +202,8 @@ jobs:
 
     - name: Pass generated OpenAPI schemas through validator.swagger.io
       run: |
-        invoke run-swagger-validator-on-url --url raw.githubusercontent.com/${GITHUB_REPOSITORY}/${GITHUB_SHA}/openapi/openapi.json
-        invoke run-swagger-validator-on-url --url raw.githubusercontent.com/${GITHUB_REPOSITORY}/${GITHUB_SHA}/openapi/index_openapi.json
+        invoke run-swagger-validator openapi/openapi.json
+        invoke run-swagger-validator openapi/index_openapi.json
 
     - name: Upload coverage to Codecov
       if: matrix.python-version == 3.8 && github.repository == 'Materials-Consortia/optimade-python-tools'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,6 @@
 pytest==6.0.1
 pytest-cov==2.10.1
 codecov==2.1.9
-openapi-spec-validator==0.2.9
 jsondiff==1.2.0
 pylint==2.6.0
 black==20.8b1

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ testing_deps = [
     "pytest~=6.0",
     "pytest-cov~=2.10",
     "codecov~=2.1",
-    "openapi-spec-validator~=0.2.9",
     "jsondiff~=1.2",
 ] + server_deps
 dev_deps = (

--- a/tasks.py
+++ b/tasks.py
@@ -297,9 +297,9 @@ def create_api_reference_docs(_, pre_clean=False):
             )
 
 
-@task(help={"url": "URL of the file to validate"})
-def run_swagger_validator_on_url(_, url=None):
-    """ This task can be used in the CI to test the generated OpenAPI schemas
+@task(help={"filename": "The JSON file containing the OpenAPI schema to validate"})
+def run_swagger_validator(_, fname):
+    """This task can be used in the CI to test the generated OpenAPI schemas
     with the online swagger validator.
 
     Returns:
@@ -310,7 +310,10 @@ def run_swagger_validator_on_url(_, url=None):
     import requests
 
     swagger_url = "https://validator.swagger.io/validator/debug"
-    response = requests.get(f"{swagger_url}/?url={url}")
+    with open(fname, "r") as f:
+        schema = json.load(f)
+    response = requests.post(swagger_url, json=schema)
+
     if response.status_code != 200:
         raise RuntimeError(f"Server returned status code {response.status_code}.")
 

--- a/tasks.py
+++ b/tasks.py
@@ -328,7 +328,7 @@ def swagger_validator(_, fname):
         print_error(f"Unable to parse validator response as JSON: {response}")
         sys.exit(1)
 
-    if len(json_response) > 0:
+    if json_response:
         print_error(f"Schema file {fname} did not pass validation.\n")
         print_error(json.dumps(response.json(), indent=2))
         sys.exit(1)

--- a/tasks.py
+++ b/tasks.py
@@ -310,7 +310,8 @@ def swagger_validator(_, fname):
     import requests
 
     def print_error(string):
-        print(f"\033[31m{string}\033[0m")
+        for line in string.split("\n"):
+            print(f"\033[31m{line}\033[0m")
 
     swagger_url = "https://validator.swagger.io/validator/debug"
     with open(fname, "r") as f:


### PR DESCRIPTION
This PR adds an invoke task to get the response from https://validator.swagger.io/debug for a given URL. The CI then uses the commit SHA/repository to construct the URL for our OpenAPI schema, currently hard-coded to be at `openapi/openapi.json` and `openapi/index_openapi.json`, which it then pings the validator with.