### PR TITLE
Fix landing page URL

### DIFF
--- a/optimade/server/exception_handlers.py
+++ b/optimade/server/exception_handlers.py
@@ -50,7 +50,7 @@ def general_exception(
 
     response = ErrorResponse(
         meta=meta_values(
-            url=str(request.url),
+            url=request.url,
             data_returned=0,
             data_available=0,
             more_data_available=False,

--- a/optimade/server/routers/index_info.py
+++ b/optimade/server/routers/index_info.py
@@ -1,4 +1,3 @@
-import urllib
 from typing import Union
 
 from fastapi import APIRouter, Request
@@ -29,12 +28,8 @@ router = APIRouter(redirect_slashes=True)
     tags=["Info"],
 )
 def get_info(request: Request):
-
-    parse_result = urllib.parse.urlparse(str(request.url))
-    base_url = get_base_url(parse_result)
-
     return IndexInfoResponse(
-        meta=meta_values(str(request.url), 1, 1, more_data_available=False),
+        meta=meta_values(request.url, 1, 1, more_data_available=False),
         data=IndexInfoResource(
             id=IndexInfoResource.schema()["properties"]["id"]["const"],
             type=IndexInfoResource.schema()["properties"]["type"]["const"],
@@ -42,7 +37,7 @@ def get_info(request: Request):
                 api_version=f"{__api_version__}",
                 available_api_versions=[
                     {
-                        "url": f"{base_url}/v{__api_version__.split('.')[0]}/",
+                        "url": f"{get_base_url(request.url)}/v{__api_version__.split('.')[0]}/",
                         "version": f"{__api_version__}",
                     }
                 ],

--- a/optimade/server/routers/info.py
+++ b/optimade/server/routers/info.py
@@ -1,5 +1,3 @@
-import urllib
-
 from typing import Union
 
 from fastapi import APIRouter, Request
@@ -32,11 +30,8 @@ router = APIRouter(redirect_slashes=True)
 def get_info(request: Request):
     from optimade.models import BaseInfoResource, BaseInfoAttributes
 
-    parse_result = urllib.parse.urlparse(str(request.url))
-    base_url = get_base_url(parse_result)
-
     return InfoResponse(
-        meta=meta_values(str(request.url), 1, 1, more_data_available=False),
+        meta=meta_values(request.url, 1, 1, more_data_available=False),
         data=BaseInfoResource(
             id=BaseInfoResource.schema()["properties"]["id"]["const"],
             type=BaseInfoResource.schema()["properties"]["type"]["const"],
@@ -44,7 +39,7 @@ def get_info(request: Request):
                 api_version=__api_version__,
                 available_api_versions=[
                     {
-                        "url": f"{base_url}/v{__api_version__.split('.')[0]}",
+                        "url": f"{get_base_url(request.url)}/v{__api_version__.split('.')[0]}",
                         "version": __api_version__,
                     }
                 ],
@@ -80,7 +75,7 @@ def get_entry_info(request: Request, entry: str):
     output_fields_by_format = {"json": list(properties.keys())}
 
     return EntryInfoResponse(
-        meta=meta_values(str(request.url), 1, 1, more_data_available=False),
+        meta=meta_values(request.url, 1, 1, more_data_available=False),
         data=EntryInfoResource(
             formats=list(output_fields_by_format.keys()),
             description=schema.get("description", "Entry Resources"),

--- a/optimade/server/routers/landing.py
+++ b/optimade/server/routers/landing.py
@@ -1,12 +1,13 @@
 """ OPTIMADE landing page, rendered as a Jinja2 template. """
 
+import urllib
 from pathlib import Path
 from fastapi.templating import Jinja2Templates
 from starlette.routing import Router, Route
 from optimade import __api_version__
 
 from optimade.server.routers import ENTRY_COLLECTIONS
-from optimade.server.routers.utils import meta_values
+from optimade.server.routers.utils import meta_values, get_base_url
 from optimade.server.config import CONFIG
 
 template_dir = Path(__file__).parent.joinpath("static").resolve()
@@ -17,13 +18,9 @@ async def landing(request):
     """ Show a human-readable landing page when the base URL is accessed. """
 
     meta = meta_values(str(request.url), 1, 1, more_data_available=False)
-
+    parse_result = urllib.parse.urlparse(str(request.url))
     major_version = __api_version__.split(".")[0]
-    versioned_url = (
-        f"{request.url}"
-        if f"v{major_version}" in f"{request.url.path}"
-        else f"{request.url}v{major_version}/"
-    )
+    versioned_url = f"{get_base_url(parse_result)}/v{major_version}/"
 
     context = {
         "request": request,

--- a/optimade/server/routers/landing.py
+++ b/optimade/server/routers/landing.py
@@ -1,7 +1,8 @@
 """ OPTIMADE landing page, rendered as a Jinja2 template. """
 
-import urllib
 from pathlib import Path
+
+from fastapi import Request
 from fastapi.templating import Jinja2Templates
 from starlette.routing import Router, Route
 from optimade import __api_version__
@@ -14,13 +15,12 @@ template_dir = Path(__file__).parent.joinpath("static").resolve()
 TEMPLATES = Jinja2Templates(directory=[template_dir])
 
 
-async def landing(request):
+async def landing(request: Request):
     """ Show a human-readable landing page when the base URL is accessed. """
 
-    meta = meta_values(str(request.url), 1, 1, more_data_available=False)
-    parse_result = urllib.parse.urlparse(str(request.url))
+    meta = meta_values(request.url, 1, 1, more_data_available=False)
     major_version = __api_version__.split(".")[0]
-    versioned_url = f"{get_base_url(parse_result)}/v{major_version}/"
+    versioned_url = f"{get_base_url(request.url)}/v{major_version}/"
 
     context = {
         "request": request,

--- a/optimade/server/routers/utils.py
+++ b/optimade/server/routers/utils.py
@@ -172,7 +172,7 @@ def get_base_url(
     Take the base URL from the config file, if it exists, otherwise use the request.
     """
     return (
-        CONFIG.base_url
+        CONFIG.base_url.rstrip("/")
         if CONFIG.base_url
         else f"{parsed_url_request.scheme}://{parsed_url_request.netloc}"
     )

--- a/optimade/server/routers/utils.py
+++ b/optimade/server/routers/utils.py
@@ -31,7 +31,7 @@ BASE_URL_PREFIXES = {
 
 
 def meta_values(
-    url: str,
+    url: Union[urllib.parse.ParseResult, urllib.parse.SplitResult, StarletteURL, str],
     data_returned: int,
     data_available: int,
     more_data_available: bool,
@@ -40,16 +40,17 @@ def meta_values(
     """Helper to initialize the meta values"""
     from optimade.models import ResponseMetaQuery
 
-    parse_result = urllib.parse.urlparse(url)
+    if isinstance(url, str):
+        url = urllib.parse.urlparse(url)
 
     # To catch all (valid) variations of the version part of the URL, a regex is used
-    if re.match(r"/v[0-9]+(\.[0-9]+){,2}/.*", parse_result.path) is not None:
-        url_path = re.sub(r"/v[0-9]+(\.[0-9]+){,2}/", "/", parse_result.path)
+    if re.match(r"/v[0-9]+(\.[0-9]+){,2}/.*", url.path) is not None:
+        url_path = re.sub(r"/v[0-9]+(\.[0-9]+){,2}/", "/", url.path)
     else:
-        url_path = parse_result.path
+        url_path = url.path
 
     return ResponseMeta(
-        query=ResponseMetaQuery(representation=f"{url_path}?{parse_result.query}"),
+        query=ResponseMetaQuery(representation=f"{url_path}?{url.query}"),
         api_version=__api_version__,
         time_stamp=datetime.now(),
         data_returned=data_returned,
@@ -164,13 +165,15 @@ def get_included_relationships(
 
 def get_base_url(
     parsed_url_request: Union[
-        urllib.parse.ParseResult, urllib.parse.SplitResult, StarletteURL
+        urllib.parse.ParseResult, urllib.parse.SplitResult, StarletteURL, str
     ]
 ) -> str:
     """Get base URL for current server
 
     Take the base URL from the config file, if it exists, otherwise use the request.
     """
+    if isinstance(parsed_url_request, str):
+        parsed_url_request = urllib.parse.urlparse(parsed_url_request)
     return (
         CONFIG.base_url.rstrip("/")
         if CONFIG.base_url
@@ -196,13 +199,12 @@ def get_entries(
 
     if more_data_available:
         # Deduce the `next` link from the current request
-        parse_result = urllib.parse.urlparse(str(request.url))
-        query = urllib.parse.parse_qs(parse_result.query)
+        query = urllib.parse.parse_qs(request.url.query)
         query["page_offset"] = int(query.get("page_offset", [0])[0]) + len(results)
         urlencoded = urllib.parse.urlencode(query, doseq=True)
-        base_url = get_base_url(parse_result)
+        base_url = get_base_url(request.url)
 
-        links = ToplevelLinks(next=f"{base_url}{parse_result.path}?{urlencoded}")
+        links = ToplevelLinks(next=f"{base_url}{request.url.path}?{urlencoded}")
     else:
         links = ToplevelLinks(next=None)
 
@@ -213,7 +215,7 @@ def get_entries(
         links=links,
         data=results,
         meta=meta_values(
-            url=str(request.url),
+            url=request.url,
             data_returned=data_returned,
             data_available=len(collection),
             more_data_available=more_data_available,
@@ -254,7 +256,7 @@ def get_single_entry(
         links=links,
         data=results,
         meta=meta_values(
-            url=str(request.url),
+            url=request.url,
             data_returned=data_returned,
             data_available=len(collection),
             more_data_available=more_data_available,

--- a/optimade/server/routers/utils.py
+++ b/optimade/server/routers/utils.py
@@ -172,8 +172,11 @@ def get_base_url(
 
     Take the base URL from the config file, if it exists, otherwise use the request.
     """
-    if isinstance(parsed_url_request, str):
-        parsed_url_request = urllib.parse.urlparse(parsed_url_request)
+    parsed_url_request = (
+        urllib.parse.urlparse(parsed_url_request)
+        if isinstance(parsed_url_request, str)
+        else parsed_url_request
+    )
     return (
         CONFIG.base_url.rstrip("/")
         if CONFIG.base_url


### PR DESCRIPTION
This should fix the endpoint URLs on the landing page to use the proper base_url rather than what comes in from the request. 


EDIT: clearly the commit names are screwed up. One is for fixing the landing page and the other ensures `get_base_url` returns consistent base URLs without the trailing slash.

Closes #371. 