### PR TITLE
insert reading of default optimade_config.json in example run script run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ ! -v OPTIMADE_CONFIG_FILE ] || [ -z "$OPTIMADE_CONFIG_FILE" ]; then
+if [ -z "$OPTIMADE_CONFIG_FILE" ]; then
     export OPTIMADE_CONFIG_FILE="./optimade_config.json"
     echo "Using the demo config file at ${OPTIMADE_CONFIG_FILE}."
     echo "Set the environment variable OPTIMADE_CONFIG_FILE to override this behaviour."

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export OPTIMADE_CONFIG_FILE="optimade_config.json"
+
 export OPTIMADE_LOG_LEVEL=info
 if [ "$1" == "debug" ]; then
     export OPTIMADE_DEBUG=1

--- a/run.sh
+++ b/run.sh
@@ -4,6 +4,7 @@ if [ -z "$OPTIMADE_CONFIG_FILE" ]; then
     export OPTIMADE_CONFIG_FILE="./optimade_config.json"
     echo "Using the demo config file at ${OPTIMADE_CONFIG_FILE}."
     echo "Set the environment variable OPTIMADE_CONFIG_FILE to override this behaviour."
+    echo "For more configuration options, please see https://www.optimade.org/optimade-python-tools/configuration/."
 fi
 
 export OPTIMADE_LOG_LEVEL=info

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
-export OPTIMADE_CONFIG_FILE="optimade_config.json"
+if [ ! -v OPTIMADE_CONFIG_FILE ] || [ -z "$OPTIMADE_CONFIG_FILE" ]; then
+    export OPTIMADE_CONFIG_FILE="./optimade_config.json"
+    echo "Using the demo config file at ${OPTIMADE_CONFIG_FILE}."
+    echo "Set the environment variable OPTIMADE_CONFIG_FILE to override this behaviour."
+fi
 
 export OPTIMADE_LOG_LEVEL=info
 if [ "$1" == "debug" ]; then


### PR DESCRIPTION
This tiny fix resolves a stumbling block for new users trying out optimade-python-tools.

Without this fix, someone downloading optimade-python-tools and executing `./run.sh` to try it out gets a server that otherwise works, but reports a 501 internal server error upon accessing the  `/structures` endpoint without a a clear error description pointing the user what to do. Enabling debug mode explains that the error is a pydantic validation error due to missing chemical formula fields.

The issue is that the test data in `optimade/server/data/test_structures.json` absolutely needs the aliases mapping set up in the config file distributed with optimade-python-tools in `/optimade_config.json`. Hence, it is not possible to start a demo server without also reading that config file.

While one could consider other solutions (e.g., changing the default config hardcoded inside the python files), I think it is the expected behavior that the default example run script uses the included example config file, so that edits in that file are reflected by the running server.
