### PR TITLE
Moved CONFIG import so it does not get triggered when just importing mapper

### DIFF
--- a/optimade/server/mappers/entries.py
+++ b/optimade/server/mappers/entries.py
@@ -1,5 +1,4 @@
 from typing import Tuple, Optional
-from optimade.server.config import CONFIG
 
 __all__ = ("BaseResourceMapper",)
 
@@ -45,6 +44,8 @@ class BaseResourceMapper:
             A tuple of alias tuples.
 
         """
+        from optimade.server.config import CONFIG
+
         return (
             tuple(
                 (f"_{CONFIG.provider.prefix}_{field}", field)
@@ -67,6 +68,8 @@ class BaseResourceMapper:
             A tuple of length alias tuples.
 
         """
+        from optimade.server.config import CONFIG
+
         return cls.LENGTH_ALIASES + tuple(
             CONFIG.length_aliases.get(cls.ENDPOINT, {}).items()
         )


### PR DESCRIPTION
This is to suppress the spurious warning reported in #568. Alternatively, we could consider making another level in the mapper hierarchy (`ReallyBaseMapper`...) that does not touch the config.

Closes #568.