### PR TITLE
This should ensure requirements*.txt are tested

### DIFF
--- a/.github/workflows/deps_lint.yml
+++ b/.github/workflows/deps_lint.yml
@@ -50,9 +50,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -U setuptools
+        pip install -e .
         pip install -r requirements.txt
         pip install -r requirements-dev.txt
-        pip install -e .[dev]
 
     - name: Run pre-commit
       run: |
@@ -75,9 +75,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -U setuptools
+        pip install -e .
         pip install -r requirements.txt
         pip install -r requirements-dev.txt
-        pip install -e .
 
     - name: Pass generated OpenAPI schemas through validator.swagger.io
       run: |
@@ -171,9 +171,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -U setuptools
+        pip install -e .
         pip install -r requirements.txt
         pip install -r requirements-dev.txt
-        pip install -e .
 
     - name: Run all tests (using a real MongoDB)
       run: pytest -rs -vvv --cov=./optimade/ --cov-report=xml tests/
@@ -235,9 +235,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -U setuptools
+        pip install -e .
         pip install -r requirements.txt
         pip install -r requirements-docs.txt
-        pip install -e .
 
     - name: Build
       run: mkdocs build --strict --verbose


### PR DESCRIPTION
By first installing the package and then from the requirements*.txt files this should ensure we test the correct versions when dependabot opens PRs.

See my comment [here](https://github.com/Materials-Consortia/optimade-python-tools/pull/525#issuecomment-698430043) for an example of where this has happened.