### PR TITLE
Fix PyPI publishing in CI

### DIFF
--- a/.github/workflows/publish-on-pypi.yml
+++ b/.github/workflows/publish-on-pypi.yml
@@ -28,7 +28,7 @@ jobs:
       run: |
         python -m pip install -U pip
         pip install -U setuptools
-        pip install -U -e .[all]
+        pip install -U -e .[all] --use-deprecated=legacy-resolver
 
     - name: Update changelog
       uses: CharMixer/auto-changelog-action@v1.1


### PR DESCRIPTION
The new pip dependency resolver now *actually* resolves dependencies, causing mayhem. Somehow one of aiida's dependencies doesn't like the latest setuptools version, so this PR reverses the order of installation so that setuptools is installed last. It might even work.

Aims to close #624. 