### PR TITLE
Absolute imports

### DIFF
--- a/optimade/models/baseinfo.py
+++ b/optimade/models/baseinfo.py
@@ -4,8 +4,8 @@ import re
 from typing import Dict, List, Optional
 from pydantic import BaseModel, AnyHttpUrl, Field, validator, root_validator
 
-from .jsonapi import Resource
-from .utils import SemanticVersion
+from optimade.models.jsonapi import Resource
+from optimade.models.utils import SemanticVersion
 
 
 __all__ = ("AvailableApiVersion", "BaseInfoAttributes", "BaseInfoResource")

--- a/optimade/models/entries.py
+++ b/optimade/models/entries.py
@@ -3,8 +3,8 @@ from datetime import datetime
 from typing import Optional, Dict, List
 from pydantic import BaseModel, Field, validator  # pylint: disable=no-name-in-module
 
-from .jsonapi import Relationships, Attributes, Resource
-from .optimade_json import Relationship, DataType
+from optimade.models.jsonapi import Relationships, Attributes, Resource
+from optimade.models.optimade_json import Relationship, DataType
 
 
 __all__ = (

--- a/optimade/models/index_metadb.py
+++ b/optimade/models/index_metadb.py
@@ -4,8 +4,8 @@ from enum import Enum
 from pydantic import Field, BaseModel  # pylint: disable=no-name-in-module
 from typing import Union, Dict
 
-from .jsonapi import BaseResource
-from .baseinfo import BaseInfoAttributes, BaseInfoResource
+from optimade.models.jsonapi import BaseResource
+from optimade.models.baseinfo import BaseInfoAttributes, BaseInfoResource
 
 
 __all__ = (

--- a/optimade/models/links.py
+++ b/optimade/models/links.py
@@ -8,8 +8,8 @@ from pydantic import (  # pylint: disable=no-name-in-module
 )
 from typing import Union, Optional
 
-from .jsonapi import Link, Attributes
-from .entries import EntryResource
+from optimade.models.jsonapi import Link, Attributes
+from optimade.models.entries import EntryResource
 
 
 __all__ = (

--- a/optimade/models/optimade_json.py
+++ b/optimade/models/optimade_json.py
@@ -7,8 +7,8 @@ from typing import Optional, Union, List, Dict, Type, Any
 
 from datetime import datetime
 
-from . import jsonapi
-from .utils import SemanticVersion
+from optimade.models import jsonapi
+from optimade.models.utils import SemanticVersion
 
 
 __all__ = (

--- a/optimade/models/references.py
+++ b/optimade/models/references.py
@@ -7,7 +7,7 @@ from pydantic import (  # pylint: disable=no-name-in-module
 )
 from typing import List, Optional
 
-from .entries import EntryResource, EntryResourceAttributes
+from optimade.models.entries import EntryResource, EntryResourceAttributes
 
 
 __all__ = ("Person", "ReferenceResourceAttributes", "ReferenceResource")

--- a/optimade/models/responses.py
+++ b/optimade/models/responses.py
@@ -3,14 +3,14 @@ from typing import Union, List, Optional, Dict, Any
 
 from pydantic import Field, root_validator
 
-from .jsonapi import Response
-from .baseinfo import BaseInfoResource
-from .entries import EntryInfoResource, EntryResource
-from .index_metadb import IndexInfoResource
-from .links import LinksResource
-from .optimade_json import Success, ResponseMeta, OptimadeError
-from .references import ReferenceResource
-from .structures import StructureResource
+from optimade.models.jsonapi import Response
+from optimade.models.baseinfo import BaseInfoResource
+from optimade.models.entries import EntryInfoResource, EntryResource
+from optimade.models.index_metadb import IndexInfoResource
+from optimade.models.links import LinksResource
+from optimade.models.optimade_json import Success, ResponseMeta, OptimadeError
+from optimade.models.references import ReferenceResource
+from optimade.models.structures import StructureResource
 
 
 __all__ = (

--- a/optimade/models/structures.py
+++ b/optimade/models/structures.py
@@ -5,8 +5,8 @@ from typing import List, Optional, Union
 
 from pydantic import Field, BaseModel, validator, root_validator, conlist
 
-from .entries import EntryResourceAttributes, EntryResource
-from .utils import CHEMICAL_SYMBOLS, EXTRA_SYMBOLS
+from optimade.models.entries import EntryResourceAttributes, EntryResource
+from optimade.models.utils import CHEMICAL_SYMBOLS, EXTRA_SYMBOLS
 
 
 EXTENDED_CHEMICAL_SYMBOLS = CHEMICAL_SYMBOLS + EXTRA_SYMBOLS

--- a/optimade/server/mappers/links.py
+++ b/optimade/server/mappers/links.py
@@ -1,4 +1,4 @@
-from .entries import BaseResourceMapper
+from optimade.server.mappers.entries import BaseResourceMapper
 
 __all__ = ("LinksMapper",)
 

--- a/optimade/server/mappers/references.py
+++ b/optimade/server/mappers/references.py
@@ -1,4 +1,4 @@
-from .entries import BaseResourceMapper
+from optimade.server.mappers.entries import BaseResourceMapper
 
 __all__ = ("ReferenceMapper",)
 

--- a/optimade/server/mappers/structures.py
+++ b/optimade/server/mappers/structures.py
@@ -1,4 +1,4 @@
-from .entries import BaseResourceMapper
+from optimade.server.mappers.entries import BaseResourceMapper
 
 __all__ = ("StructureMapper",)
 

--- a/optimade/server/query_params.py
+++ b/optimade/server/query_params.py
@@ -1,7 +1,7 @@
 from fastapi import Query
 from pydantic import EmailStr  # pylint: disable=no-name-in-module
 
-from .config import CONFIG
+from optimade.server.config import CONFIG
 
 
 class EntryListingQueryParams:

--- a/optimade/server/routers/info.py
+++ b/optimade/server/routers/info.py
@@ -15,7 +15,11 @@ from optimade.models import (
     StructureResource,
 )
 
-from .utils import meta_values, retrieve_queryable_properties, get_base_url
+from optimade.server.routers.utils import (
+    meta_values,
+    retrieve_queryable_properties,
+    get_base_url,
+)
 
 
 router = APIRouter(redirect_slashes=True)

--- a/optimade/server/routers/links.py
+++ b/optimade/server/routers/links.py
@@ -8,7 +8,7 @@ from optimade.server.entry_collections import MongoCollection, client
 from optimade.server.mappers import LinksMapper
 from optimade.server.query_params import EntryListingQueryParams
 
-from .utils import get_entries
+from optimade.server.routers.utils import get_entries
 
 router = APIRouter(redirect_slashes=True)
 

--- a/optimade/server/routers/references.py
+++ b/optimade/server/routers/references.py
@@ -13,7 +13,7 @@ from optimade.server.entry_collections import MongoCollection, client
 from optimade.server.mappers import ReferenceMapper
 from optimade.server.query_params import EntryListingQueryParams, SingleEntryQueryParams
 
-from .utils import get_entries, get_single_entry
+from optimade.server.routers.utils import get_entries, get_single_entry
 
 
 router = APIRouter(redirect_slashes=True)

--- a/optimade/server/routers/structures.py
+++ b/optimade/server/routers/structures.py
@@ -13,7 +13,7 @@ from optimade.server.entry_collections import MongoCollection, client
 from optimade.server.mappers import StructureMapper
 from optimade.server.query_params import EntryListingQueryParams, SingleEntryQueryParams
 
-from .utils import get_entries, get_single_entry
+from optimade.server.routers.utils import get_entries, get_single_entry
 
 router = APIRouter(redirect_slashes=True)
 

--- a/optimade/server/routers/versions.py
+++ b/optimade/server/routers/versions.py
@@ -1,7 +1,7 @@
 from fastapi import Request, APIRouter
 from fastapi.responses import Response
 
-from .utils import BASE_URL_PREFIXES
+from optimade.server.routers.utils import BASE_URL_PREFIXES
 
 router = APIRouter(redirect_slashes=True)
 

--- a/optimade/validator/validator.py
+++ b/optimade/validator/validator.py
@@ -24,8 +24,8 @@ from fastapi.testclient import TestClient
 
 from optimade.models import InfoResponse, EntryInfoResponse, IndexInfoResponse
 
-from .data import MANDATORY_FILTER_EXAMPLES, OPTIONAL_FILTER_EXAMPLES
-from .validator_model_patches import (
+from optimade.validator.data import MANDATORY_FILTER_EXAMPLES, OPTIONAL_FILTER_EXAMPLES
+from optimade.validator.validator_model_patches import (
     ValidatorLinksResponse,
     ValidatorEntryResponseOne,
     ValidatorEntryResponseMany,


### PR DESCRIPTION
Use absolute imports everywhere, except for `__init__.py` files as well as in `test_*.py` files.

Fixes #298 