### PR TITLE
Minor fixes for the validator

### DIFF
--- a/optimade/validator/utils.py
+++ b/optimade/validator/utils.py
@@ -148,7 +148,7 @@ class ValidatorResults:
             "optional": (print, print),
         }
         pprint, warning_pprint = pprint_types.get(
-            "failure_type", (print_failure, print_warning)
+            failure_type, (print_failure, print_warning)
         )
 
         symbol = "!" if failure_type == "internal" else "✖"

--- a/optimade/validator/validator.py
+++ b/optimade/validator/validator.py
@@ -211,7 +211,7 @@ class ImplementationValidator:
             print(
                 "There were internal validator failures associated with this run.\n"
                 "If this problem persists, please report it at:\n"
-                "https://github.com/Materials-Consortia/optimade-python-tools/issues/new.\n"
+                "https://github.com/Materials-Consortia/optimade-python-tools/issues/new\n"
             )
 
             for message in self.results.internal_failure_messages:
@@ -481,17 +481,16 @@ class ImplementationValidator:
             returned_fields -= CONF.top_level_non_attribute_fields
 
             if expected_fields != returned_fields:
-                raise RuntimeError(
-                    f"Response fields not obeyed by {endp!r}:\n{expected_fields}\n{returned_fields}"
+                raise ResponseError(
+                    f"Response fields not obeyed by {endp!r}:\nExpected: {expected_fields}\nReturned: {returned_fields}"
                 )
 
             return True, "Successfully limited response fields"
 
-        else:
-            return (
-                None,
-                f"Unable to test adherence to response fields as no entries were returned for endpoint {endp!r}.",
-            )
+        return (
+            None,
+            f"Unable to test adherence to response fields as no entries were returned for endpoint {endp!r}.",
+        )
 
     @test_case
     def _construct_queries_for_property(

--- a/optimade/validator/validator.py
+++ b/optimade/validator/validator.py
@@ -997,7 +997,9 @@ class ImplementationValidator:
         if re.match(VERSIONS_REGEXP, self.base_url_parsed.path) is not None:
             expected_status_code = [404, 400]
 
-        self._get_endpoint("v123123", expected_status_code=expected_status_code)
+        self._get_endpoint(
+            "v123123", expected_status_code=expected_status_code, optional=True
+        )
 
     @test_case
     def _test_page_limit(


### PR DESCRIPTION
- [x] Test for `553 Version Not Supported` is now optional as its only a SHOULD in the specification
- [x] Fix optional test output colour
- [x] Removed extraneous punctuation from link
- [x] Made response field errors non-fatal 

