### PR TITLE
Minor fixes for versions endpoint validation

### DIFF
--- a/optimade/validator/validator.py
+++ b/optimade/validator/validator.py
@@ -37,7 +37,7 @@ from optimade.validator.utils import (
 
 from optimade.validator.config import VALIDATOR_CONFIG as CONF
 
-VERSIONS_REGEXP = r"/v[0-9]+(\.[0-9]+){,2}"
+VERSIONS_REGEXP = r".*/v[0-9]+(\.[0-9]+){,2}$"
 
 __all__ = ("ImplementationValidator",)
 
@@ -995,7 +995,7 @@ class ImplementationValidator:
         """
         expected_status_code = 553
         if re.match(VERSIONS_REGEXP, self.base_url_parsed.path) is not None:
-            expected_status_code = 404
+            expected_status_code = [404, 400]
 
         self._get_endpoint("v123123", expected_status_code=expected_status_code)
 


### PR DESCRIPTION
- Allow dodgy version request to return 400 as well as 404 (e.g. `example.org/v1/v123123`) (reasoning below at https://github.com/Materials-Consortia/optimade-python-tools/pull/591#issuecomment-727952553)
- Tweaked regexp so that `/optimade/v1/` is detected as "versioned"