### PR TITLE
Update dependencies - remove black as direct dependency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     - id: end-of-file-fixer
 
   - repo: https://gitlab.com/pycqa/flake8
-    rev: '3.8.3'
+    rev: '3.8.4'
     hooks:
     -   id: flake8
 

--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -1,5 +1,5 @@
-aiida-core==1.4.1
+aiida-core==1.4.2
 ase==3.20.1
 numpy==1.19.2
 pymatgen==2020.9.14
-jarvis-tools==2020.9.22
+jarvis-tools==2020.10.3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-pytest==6.1.0
+pytest==6.1.1
 pytest-cov==2.10.1
 codecov==2.1.9
 jsondiff==1.2.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,5 @@ pytest-cov==2.10.1
 codecov==2.1.9
 jsondiff==1.2.0
 pylint==2.6.0
-black==20.8b1
 pre-commit==2.7.1
 invoke==1.4.1

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,5 +1,5 @@
 mkdocs==1.1.2
-mkdocs-awesome-pages-plugin==2.2.1
-mkdocs-material==6.0.1
+mkdocs-awesome-pages-plugin==2.3.1
+mkdocs-material==6.0.2
 mkdocs-minify-plugin==0.3.0
 mkdocstrings==0.13.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,10 +3,10 @@ lark-parser==0.10.0
 pydantic==1.6.1
 email_validator==1.1.1
 requests==2.24.0
-uvicorn==0.12.0
+uvicorn==0.12.1
 pymongo==3.11.0
 mongomock==3.20.0
-django==3.1.1
+django==3.1.2
 elasticsearch-dsl==7.3.0
 Jinja2==2.11.2
 typing-extensions==3.7.4.3

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ testing_deps = [
     "jsondiff~=1.2",
 ] + server_deps
 dev_deps = (
-    ["pylint~=2.6", "black~=20.8b1", "pre-commit~=2.7", "invoke~=1.4"]
+    ["pylint~=2.6", "pre-commit~=2.7", "invoke~=1.4"]
     + docs_deps
     + testing_deps
     + client_deps

--- a/setup.py
+++ b/setup.py
@@ -20,21 +20,21 @@ with open(module_dir.joinpath("optimade/__init__.py")) as version_file:
 django_deps = ["django>=2.2.9,<4.0"]
 elastic_deps = ["elasticsearch-dsl>=6.4,<8.0"]
 mongo_deps = ["pymongo~=3.11", "mongomock~=3.20"]
-server_deps = ["uvicorn~=0.12.0", "Jinja2~=2.11"] + mongo_deps
+server_deps = ["uvicorn~=0.12.1", "Jinja2~=2.11"] + mongo_deps
 
 # Client minded
-aiida_deps = ["aiida-core~=1.4.1"]
+aiida_deps = ["aiida-core~=1.4.2"]
 ase_deps = ["ase~=3.20"]
 cif_deps = ["numpy~=1.19"]
 pdb_deps = cif_deps
 pymatgen_deps = ["pymatgen==2020.9.14"]
-jarvis_deps = ["jarvis-tools==2020.9.22"]
+jarvis_deps = ["jarvis-tools==2020.10.3"]
 client_deps = cif_deps
 
 # General
 docs_deps = [
     "mkdocs~=1.1",
-    "mkdocs-awesome-pages-plugin~=2.2",
+    "mkdocs-awesome-pages-plugin~=2.3",
     "mkdocs-material~=6.0",
     "mkdocs-minify-plugin~=0.3.0",
     "mkdocstrings~=0.13.6",


### PR DESCRIPTION
Octopus merge of all dependabot PRs.

Update `setup.py` accordingly.

Update `flake8` for pre-commit.
For this I also ran `pre-commit run --all-files`, but the updated `flake8` didn't introduce any changes.

I have used this PR to also remove the direct dependency of `black`, since this is only used in pre-commit, where it is installed separately, hence there is no reason to depend on it directly - unless someone is using this in their editor directly (like the case is for me concerning `pylint`).