### PR TITLE
Improve handling of MongoDB ObjectID

### DIFF
--- a/optimade/filtertransformers/mongo.py
+++ b/optimade/filtertransformers/mongo.py
@@ -466,7 +466,7 @@ class MongoTransformer(Transformer):
                     if self.mapper is not None:
                         prop = self.mapper.alias_of(prop)
                     raise BadRequest(
-                        detail=f"Operator not supported for query on field {prop}, can only test for equality"
+                        detail=f"Operator not supported for query on field {prop!r}, can only test for equality"
                     )
                 if isinstance(val, str):
                     subdict[prop][operator] = ObjectId(val)

--- a/optimade/server/entry_collections/entry_collections.py
+++ b/optimade/server/entry_collections/entry_collections.py
@@ -171,9 +171,12 @@ class EntryCollection(ABC):
             cursor_kwargs["limit"] = CONFIG.page_limit
 
         cursor_kwargs["fields"] = self.all_fields
-        cursor_kwargs["projection"] = [
-            self.resource_mapper.alias_for(f) for f in self.all_fields
-        ]
+        cursor_kwargs["projection"] = {
+            f"{self.resource_mapper.alias_for(f)}": True for f in self.all_fields
+        }
+
+        if "_id" not in cursor_kwargs["projection"]:
+            cursor_kwargs["projection"]["_id"] = False
 
         if getattr(params, "sort", False):
             cursor_kwargs["sort"] = self.parse_sort_params(params.sort)

--- a/optimade/server/entry_collections/mongo.py
+++ b/optimade/server/entry_collections/mongo.py
@@ -116,6 +116,8 @@ class MongoCollection(EntryCollection):
 
         results = []
         for doc in self.collection.find(**criteria):
+            if "_id" in doc:
+                doc["_id"] = str(doc["_id"])
             results.append(self.resource_cls(**self.resource_mapper.map_back(doc)))
 
         nresults_now = len(results)

--- a/optimade/server/entry_collections/mongo.py
+++ b/optimade/server/entry_collections/mongo.py
@@ -116,7 +116,7 @@ class MongoCollection(EntryCollection):
 
         results = []
         for doc in self.collection.find(**criteria):
-            if "_id" in doc:
+            if criteria.get("projection", {}).get("_id"):
                 doc["_id"] = str(doc["_id"])
             results.append(self.resource_cls(**self.resource_mapper.map_back(doc)))
 

--- a/optimade/server/exceptions.py
+++ b/optimade/server/exceptions.py
@@ -1,7 +1,23 @@
 from fastapi import HTTPException
 
+__all__ = (
+    "BadRequest",
+    "VersionNotSupported",
+    "Forbidden",
+)
 
-class BadRequest(HTTPException):
+
+class StrReprMixin(HTTPException):
+    """This mixin can be useful when testing requires a string
+    representation of an exception that contains the HTTPException
+    detail string, rather than the standard Python exception message.
+    """
+
+    def __str__(self):
+        return self.__repr__()
+
+
+class BadRequest(StrReprMixin, HTTPException):
     """400 Bad Request"""
 
     def __init__(
@@ -15,7 +31,7 @@ class BadRequest(HTTPException):
         self.title = title
 
 
-class VersionNotSupported(HTTPException):
+class VersionNotSupported(StrReprMixin, HTTPException):
     """553 Version Not Supported"""
 
     def __init__(
@@ -29,7 +45,7 @@ class VersionNotSupported(HTTPException):
         self.title = title
 
 
-class Forbidden(HTTPException):
+class Forbidden(StrReprMixin, HTTPException):
     """403 Forbidden"""
 
     def __init__(

--- a/optimade/server/mappers/entries.py
+++ b/optimade/server/mappers/entries.py
@@ -146,9 +146,6 @@ class BaseResourceMapper:
             A resource object in OPTIMADE format.
 
         """
-        if "_id" in doc:
-            del doc["_id"]
-
         mapping = ((real, alias) for alias, real in cls.all_aliases())
         newdoc = {}
         reals = {real for alias, real in cls.all_aliases()}

--- a/optimade_config.json
+++ b/optimade_config.json
@@ -23,6 +23,7 @@
     "aliases": {
         "structures": {
             "id": "task_id",
+            "immutable_id": "_id",
             "chemical_formula_descriptive": "pretty_formula",
             "chemical_formula_reduced": "pretty_formula",
             "chemical_formula_anonymous": "formula_anonymous"

--- a/tests/filtertransformers/test_mongo.py
+++ b/tests/filtertransformers/test_mongo.py
@@ -399,7 +399,10 @@ class TestMongoTransformer:
         ) == {"_id": {"$ne": ObjectId("5cfb441f053b174410700d02")}}
 
         for op in ("CONTAINS", "STARTS WITH", "ENDS WITH", "HAS"):
-            with pytest.raises(BadRequest):
+            with pytest.raises(
+                BadRequest,
+                match=r".*not supported for query on field 'immutable_id', can only test for equality.*",
+            ):
                 transformer.transform(parser.parse(f'immutable_id {op} "abcdef"'))
 
     def test_aliased_length_operator(self, mapper):

--- a/tests/filtertransformers/test_mongo.py
+++ b/tests/filtertransformers/test_mongo.py
@@ -385,17 +385,7 @@ class TestMongoTransformer:
         from bson import ObjectId
 
         class MyMapper(mapper("StructureMapper")):
-            ALIASES = (
-                ("elements", "my_elements"),
-                ("nelements", "nelem"),
-                ("immutable_id", "_id"),
-            )
-            LENGTH_ALIASES = (
-                ("chemsys", "nelements"),
-                ("cartesian_site_positions", "nsites"),
-                ("elements", "nelements"),
-            )
-            PROVIDER_FIELDS = ("chemsys",)
+            ALIASES = (("immutable_id", "_id"),)
 
         transformer = MongoTransformer(mapper=MyMapper())
         parser = LarkParser(version=self.version, variant=self.variant)

--- a/tests/filtertransformers/test_mongo.py
+++ b/tests/filtertransformers/test_mongo.py
@@ -3,6 +3,7 @@ import pytest
 from lark.exceptions import VisitError
 
 from optimade.filterparser import LarkParser, ParserError
+from optimade.server.exceptions import BadRequest
 
 
 class TestMongoTransformer:
@@ -377,6 +378,39 @@ class TestMongoTransformer:
         assert self.transform("cartesian_site_positions LENGTH > 10") == {
             "cartesian_site_positions.11": {"$exists": True}
         }
+
+    def test_mongo_special_id(self, mapper):
+
+        from optimade.filtertransformers.mongo import MongoTransformer
+        from bson import ObjectId
+
+        class MyMapper(mapper("StructureMapper")):
+            ALIASES = (
+                ("elements", "my_elements"),
+                ("nelements", "nelem"),
+                ("immutable_id", "_id"),
+            )
+            LENGTH_ALIASES = (
+                ("chemsys", "nelements"),
+                ("cartesian_site_positions", "nsites"),
+                ("elements", "nelements"),
+            )
+            PROVIDER_FIELDS = ("chemsys",)
+
+        transformer = MongoTransformer(mapper=MyMapper())
+        parser = LarkParser(version=self.version, variant=self.variant)
+
+        assert transformer.transform(
+            parser.parse('immutable_id = "5cfb441f053b174410700d02"')
+        ) == {"_id": {"$eq": ObjectId("5cfb441f053b174410700d02")}}
+
+        assert transformer.transform(
+            parser.parse('immutable_id != "5cfb441f053b174410700d02"')
+        ) == {"_id": {"$ne": ObjectId("5cfb441f053b174410700d02")}}
+
+        for op in ("CONTAINS", "STARTS WITH", "ENDS WITH", "HAS"):
+            with pytest.raises(BadRequest):
+                transformer.transform(parser.parse(f'immutable_id {op} "abcdef"'))
 
     def test_aliased_length_operator(self, mapper):
         from optimade.filtertransformers.mongo import MongoTransformer


### PR DESCRIPTION
This PR moves the BSON `ObjectID` handling code out of the general mapper and into the mongo-specific entry collection. It also adds a post-processing method to the `MongoTransformer` to handle queries on the underlying Mongo `_id` (e.g. if you aliased `immutable_id` to `_id`) by converting them to the corresponding `{"$oid": {"$eq": "123456"}` query, disallowing other string filters. This means it can now be aliased in the same way as any other field.

- The test server now uses `_id` as the underlying field for the `immutable_id` OPTIMADE field.
- MongoDB projection is now done in a dict format to allow for explicit exclusion of `_id` if it has not been aliased (by default, our existing list-based projection always includes `_id`, which is why we had to delete it every time in the mapper).
