### PR TITLE
Moving and adding some utilities

### DIFF
--- a/optimade/server/logger.py
+++ b/optimade/server/logger.py
@@ -4,8 +4,6 @@ import os
 from pathlib import Path
 import sys
 
-from uvicorn.logging import DefaultFormatter
-
 
 # Instantiate LOGGER
 LOGGER = logging.getLogger("optimade")
@@ -25,9 +23,15 @@ try:
 except ImportError:
     CONSOLE_HANDLER.setLevel(os.getenv("OPTIMADE_LOG_LEVEL", "INFO").upper())
 
-# Formatter
-CONSOLE_FORMATTER = DefaultFormatter("%(levelprefix)s [%(name)s] %(message)s")
-CONSOLE_HANDLER.setFormatter(CONSOLE_FORMATTER)
+# Formatter; try to use uvicorn default, otherwise just use built-in default
+try:
+    from uvicorn.logging import DefaultFormatter
+
+    CONSOLE_FORMATTER = DefaultFormatter("%(levelprefix)s [%(name)s] %(message)s")
+    CONSOLE_HANDLER.setFormatter(CONSOLE_FORMATTER)
+except ImportError:
+    pass
+
 
 # Add handler to LOGGER
 LOGGER.addHandler(CONSOLE_HANDLER)

--- a/optimade/server/main.py
+++ b/optimade/server/main.py
@@ -73,7 +73,7 @@ if not CONFIG.use_real_mongo:
             LOGGER.debug(
                 "  Adding Materials-Consortia providers to links from optimade.org"
             )
-            providers = get_providers()
+            providers = get_providers(add_mongo_id=True)
             for doc in providers:
                 endpoint_collection.collection.replace_one(
                     filter={"_id": ObjectId(doc["_id"]["$oid"])},

--- a/optimade/server/main_index.py
+++ b/optimade/server/main_index.py
@@ -73,7 +73,7 @@ if not CONFIG.use_real_mongo and CONFIG.index_links_path.exists():
     )
 
     LOGGER.debug("  Adding Materials-Consortia providers to links from optimade.org...")
-    providers = get_providers()
+    providers = get_providers(add_mongo_id=True)
     for doc in providers:
         links_coll.collection.replace_one(
             filter={"_id": ObjectId(doc["_id"]["$oid"])},

--- a/optimade/server/routers/utils.py
+++ b/optimade/server/routers/utils.py
@@ -20,6 +20,19 @@ from optimade.server.config import CONFIG
 from optimade.server.entry_collections import EntryCollection
 from optimade.server.exceptions import BadRequest
 from optimade.server.query_params import EntryListingQueryParams, SingleEntryQueryParams
+from optimade.utils import mongo_id_for_database, get_providers
+
+__all__ = (
+    "BASE_URL_PREFIXES",
+    "meta_values",
+    "handle_response_fields",
+    "get_included_relationships",
+    "get_base_url",
+    "get_entries",
+    "get_single_entry",
+    "mongo_id_for_database",
+    "get_providers",
+)
 
 # we need to get rid of any release tags (e.g. -rc.2) and any build metadata (e.g. +py36)
 # from the api_version before allowing the URL
@@ -274,91 +287,3 @@ def get_single_entry(
         ),
         included=included,
     )
-
-
-def mongo_id_for_database(database_id: str, database_type: str) -> str:
-    """Produce a MondoDB ObjectId for a database"""
-    from bson.objectid import ObjectId
-
-    oid = f"{database_id}{database_type}"
-    if len(oid) > 12:
-        oid = oid[:12]
-    elif len(oid) < 12:
-        oid = f"{oid}{'0' * (12 - len(oid))}"
-
-    return str(ObjectId(oid.encode("UTF-8")))
-
-
-def get_providers() -> list:
-    """Retrieve Materials-Consortia providers (from https://providers.optimade.org/v1/links).
-
-    Fallback order if providers.optimade.org is not available:
-
-    1. Try Materials-Consortia/providers on GitHub.
-    2. Try submodule `providers`' list of providers.
-    3. Log warning that providers list from Materials-Consortia is not included in the
-       `/links`-endpoint.
-
-    Returns:
-        List of raw JSON-decoded providers including MongoDB object IDs.
-
-    """
-    import requests
-
-    try:
-        import simplejson as json
-    except ImportError:
-        import json
-
-    provider_list_urls = [
-        "https://providers.optimade.org/v1/links",
-        "https://raw.githubusercontent.com/Materials-Consortia/providers"
-        "/master/src/links/v1/providers.json",
-    ]
-
-    for provider_list_url in provider_list_urls:
-        try:
-            providers = requests.get(provider_list_url).json()
-        except (
-            requests.exceptions.ConnectionError,
-            requests.exceptions.ConnectTimeout,
-            json.JSONDecodeError,
-        ):
-            pass
-        else:
-            break
-    else:
-        try:
-            from optimade.server.data import providers
-        except ImportError:
-            from optimade.server.logger import LOGGER
-
-            LOGGER.warning(
-                """Could not retrieve a list of providers!
-
-    Tried the following resources:
-
-{}
-    The list of providers will not be included in the `/links`-endpoint.
-""".format(
-                    "".join([f"    * {_}\n" for _ in provider_list_urls])
-                )
-            )
-            return []
-
-    providers_list = []
-    for provider in providers.get("data", []):
-        # Remove/skip "exmpl"
-        if provider["id"] == "exmpl":
-            continue
-
-        provider.update(provider.pop("attributes", {}))
-
-        # Add MongoDB ObjectId
-        provider["_id"] = {
-            "$oid": mongo_id_for_database(provider["id"], provider["type"])
-        }
-
-        providers_list.append(provider)
-
-    return providers_list

--- a/optimade/utils.py
+++ b/optimade/utils.py
@@ -1,0 +1,131 @@
+from typing import List
+
+from optimade.models.links import LinksResource
+
+
+def mongo_id_for_database(database_id: str, database_type: str) -> str:
+    """Produce a MongoDB ObjectId for a database"""
+    from bson.objectid import ObjectId
+
+    oid = f"{database_id}{database_type}"
+    if len(oid) > 12:
+        oid = oid[:12]
+    elif len(oid) < 12:
+        oid = f"{oid}{'0' * (12 - len(oid))}"
+
+    return str(ObjectId(oid.encode("UTF-8")))
+
+
+def get_providers(add_mongo_id: bool = False) -> list:
+    """Retrieve Materials-Consortia providers (from https://providers.optimade.org/v1/links).
+
+    Fallback order if providers.optimade.org is not available:
+
+    1. Try Materials-Consortia/providers on GitHub.
+    2. Try submodule `providers`' list of providers.
+    3. Log warning that providers list from Materials-Consortia is not included in the
+       `/links`-endpoint.
+
+    Arguments:
+        Whether to populate the `_id` field of the provider with MongoDB ObjectID.
+
+    Returns:
+        List of raw JSON-decoded providers including MongoDB object IDs.
+
+    """
+    import requests
+
+    try:
+        import simplejson as json
+    except ImportError:
+        import json
+
+    provider_list_urls = [
+        "https://providers.optimade.org/v1/links",
+        "https://raw.githubusercontent.com/Materials-Consortia/providers"
+        "/master/src/links/v1/providers.json",
+    ]
+
+    for provider_list_url in provider_list_urls:
+        try:
+            providers = requests.get(provider_list_url).json()
+        except (
+            requests.exceptions.ConnectionError,
+            requests.exceptions.ConnectTimeout,
+            json.JSONDecodeError,
+        ):
+            pass
+        else:
+            break
+    else:
+        try:
+            from optimade.server.data import providers
+        except ImportError:
+            from optimade.server.logger import LOGGER
+
+            LOGGER.warning(
+                """Could not retrieve a list of providers!
+
+    Tried the following resources:
+
+{}
+    The list of providers will not be included in the `/links`-endpoint.
+""".format(
+                    "".join([f"    * {_}\n" for _ in provider_list_urls])
+                )
+            )
+            return []
+
+    providers_list = []
+    for provider in providers.get("data", []):
+        # Remove/skip "exmpl"
+        if provider["id"] == "exmpl":
+            continue
+
+        provider.update(provider.pop("attributes", {}))
+
+        # Add MongoDB ObjectId
+        if add_mongo_id:
+            provider["_id"] = {
+                "$oid": mongo_id_for_database(provider["id"], provider["type"])
+            }
+
+        providers_list.append(provider)
+
+    return providers_list
+
+
+def get_child_database_links(provider: LinksResource) -> List[LinksResource]:
+    """For a provider, return a list of available child databases.
+
+    Arguments:
+        provider: The links entry for the provider.
+
+    Returns:
+        A list of the valid links entries from this provider that
+        have `link_type` `"child"`.
+
+    """
+    import requests
+    from optimade.models.responses import LinksResponse
+    from optimade.models.links import LinkType
+
+    base_url = provider.pop("base_url")
+    if base_url is None:
+        raise RuntimeError(f"Provider {provider['id']} provides no base URL.")
+
+    links_endp = base_url + "/v1/links"
+    links = requests.get(links_endp)
+
+    if links.status_code != 200:
+        raise RuntimeError(
+            f"Invalid response from {links_endp} for provider {provider['id']}: {links.content}."
+        )
+
+    links = LinksResponse(**links.json())
+    return [
+        link
+        for link in links.data
+        if link.attributes.link_type == LinkType.child
+        and link.attributes.base_url is not None
+    ]


### PR DESCRIPTION
I've just been playing around with some CLI client code, and a couple of things came up when installing this package without the server deps.

- [x] Moved `get_providers()` out to a new top-level utils module, to avoid importing router-related stuff
- [x] Made setting a mongo ID optional when getting providers 
- [x] Added a `get_child_database_links()` function for finding all dbs from a provider link
- [x] Do not require uvicorn when using the `LOGGER`, just fallback the default logging formatter instead