### PR TITLE
Bugfixes for elasticsearch filtertransformer comparision operators.

### DIFF
--- a/optimade/filtertransformers/elasticsearch.py
+++ b/optimade/filtertransformers/elasticsearch.py
@@ -11,7 +11,7 @@ __all__ = (
 
 
 _cmp_operators = {">": "gt", ">=": "gte", "<": "lt", "<=": "lte"}
-_rev_cmp_operators = {">": "<", ">=": "<=", "<": ">", "<=": "=>"}
+_rev_cmp_operators = {">": "<", ">=": "<=", "<": ">", "<=": ">=", "=": "=", "!=": "!="}
 _has_operators = {"ALL": "must", "ANY": "should"}
 _length_quantities = {
     "elements": "nelements",


### PR DESCRIPTION
With the current elasticsearch filtertransformer some of the optimade-validator checks fail due to buggy comparison operators. This fixes it.