### PR TITLE
Fix field optonality inconsistency in schema

### DIFF
--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -2998,6 +2998,8 @@
           "chemical_formula_reduced",
           "chemical_formula_anonymous",
           "dimension_types",
+          "nperiodic_dimensions",
+          "lattice_vectors",
           "cartesian_site_positions",
           "nsites",
           "species",

--- a/optimade/models/structures.py
+++ b/optimade/models/structures.py
@@ -396,8 +396,8 @@ Note: the elements in this list each refer to the direction of the corresponding
     - For a bulk 3D system: `[1, 1, 1]`""",
     )
 
-    nperiodic_dimensions: Optional[int] = Field(
-        None,
+    nperiodic_dimensions: int = Field(
+        ...,
         description="""An integer specifying the number of periodic dimensions in the structure, equivalent to the number of non-zero entries in `dimension_types`.
 
 - **Type**: integer
@@ -416,10 +416,8 @@ Note: the elements in this list each refer to the direction of the corresponding
     - Match all structures with 2 or fewer periodic dimensions: `nperiodic_dimensions<=2`""",
     )
 
-    lattice_vectors: Optional[
-        conlist(Vector3D_unknown, min_items=3, max_items=3)
-    ] = Field(
-        None,
+    lattice_vectors: conlist(Vector3D_unknown, min_items=3, max_items=3) = Field(
+        ...,
         description="""The three lattice vectors in Cartesian coordinates, in ångström (Å).
 
 - **Type**: list of list of floats or unknown values.


### PR DESCRIPTION
As it stands, all SHOULD fields are non-optional in our **pydantic models**. Somehow this did not apply to `nperiodic_dimensions` and `lattice_vectors`, so this PR fixes that.

There is still an outstanding question about how we should handle these fields in pydantic and in OpenAPI. Are "SHOULD" fields "required"? It is impossible to validate our `StructureResource` automatically with pydantic with some fields missing, unless we made them `Optional` and added conditionals to the pydantic validators. 

We might be able to get around this in the implementation validator by just ignoring documents that are not "full" of all the "SHOULD" fields (i.e. not returning an error), but then obviously their contents will not be well-checked. 

I've written this description in this PR for posterity and will probably cross-post it to the appropriate issue.