### PR TITLE
Allow Link objects for pagination

### DIFF
--- a/openapi/index_openapi.json
+++ b/openapi/index_openapi.json
@@ -1665,35 +1665,63 @@
           },
           "first": {
             "title": "First",
-            "maxLength": 65536,
-            "minLength": 1,
-            "type": "string",
-            "description": "The first page of data",
-            "format": "uri"
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 65536,
+                "format": "uri"
+              },
+              {
+                "$ref": "#/components/schemas/Link"
+              }
+            ],
+            "description": "The first page of data"
           },
           "last": {
             "title": "Last",
-            "maxLength": 65536,
-            "minLength": 1,
-            "type": "string",
-            "description": "The last page of data",
-            "format": "uri"
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 65536,
+                "format": "uri"
+              },
+              {
+                "$ref": "#/components/schemas/Link"
+              }
+            ],
+            "description": "The last page of data"
           },
           "prev": {
             "title": "Prev",
-            "maxLength": 65536,
-            "minLength": 1,
-            "type": "string",
-            "description": "The previous page of data",
-            "format": "uri"
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 65536,
+                "format": "uri"
+              },
+              {
+                "$ref": "#/components/schemas/Link"
+              }
+            ],
+            "description": "The previous page of data"
           },
           "next": {
             "title": "Next",
-            "maxLength": 65536,
-            "minLength": 1,
-            "type": "string",
-            "description": "The next page of data",
-            "format": "uri"
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 65536,
+                "format": "uri"
+              },
+              {
+                "$ref": "#/components/schemas/Link"
+              }
+            ],
+            "description": "The next page of data"
           }
         },
         "description": "A set of Links objects, possibly including pagination"

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -3340,35 +3340,63 @@
           },
           "first": {
             "title": "First",
-            "maxLength": 65536,
-            "minLength": 1,
-            "type": "string",
-            "description": "The first page of data",
-            "format": "uri"
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 65536,
+                "format": "uri"
+              },
+              {
+                "$ref": "#/components/schemas/Link"
+              }
+            ],
+            "description": "The first page of data"
           },
           "last": {
             "title": "Last",
-            "maxLength": 65536,
-            "minLength": 1,
-            "type": "string",
-            "description": "The last page of data",
-            "format": "uri"
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 65536,
+                "format": "uri"
+              },
+              {
+                "$ref": "#/components/schemas/Link"
+              }
+            ],
+            "description": "The last page of data"
           },
           "prev": {
             "title": "Prev",
-            "maxLength": 65536,
-            "minLength": 1,
-            "type": "string",
-            "description": "The previous page of data",
-            "format": "uri"
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 65536,
+                "format": "uri"
+              },
+              {
+                "$ref": "#/components/schemas/Link"
+              }
+            ],
+            "description": "The previous page of data"
           },
           "next": {
             "title": "Next",
-            "maxLength": 65536,
-            "minLength": 1,
-            "type": "string",
-            "description": "The next page of data",
-            "format": "uri"
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 65536,
+                "format": "uri"
+              },
+              {
+                "$ref": "#/components/schemas/Link"
+              }
+            ],
+            "description": "The next page of data"
           }
         },
         "description": "A set of Links objects, possibly including pagination"

--- a/optimade/models/jsonapi.py
+++ b/optimade/models/jsonapi.py
@@ -86,7 +86,7 @@ class ToplevelLinks(BaseModel):
         """
         for key, value in values.items():
             if key not in cls.schema()["properties"]:
-                values[key] = parse_obj_as(Union[AnyUrl, Link], value)
+                values[key] = parse_obj_as(Optional[Union[AnyUrl, Link]], value)
 
         return values
 

--- a/optimade/models/jsonapi.py
+++ b/optimade/models/jsonapi.py
@@ -61,10 +61,18 @@ class ToplevelLinks(BaseModel):
     )
 
     # Pagination
-    first: Optional[AnyUrl] = Field(None, description="The first page of data")
-    last: Optional[AnyUrl] = Field(None, description="The last page of data")
-    prev: Optional[AnyUrl] = Field(None, description="The previous page of data")
-    next: Optional[AnyUrl] = Field(None, description="The next page of data")
+    first: Optional[Union[AnyUrl, Link]] = Field(
+        None, description="The first page of data"
+    )
+    last: Optional[Union[AnyUrl, Link]] = Field(
+        None, description="The last page of data"
+    )
+    prev: Optional[Union[AnyUrl, Link]] = Field(
+        None, description="The previous page of data"
+    )
+    next: Optional[Union[AnyUrl, Link]] = Field(
+        None, description="The next page of data"
+    )
 
 
 class ErrorLinks(BaseModel):

--- a/optimade/models/jsonapi.py
+++ b/optimade/models/jsonapi.py
@@ -56,9 +56,6 @@ class JsonApi(BaseModel):
 class ToplevelLinks(BaseModel):
     """A set of Links objects, possibly including pagination"""
 
-    class Config:
-        extra = "allow"
-
     self: Optional[Union[AnyUrl, Link]] = Field(None, description="A link to itself")
     related: Optional[Union[AnyUrl, Link]] = Field(
         None, description="A related resource link"
@@ -89,6 +86,9 @@ class ToplevelLinks(BaseModel):
                 values[key] = parse_obj_as(Optional[Union[AnyUrl, Link]], value)
 
         return values
+
+    class Config:
+        extra = "allow"
 
 
 class ErrorLinks(BaseModel):

--- a/optimade/models/links.py
+++ b/optimade/models/links.py
@@ -47,12 +47,12 @@ class LinksResourceAttributes(Attributes):
         ...,
         description="Human-readable description for the OPTIMADE API implementation, e.g., for use in clients to show a description to the end-user.",
     )
-    base_url: Union[AnyUrl, Link, None] = Field(
+    base_url: Optional[Union[AnyUrl, Link]] = Field(
         ...,
         description="JSON API links object, pointing to the base URL for this implementation",
     )
 
-    homepage: Union[AnyUrl, Link, None] = Field(
+    homepage: Optional[Union[AnyUrl, Link]] = Field(
         ...,
         description="JSON API links object, pointing to a homepage URL for this implementation",
     )

--- a/tests/models/test_jsonapi.py
+++ b/tests/models/test_jsonapi.py
@@ -1,6 +1,56 @@
-from optimade.models.jsonapi import Error
+from pydantic import ValidationError
+import pytest
+from optimade.models.jsonapi import Error, ToplevelLinks
 
 
 def test_hashability():
     error = Error(id="test")
     assert set([error])
+
+
+def test_toplevel_links():
+    """Test top-level links responses as both URLs and Links objects,
+    and check that any arbitrary key is allowed as long as the value
+    can be validated as a URL or a Links object too.
+
+    """
+    test_links = {
+        "first": {"href": "http://example.org/structures?page_limit=3&page_offset=0"},
+        "last": {"href": "http://example.org/structures?page_limit=3&page_offset=10"},
+        "prev": {
+            "href": "http://example.org/structures?page_limit=3&page_offset=2",
+            "meta": {"description": "the previous link"},
+        },
+        "next": {
+            "href": "http://example.org/structures?page_limit=3&page_offset=3",
+            "meta": {"description": "the next link"},
+        },
+    }
+
+    # Test all defined fields as URLs and Links objects
+    for link in test_links:
+        assert ToplevelLinks(**{link: test_links[link]})
+        assert ToplevelLinks(**{link: test_links[link]["href"]})
+
+    # Allow arbitrary keys are as long as they are links
+    assert ToplevelLinks(
+        **{
+            "base_url": "https://example.org/structures",
+            "other_url": {"href": "https://example.org"},
+        }
+    )
+    assert ToplevelLinks(
+        **{
+            "base_url5": {
+                "href": "https://example.org/structures",
+                "meta": {"description": "the base URL"},
+            }
+        }
+    )
+
+    # Check that non-URL and non-Links objects will fail to validate
+    with pytest.raises(ValidationError):
+        ToplevelLinks(**{"base_url": {"this object": "is not a URL or a Links object"}})
+
+    with pytest.raises(ValidationError):
+        ToplevelLinks(**{"base_url": {"href": "not a link"}})

--- a/tests/models/test_jsonapi.py
+++ b/tests/models/test_jsonapi.py
@@ -44,7 +44,8 @@ def test_toplevel_links():
             "base_url5": {
                 "href": "https://example.org/structures",
                 "meta": {"description": "the base URL"},
-            }
+            },
+            "none_url": None,
         }
     )
 


### PR DESCRIPTION
I found a few more links that can be `jsonapi.Link` objects that must have been causing problems. Closes #394 (I hope - sorry it took so long @merkys!)

Continues to add onto our issues of unravelling the schema models with nested `$ref`'s under `allOf` etc... in discussion with @CasperWA earlier, the suggestion is to try to find a general tool to dereference the JSON schema in place of our current homebrewed solution...