### PR TITLE
Improve support for timestamp queries in MongoTransformer

### DIFF
--- a/optimade/filtertransformers/mongo.py
+++ b/optimade/filtertransformers/mongo.py
@@ -1,7 +1,6 @@
 import copy
 from lark import v_args, Token
 from optimade.filtertransformers.base_transformer import BaseTransformer
-from optimade.server.exceptions import BadRequest
 
 __all__ = ("MongoTransformer",)
 
@@ -396,8 +395,8 @@ class MongoTransformer(BaseTransformer):
                 if operator not in ("$eq", "$ne"):
                     if self.mapper is not None:
                         prop = self.mapper.alias_of(prop)
-                    raise BadRequest(
-                        detail=f"Operator not supported for query on field {prop!r}, can only test for equality"
+                    raise NotImplementedError(
+                        f"Operator {operator} not supported for query on field {prop!r}, can only test for equality"
                     )
                 if isinstance(val, str):
                     subdict[prop][operator] = ObjectId(val)

--- a/optimade/filtertransformers/mongo.py
+++ b/optimade/filtertransformers/mongo.py
@@ -424,8 +424,11 @@ class MongoTransformer(BaseTransformer):
 
             for operator in subdict[prop]:
                 subdict[prop][operator] = bson.json_util.loads(
-                    bson.json_util.dumps({"$date": subdict[prop][operator]})
-                ).replace(tzinfo=None)
+                    bson.json_util.dumps({"$date": subdict[prop][operator]}),
+                    json_options=bson.json_util.DEFAULT_JSON_OPTIONS.with_options(
+                        tz_aware=True, tzinfo=bson.tz_util.utc
+                    ),
+                )
 
             return subdict
 

--- a/optimade/filtertransformers/mongo.py
+++ b/optimade/filtertransformers/mongo.py
@@ -426,7 +426,7 @@ class MongoTransformer(BaseTransformer):
             for operator in subdict[prop]:
                 subdict[prop][operator] = bson.json_util.loads(
                     bson.json_util.dumps({"$date": subdict[prop][operator]})
-                )
+                ).replace(tzinfo=None)
 
             return subdict
 

--- a/optimade/models/jsonapi.py
+++ b/optimade/models/jsonapi.py
@@ -352,6 +352,13 @@ class Response(BaseModel):
         return values
 
     class Config:
+        """The specification mandates that datetimes must be encoded following
+        [RFC3339](https://tools.ietf.org/html/rfc3339), which does not support
+        fractional seconds, thus they must be stripped in the response. This can
+        cause issues when the underlying database contains fields that do include
+        microseconds, as filters may return unexpected results.
+        """
+
         json_encoders = {
             datetime: lambda v: v.astimezone(timezone.utc).strftime(
                 "%Y-%m-%dT%H:%M:%SZ"

--- a/optimade/server/data/test_structures.json
+++ b/optimade/server/data/test_structures.json
@@ -3562,7 +3562,7 @@
     ],
     "formula_anonymous": "A26B8C2D2E2FGHI",
     "last_modified": {
-      "$date": "2019-06-08T05:13:37.945Z"
+      "$date": "2018-06-08T05:13:37.945Z"
     },
     "lattice_vectors": [
       [

--- a/optimade/server/warnings.py
+++ b/optimade/server/warnings.py
@@ -42,3 +42,10 @@ class QueryParamNotUsed(OptimadeWarning):
 class MissingExpectedField(OptimadeWarning):
     """A field was provided with a null value when a related field was provided
     with a value."""
+
+
+class TimestampNotRFCCompliant(OptimadeWarning):
+    """A timestamp has been used in a filter that contains microseconds and is thus not
+    RFC 3339 compliant. This may cause undefined behaviour in the query results.
+
+    """

--- a/optimade/validator/config.py
+++ b/optimade/validator/config.py
@@ -74,11 +74,6 @@ _INCLUSIVE_OPERATORS = {
         "=",
         "<=",
         ">=",
-        "CONTAINS",
-        "STARTS WITH",
-        "STARTS",
-        "ENDS WITH",
-        "ENDS",
     ),
     DataType.INTEGER: (
         "=",

--- a/optimade/validator/config.py
+++ b/optimade/validator/config.py
@@ -71,8 +71,10 @@ _INCLUSIVE_OPERATORS = {
         "ENDS",
     ),
     DataType.TIMESTAMP: (
-        "=",
-        "<=",
+        # "=" and "<=" are disabled due to issue with microseconds stored in database vs API response (see Materials-Consortia/optimade-python-tools/#606)
+        # ">=" is fine as all microsecond trimming will round times down
+        # "=",
+        # "<=",
         ">=",
     ),
     DataType.INTEGER: (
@@ -92,7 +94,7 @@ exclusive_ops = ("!=", "<", ">")
 
 _EXCLUSIVE_OPERATORS = {
     DataType.STRING: exclusive_ops,
-    DataType.TIMESTAMP: exclusive_ops,
+    DataType.TIMESTAMP: (),
     DataType.FLOAT: exclusive_ops,
     DataType.INTEGER: exclusive_ops,
     DataType.LIST: (),

--- a/optimade/validator/validator.py
+++ b/optimade/validator/validator.py
@@ -621,7 +621,7 @@ class ImplementationValidator:
                 else:
                     _test_value = test_value[0]
 
-        elif prop_type == DataType.STRING:
+        elif prop_type in (DataType.STRING, DataType.TIMESTAMP):
             _test_value = f'"{test_value}"'
 
         else:
@@ -700,7 +700,7 @@ class ImplementationValidator:
                 self._log.warning(msg)
                 return None, msg
 
-        if prop_type in (DataType.DICTIONARY, DataType.TIMESTAMP):
+        if prop_type in (DataType.DICTIONARY,):
             msg = f"Not testing queries on field {prop} of type {prop_type}."
             self._log.warning(msg)
             return None, msg
@@ -823,7 +823,7 @@ class ImplementationValidator:
                     chosen_entry["id"] in set(entry["id"] for entry in response["data"])
                 ):
                     raise ResponseError(
-                        f"Objects {excluded} were not necessarily excluded by {query}"
+                        f"Object {chosen_entry['id']} with value {test_value} was not excluded by {query}"
                     )
 
             # check that at least the archetypal structure was returned, unless we are using a fallback value

--- a/tests/filtertransformers/test_mongo.py
+++ b/tests/filtertransformers/test_mongo.py
@@ -3,7 +3,6 @@ import pytest
 from lark.exceptions import VisitError
 
 from optimade.filterparser import LarkParser, ParserError
-from optimade.server.exceptions import BadRequest
 
 
 class TestMongoTransformer:
@@ -476,7 +475,7 @@ class TestMongoTransformer:
 
         for op in ("CONTAINS", "STARTS WITH", "ENDS WITH", "HAS"):
             with pytest.raises(
-                BadRequest,
+                NotImplementedError,
                 match=r".*not supported for query on field 'immutable_id', can only test for equality.*",
             ):
                 transformer.transform(parser.parse(f'immutable_id {op} "abcdef"'))

--- a/tests/filtertransformers/test_mongo.py
+++ b/tests/filtertransformers/test_mongo.py
@@ -378,7 +378,7 @@ class TestMongoTransformer:
                     minute=13,
                     second=37,
                     microsecond=0,
-                    tzinfo=bson.tz_util.FixedOffset(0, "none"),
+                    tzinfo=bson.tz_util.utc,
                 )
             }
         }
@@ -392,7 +392,7 @@ class TestMongoTransformer:
                     minute=13,
                     second=37,
                     microsecond=0,
-                    tzinfo=bson.tz_util.FixedOffset(0, "none"),
+                    tzinfo=bson.tz_util.utc,
                 )
             }
         }
@@ -415,7 +415,7 @@ class TestMongoTransformer:
                     minute=13,
                     second=37,
                     microsecond=0,
-                    tzinfo=bson.tz_util.FixedOffset(0, "none"),
+                    tzinfo=bson.tz_util.utc,
                 )
             }
         }
@@ -431,7 +431,7 @@ class TestMongoTransformer:
                     minute=13,
                     second=37,
                     microsecond=0,
-                    tzinfo=bson.tz_util.FixedOffset(0, "none"),
+                    tzinfo=bson.tz_util.utc,
                 )
             }
         }

--- a/tests/server/query_params/test_filter.py
+++ b/tests/server/query_params/test_filter.py
@@ -1,4 +1,5 @@
 """Make sure response_fields is handled correctly"""
+import pytest
 
 
 def test_custom_field(check_response):
@@ -168,21 +169,27 @@ def test_list_correlated(check_error_response):
 
 
 def test_timestamp_query(check_response):
+    from optimade.server.warnings import TimestampNotRFCCompliant
+
     request = '/structures?filter=last_modified="2019-06-08T05:13:37.331Z"&page_limit=5'
     expected_ids = ["mpf_1", "mpf_2", "mpf_3"]
-    check_response(request, expected_ids, expected_as_is=True)
+    with pytest.warns(TimestampNotRFCCompliant):
+        check_response(request, expected_ids, expected_as_is=True)
 
     request = '/structures?filter=last_modified<"2019-06-08T05:13:37.331Z"&page_limit=5'
     expected_ids = ["mpf_3819"]
-    check_response(request, expected_ids, expected_as_is=True)
+    with pytest.warns(TimestampNotRFCCompliant):
+        check_response(request, expected_ids, expected_as_is=True)
 
     request = '/structures?filter=last_modified="2018-06-08T05:13:37.945Z"&page_limit=5'
     expected_ids = ["mpf_3819"]
-    check_response(request, expected_ids, expected_as_is=True)
+    with pytest.warns(TimestampNotRFCCompliant):
+        check_response(request, expected_ids, expected_as_is=True)
 
     request = '/structures?filter=last_modified>"2018-06-08T05:13:37.945Z" AND last_modified<="2019-06-08T05:13:37.331Z"&page_limit=5'
     expected_ids = ["mpf_1", "mpf_2", "mpf_3"]
-    check_response(request, expected_ids, expected_as_is=True)
+    with pytest.warns(TimestampNotRFCCompliant):
+        check_response(request, expected_ids, expected_as_is=True)
 
 
 def test_is_known(check_response):

--- a/tests/server/query_params/test_filter.py
+++ b/tests/server/query_params/test_filter.py
@@ -167,6 +167,24 @@ def test_list_correlated(check_error_response):
     # check_response(request, expected_ids)
 
 
+def test_timestamp_query(check_response):
+    request = '/structures?filter=last_modified="2019-06-08T05:13:37.331Z"&page_limit=5'
+    expected_ids = ["mpf_1", "mpf_2", "mpf_3"]
+    check_response(request, expected_ids, expected_as_is=True)
+
+    request = '/structures?filter=last_modified<"2019-06-08T05:13:37.331Z"&page_limit=5'
+    expected_ids = ["mpf_3819"]
+    check_response(request, expected_ids, expected_as_is=True)
+
+    request = '/structures?filter=last_modified="2018-06-08T05:13:37.945Z"&page_limit=5'
+    expected_ids = ["mpf_3819"]
+    check_response(request, expected_ids, expected_as_is=True)
+
+    request = '/structures?filter=last_modified>"2018-06-08T05:13:37.945Z" AND last_modified<="2019-06-08T05:13:37.331Z"&page_limit=5'
+    expected_ids = ["mpf_1", "mpf_2", "mpf_3"]
+    check_response(request, expected_ids, expected_as_is=True)
+
+
 def test_is_known(check_response):
     request = "/structures?filter=nsites IS KNOWN AND nsites>=44"
     expected_ids = ["mpf_551", "mpf_3803", "mpf_3819"]


### PR DESCRIPTION
Addresses #102, where it was decided that timestamps should be handled by the transformers, rather than in the grammar themselves (which would have involved a horrible regexp, and goes slightly against the specification).

This PR adds an extra step in the `MongoTransformer` to detect OPTIMADE timestamp fields (just `last_modified` at the moment), and encode the filter value properly with BSON.

Pending the next few PRs (e.g. #504), filter transformers will get access to schemas directly, allowing them to directly query for e.g. fields of type `DataType.TIMESTAMP`, rather than hard-coding `last_modified`.

As RFC3339 does not support fractional seconds, the only operation that can be tested by the `optimade-validator` is `>=` (as fractional seconds will always lead to rounded times in the underlying database). This means that there will always be an inconsistency between e.g. the MongoDB server (which has milliseconds) and the JSON response (which does not).

- [x] Add postprocessing methods to find timestamps
- [x] Add filtertransformer tests
- [x] Add server tests to check documents are actually returned with various operations
- [x] Add server validation, modulo microseconds in the timestamp