### PR TITLE
Added "root_path" config parameter for FastAPI apps

### DIFF
--- a/optimade/server/config.py
+++ b/optimade/server/config.py
@@ -74,6 +74,14 @@ class ServerConfig(BaseSettings):
         "test_server",
         description="ID of /links endpoint resource for the chosen default OPTIMADE implementation (only relevant for the index meta-database)",
     )
+    root_path: Optional[str] = Field(
+        None,
+        description=(
+            "Sets the FastAPI app `root_path` parameter. This can be used to serve the API under a "
+            "path prefix behind a proxy or as a sub-application of another FastAPI app. "
+            "See https://fastapi.tiangolo.com/advanced/sub-applications/#technical-details-root_path for details."
+        ),
+    )
     base_url: Optional[str] = Field(
         None, description="Base URL for this implementation"
     )

--- a/optimade/server/main.py
+++ b/optimade/server/main.py
@@ -45,6 +45,7 @@ if CONFIG.debug:  # pragma: no cover
     LOGGER.info("DEBUG MODE")
 
 app = FastAPI(
+    root_path=CONFIG.root_path,
     title="OPTIMADE API",
     description=(
         f"""The [Open Databases Integration for Materials Design (OPTIMADE) consortium](https://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.

--- a/optimade/server/main_index.py
+++ b/optimade/server/main_index.py
@@ -36,6 +36,7 @@ if CONFIG.debug:  # pragma: no cover
 
 
 app = FastAPI(
+    root_path=CONFIG.root_path,
     title="OPTIMADE API - Index meta-database",
     description=(
         f"""The [Open Databases Integration for Materials Design (OPTIMADE) consortium](https://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.


### PR DESCRIPTION
…pi app root_path.

Fastapi allows to configure a root_path in cases where the app cannot be served directly at the path root. This is meaningful if you need to serve multiple apps/sites from the same host or have other constraints and need to put optimade "somewhere else". We for example want to mount optimade into another fastapi app (alongside our proprietary API, [see fastapi docs](https://fastapi.tiangolo.com/advanced/sub-applications/)), other might need to proxy optimade with a path prefix (see [fastapi docs here](https://fastapi.tiangolo.com/advanced/behind-a-proxy/)). 