### PR TITLE
Validator improvements

### DIFF
--- a/optimade/server/routers/utils.py
+++ b/optimade/server/routers/utils.py
@@ -78,7 +78,15 @@ def handle_response_fields(
     new_results = []
     while results:
         entry = results.pop(0)
-        new_entry = entry.dict(exclude_unset=True)
+
+        # TODO: re-enable exclude_unset when proper handling of known/unknown fields
+        # has been implemented (relevant issue: https://github.com/Materials-Consortia/optimade-python-tools/issues/263)
+        # Have to handle top level fields explicitly here for now
+        new_entry = entry.dict(exclude_unset=False)
+        for field in ("relationships", "links", "meta", "type", "id"):
+            if field in new_entry and new_entry[field] is None:
+                del new_entry[field]
+
         for field in exclude_fields:
             if field in new_entry["attributes"]:
                 del new_entry["attributes"][field]

--- a/optimade/validator/config.py
+++ b/optimade/validator/config.py
@@ -18,6 +18,7 @@ from optimade.validator.utils import (
     ValidatorStructureResponseOne,
     ValidatorStructureResponseMany,
 )
+from optimade.server.mappers import BaseResourceMapper
 from optimade.server.schemas import (
     ENTRY_INFO_SCHEMAS,
     retrieve_queryable_properties,
@@ -152,6 +153,10 @@ class ValidatorConfig(BaseSettings):
     non_entry_endpoints: Set[str] = Field(
         _NON_ENTRY_ENDPOINTS,
         description="The list specification-mandated endpoint names that do not contain entries",
+    )
+    top_level_non_attribute_fields: Set[str] = Field(
+        BaseResourceMapper.TOP_LEVEL_NON_ATTRIBUTES_FIELDS,
+        description="Field names to treat as top-level",
     )
 
 

--- a/optimade/validator/utils.py
+++ b/optimade/validator/utils.py
@@ -90,8 +90,8 @@ class ValidatorResults:
         """Register a validation success to the results class.
 
         Parameters:
-            summary: a summary of the success to be printed
-            success_type: either `None`, `"optional"` depending on the
+            summary: A summary of the success to be printed.
+            success_type: Either `None` or `"optional"` depending on the
                 type of the check.
 
         """
@@ -121,9 +121,9 @@ class ValidatorResults:
         corresponding summary, message and type.
 
         Parameters:
-            summary: Short error message
-            message: Full error message, potentially containing a traceback
-            failure_type: either `None`, `"internal"` or `"optional"`
+            summary: Short error message.
+            message: Full error message, potentially containing a traceback.
+            failure_type: Either `None`, `"internal"` or `"optional"`
                 depending on the type of check that was failed.
 
         """

--- a/tests/validator/test_utils.py
+++ b/tests/validator/test_utils.py
@@ -121,9 +121,9 @@ def test_expected_failure_test_case():
 
     assert (
         validator.results.failure_messages[-1][0]
-        == "✖: http://example.org/test_request - dummy_test_case - failed with error"
+        == "http://example.org/test_request - dummy_test_case - failed with error"
     )
-    assert validator.results.failure_messages[-1][1] == ["ResponseError: Dummy error"]
+    assert validator.results.failure_messages[-1][1] == "ResponseError: Dummy error"
 
     output = dummy_test_case(
         validator,
@@ -143,11 +143,12 @@ def test_expected_failure_test_case():
 
     assert (
         validator.results.optional_failure_messages[-1][0]
-        == "✖: http://example.org/test_request - dummy_test_case - failed with error"
+        == "http://example.org/test_request - dummy_test_case - failed with error"
     )
-    assert validator.results.optional_failure_messages[-1][1] == [
-        "ResponseError: Dummy error"
-    ]
+    assert (
+        validator.results.optional_failure_messages[-1][1]
+        == "ResponseError: Dummy error"
+    )
 
     output = dummy_test_case(
         validator,
@@ -169,11 +170,12 @@ def test_expected_failure_test_case():
     )
     assert (
         validator.results.optional_failure_messages[-1][0]
-        == "✖: http://example.org/test_request - dummy_test_case - failed with error"
+        == "http://example.org/test_request - dummy_test_case - failed with error"
     )
-    assert validator.results.optional_failure_messages[-1][1] == [
-        "Critical: unable to parse server response as JSON. JSONDecodeError: Dummy JSON error: line 1 column 1 (char 0)"
-    ]
+    assert (
+        validator.results.optional_failure_messages[-1][1]
+        == "Critical: unable to parse server response as JSON. JSONDecodeError: Dummy JSON error: line 1 column 1 (char 0)"
+    )
 
 
 def test_unexpected_failure_test_case():
@@ -197,11 +199,12 @@ def test_unexpected_failure_test_case():
     assert output[1] == "FileNotFoundError: Unexpected error"
     assert (
         validator.results.internal_failure_messages[-1][0]
-        == "!: http://example.org/test_request - dummy_test_case - failed with internal error"
+        == "http://example.org/test_request - dummy_test_case - failed with internal error"
     )
-    assert validator.results.internal_failure_messages[-1][1] == [
-        "FileNotFoundError: Unexpected error"
-    ]
+    assert (
+        validator.results.internal_failure_messages[-1][1]
+        == "FileNotFoundError: Unexpected error"
+    )
 
     output = dummy_test_case(
         validator,
@@ -220,11 +223,12 @@ def test_unexpected_failure_test_case():
     assert output[1] == "FileNotFoundError: Unexpected error"
     assert (
         validator.results.internal_failure_messages[-1][0]
-        == "!: http://example.org/test_request - dummy_test_case - failed with internal error"
+        == "http://example.org/test_request - dummy_test_case - failed with internal error"
     )
-    assert validator.results.internal_failure_messages[-1][1] == [
-        "FileNotFoundError: Unexpected error"
-    ]
+    assert (
+        validator.results.internal_failure_messages[-1][1]
+        == "FileNotFoundError: Unexpected error"
+    )
 
 
 def test_multistage_test_case():
@@ -264,11 +268,12 @@ def test_multistage_test_case():
     assert output[1] == "ResponseError: Stage of test failed"
     assert (
         validator.results.failure_messages[-1][0]
-        == "✖: http://example.org/test_request - dummy_test_case - failed with error"
+        == "http://example.org/test_request - dummy_test_case - failed with error"
     )
-    assert validator.results.failure_messages[-1][1] == [
-        "ResponseError: Stage of test failed"
-    ]
+    assert (
+        validator.results.failure_messages[-1][1]
+        == "ResponseError: Stage of test failed"
+    )
 
 
 def test_fail_fast_test_case():
@@ -294,11 +299,12 @@ def test_fail_fast_test_case():
     assert output[0] is None
     assert output[1] == "ResponseError: Optional test failed"
     assert validator.results.optional_failure_messages[-1][0] == (
-        "✖: http://example.org/test_request - dummy_test_case - failed with error"
+        "http://example.org/test_request - dummy_test_case - failed with error"
     )
-    assert validator.results.optional_failure_messages[-1][1] == [
-        "ResponseError: Optional test failed"
-    ]
+    assert (
+        validator.results.optional_failure_messages[-1][1]
+        == "ResponseError: Optional test failed"
+    )
 
     # Check that the same non-optional failures do trigger fail fast
     with pytest.raises(SystemExit):
@@ -315,11 +321,12 @@ def test_fail_fast_test_case():
     assert validator.results.optional_failure_count == 1
     assert validator.results.internal_failure_count == 0
     assert validator.results.failure_messages[-1][0] == (
-        "✖: http://example.org/test_request - dummy_test_case - failed with error"
+        "http://example.org/test_request - dummy_test_case - failed with error"
     )
-    assert validator.results.failure_messages[-1][1] == [
-        "ResponseError: Non-optional test failed"
-    ]
+    assert (
+        validator.results.failure_messages[-1][1]
+        == "ResponseError: Non-optional test failed"
+    )
 
     # Check that an internal error also triggers fast
     with pytest.raises(SystemExit):
@@ -335,11 +342,12 @@ def test_fail_fast_test_case():
     assert validator.results.optional_failure_count == 1
     assert validator.results.internal_failure_count == 1
     assert validator.results.internal_failure_messages[-1][0] == (
-        "!: http://example.org/test_request - dummy_test_case - failed with internal error"
+        "http://example.org/test_request - dummy_test_case - failed with internal error"
     )
-    assert validator.results.internal_failure_messages[-1][1] == [
-        "FileNotFoundError: Internal error"
-    ]
+    assert (
+        validator.results.internal_failure_messages[-1][1]
+        == "FileNotFoundError: Internal error"
+    )
 
 
 def test_that_system_exit_is_fatal_in_test_case():


### PR DESCRIPTION
Closes #514, supercedes #513

Blocked by #503. 

This PR fixes the above problems, and tidies some of the `@test_case` decorator into the `ValidatorResults` class.

- [x] Tidy up `ValidatorResults` & `test_case`
- [x] Ask for all supported response fields and validate them when doing `chosen_entry` query (closes #514)
- [x] Better error-handling for case where no archetypal entry could be found (e.g. endpoint is empty)
- [x] Use response fields when doing multi/single entry endpoint tests to remove some deserialization errors
- [x] Temporary fix for response_fields and unset values: turn off `exclude_unset` when handling query params. This will need a proper treatment based on the actual requested fields, pending #504...