### PR TITLE
Responses for unknown fields

### DIFF
--- a/optimade/server/entry_collections/mongo.py
+++ b/optimade/server/entry_collections/mongo.py
@@ -69,6 +69,8 @@ class MongoCollection(EntryCollection):
             version=(0, 10, 1), variant="default"
         )  # The MongoTransformer only supports v0.10.1 as the latest grammar
 
+        self.transformer.all_fields = self.all_fields
+
         # check aliases do not clash with mongo operators
         self._check_aliases(self.resource_mapper.all_aliases())
         self._check_aliases(self.resource_mapper.all_length_aliases())

--- a/optimade/validator/validator.py
+++ b/optimade/validator/validator.py
@@ -373,7 +373,49 @@ class ImplementationValidator:
                 optional=optional,
             )
 
+        self._test_unknown_provider_property(endp)
+        self._test_completely_unknown_property(endp)
+
         return True, f"successfully recursed through endpoint {endp}."
+
+    @test_case
+    def _test_completely_unknown_property(self, endp):
+        request = f"{endp}?filter=crazyfield = 2"
+        response, _ = self._get_endpoint(
+            request,
+            expected_status_code=400,
+        )
+
+        return True, "unknown field returned 400 Bad Request, as expected"
+
+    @test_case
+    def _test_unknown_provider_property(self, endp):
+
+        dummy_provider_field = "_crazyprovider_field"
+
+        request = f"{endp}?filter={dummy_provider_field}=2"
+        response, _ = self._get_endpoint(
+            request,
+            multistage=True,
+            request=request,
+        )
+
+        if response is not None:
+            deserialized, _ = self._deserialize_response(
+                response, CONF.response_classes[endp], request=request, multistage=True
+            )
+            self._test_data_available_matches_data_returned(
+                deserialized, request=request, multistage=True
+            )
+
+            return (
+                True,
+                "Unknown provider field was ignored when filtering, as expected",
+            )
+
+        raise ResponseError(
+            "Failed to handle field from unknown provider; should return without affecting filter results"
+        )
 
     def _check_entry_info(self, entry_info: Dict[str, Any], endp: str) -> List[str]:
         """Checks that `entry_info` contains all the required properties,

--- a/tests/filtertransformers/test_mongo.py
+++ b/tests/filtertransformers/test_mongo.py
@@ -390,8 +390,12 @@ class TestMongoTransformer:
             )
             PROVIDER_FIELDS = ("chemsys",)
 
-        transformer = MongoTransformer(mapper=MyMapper())
+        transformer = MongoTransformer(
+            mapper=MyMapper(), all_fields=("id", "type", "lattice_vectors")
+        )
         parser = LarkParser(version=self.version, variant=self.variant)
+
+        assert transformer.transform(parser.parse("_asdfa_asdf LENGTH <= 3")) == {}
 
         assert transformer.transform(
             parser.parse("cartesian_site_positions LENGTH <= 3")
@@ -439,7 +443,9 @@ class TestMongoTransformer:
             )
 
         mapper = MyStructureMapper()
-        t = MongoTransformer(mapper=mapper)
+        t = MongoTransformer(
+            mapper=mapper, all_fields=["unknown_field", "_exmpl_nested_field"]
+        )
 
         assert mapper.alias_for("elements") == "my_elements"
 


### PR DESCRIPTION
Eventually closes #263. 

- [x] Parse filters for unknown properties, dropping those that are from other providers and raising errors for those that are entirely unknown
   - [ ] Find better way of passing field list to `FilterTransformer`, probably via `Mapper` which should save the schema too
- [x] Handle unknown response as a 400 Bad Request
- [x] Validate unknown field responses