### PR TITLE
Commit only when necessary

### DIFF
--- a/.github/workflows/update_docs.sh
+++ b/.github/workflows/update_docs.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-set -e
 
 echo "\n-o- Checkout fresh branch -o-"
 git checkout -b update_changelog

--- a/.github/workflows/update_docs.sh
+++ b/.github/workflows/update_docs.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 echo "\n-o- Checkout fresh branch -o-"
 git checkout -b update_changelog
@@ -16,7 +17,10 @@ invoke create-api-reference-docs --pre-clean
 
 echo "\n-o- Commit update - API Reference -o-"
 git add docs/api_reference
-git commit -m "Release ${GITHUB_REF#refs/tags/} - API Reference"
+if [ -n "$(git status --porcelain)" ]; then
+    # Only commit if there's something to commit (git will return non-zero otherwise)
+    git commit -m "Release ${GITHUB_REF#refs/tags/} - API Reference"
+fi
 
 echo "\n-o- Update version -o-"
 invoke setver -v ${GITHUB_REF#refs/tags/}


### PR DESCRIPTION
The `update_docs.sh` script used to update the changelog and more upon a new release is set to exit at any time if a return value different than 0 occurs (`set -e`).

Since `git` will return a non-zero value if trying to commit and there's nothing to commit, a check for this has been added to `update_docs.sh`.

It is _not_ done for the second `git commit` line, since if there is no CHANGELOG to commit, I would suspect there shouldn't be a release at all. However, this can be argued against.