### PR TITLE
Don't report untracked and ignored files

### DIFF
--- a/.github/workflows/update_docs.sh
+++ b/.github/workflows/update_docs.sh
@@ -17,7 +17,7 @@ invoke create-api-reference-docs --pre-clean
 
 echo "\n-o- Commit update - API Reference -o-"
 git add docs/api_reference
-if [ -n "$(git status --porcelain)" ]; then
+if [ -n "$(git status --porcelain --untracked-files=no --ignored=no)" ]; then
     # Only commit if there's something to commit (git will return non-zero otherwise)
     git commit -m "Release ${GITHUB_REF#refs/tags/} - API Reference"
 fi


### PR DESCRIPTION
Make sure to ignore "untracked" and "ignored" files for `git status` check.