### PR TITLE
Report user errors in filter as HTTP 400 Bad Request and not 501 Not Implemented

### DIFF
--- a/optimade/filtertransformers/elasticsearch.py
+++ b/optimade/filtertransformers/elasticsearch.py
@@ -4,6 +4,7 @@ from lark import v_args
 from elasticsearch_dsl import Q, Text, Keyword, Integer, Field
 from optimade.models import CHEMICAL_SYMBOLS, ATOMIC_NUMBERS
 from optimade.filtertransformers import BaseTransformer
+from optimade.server.exceptions import BadRequest
 
 __all__ = ("ElasticTransformer",)
 
@@ -352,7 +353,7 @@ class ElasticTransformer(BaseTransformer):
         quantity_name = args[0]
 
         if quantity_name not in self.index_mapping:
-            raise Exception("%s is not a searchable quantity" % quantity_name)
+            raise BadRequest(detail=f"{quantity_name} is not a searchable quantity")
 
         quantity = self.index_mapping.get(quantity_name, None)
         if quantity is None:

--- a/optimade/filtertransformers/elasticsearch.py
+++ b/optimade/filtertransformers/elasticsearch.py
@@ -131,21 +131,25 @@ class ElasticTransformer(BaseTransformer):
             # an anonymous "formula" based on elements sorted by order number and
             # can do a = comparision to check if all elements are contained
             if len(quantities) > 1:
-                raise Exception("HAS ONLY is not supported with zip")
+                raise NotImplementedError("HAS ONLY is not supported with zip")
             quantity = quantities[0]
 
             if quantity.has_only_quantity is None:
-                raise Exception("HAS ONLY is not supported by %s" % quantity.name)
+                raise NotImplementedError(
+                    "HAS ONLY is not supported by %s" % quantity.name
+                )
 
             def values():
                 for predicates in predicate_zip_list:
                     if len(predicates) != 1:
-                        raise Exception("Tuples not supported in HAS ONLY")
+                        raise NotImplementedError("Tuples not supported in HAS ONLY")
                     op, value = predicates[0]
                     if op != "=":
-                        raise Exception("Predicated not supported in HAS ONLY")
+                        raise NotImplementedError(
+                            "Predicated not supported in HAS ONLY"
+                        )
                     if not isinstance(value, str):
-                        raise Exception("Only strings supported in HAS ONLY")
+                        raise NotImplementedError("Only strings supported in HAS ONLY")
                     yield value
 
             try:
@@ -155,7 +159,9 @@ class ElasticTransformer(BaseTransformer):
                     [CHEMICAL_SYMBOLS[number - 1] for number in order_numbers]
                 )
             except KeyError:
-                raise Exception("HAS ONLY is only supported for chemical symbols")
+                raise NotImplementedError(
+                    "HAS ONLY is only supported for chemical symbols"
+                )
 
             return Q("term", **{quantity.has_only_quantity.name: value})
         else:
@@ -172,7 +178,7 @@ class ElasticTransformer(BaseTransformer):
         for quantity pericate combination.
         """
         if len(quantities) != len(predicates):
-            raise Exception(
+            raise ValueError(
                 "Tuple length does not match: %s <o> %s "
                 % (":".join(quantities), ":".join(predicates))
             )
@@ -186,7 +192,7 @@ class ElasticTransformer(BaseTransformer):
             q.nested_quantity != nested_quantity for q in quantities
         )
         if nested_quantity is None or same_nested_quantity:
-            raise Exception(
+            raise NotImplementedError(
                 "Expression with tuples are only supported for %s"
                 % ", ".join(quantities)
             )
@@ -241,7 +247,7 @@ class ElasticTransformer(BaseTransformer):
     def constant_first_comparison(self, value, op, quantity):
         # constant_first_comparison: constant OPERATOR ( non_string_value | ...not_implemented_string )
         if not isinstance(quantity, Quantity):
-            raise Exception("Only quantities can be compared to constant values.")
+            raise TypeError("Only quantities can be compared to constant values.")
 
         return self._query_op(quantity, _rev_cmp_operators[op], value)
 
@@ -260,7 +266,9 @@ class ElasticTransformer(BaseTransformer):
 
         def query(quantity):
             if quantity.length_quantity is None:
-                raise Exception("LENGTH is not supported for %s" % quantity.name)
+                raise NotImplementedError(
+                    "LENGTH is not supported for %s" % quantity.name
+                )
             quantity = quantity.length_quantity
             return self._query_op(quantity, op, value)
 

--- a/optimade/server/exception_handlers.py
+++ b/optimade/server/exception_handlers.py
@@ -23,6 +23,19 @@ def general_exception(
     status_code: int = 500,  # A status_code in `exc` will take precedence
     errors: List[OptimadeError] = None,
 ) -> JSONResponse:
+    """Handle an exception
+
+    Parameters:
+        request: The HTTP request resulting in the exception being raised.
+        exc: The exception being raised.
+        status_code: The returned HTTP status code for the error response.
+        errors: List of error resources as defined in
+            [the OPTIMADE specification](https://github.com/Materials-Consortia/OPTIMADE/blob/develop/optimade.rst#json-response-schema-common-fields).
+
+    Returns:
+        A JSON HTTP response based on [`ErrorResponse`][optimade.models.responses.ErrorResponse].
+
+    """
     debug_info = {}
     if CONFIG.debug:
         tb = "".join(
@@ -66,15 +79,57 @@ def general_exception(
     )
 
 
-def http_exception_handler(request: Request, exc: StarletteHTTPException):
+def http_exception_handler(
+    request: Request, exc: StarletteHTTPException
+) -> JSONResponse:
+    """Handle a general HTTP Exception from Starlette
+
+    Parameters:
+        request: The HTTP request resulting in the exception being raised.
+        exc: The exception being raised.
+
+    Returns:
+        A JSON HTTP response through [`general_exception()`][optimade.server.exception_handlers.general_exception].
+
+    """
     return general_exception(request, exc)
 
 
-def request_validation_exception_handler(request: Request, exc: RequestValidationError):
+def request_validation_exception_handler(
+    request: Request, exc: RequestValidationError
+) -> JSONResponse:
+    """Handle a request validation error from FastAPI
+
+    `RequestValidationError` is a specialization of a general pydantic `ValidationError`.
+    Pass-through directly to [`general_exception()`][optimade.server.exception_handlers.general_exception].
+
+    Parameters:
+        request: The HTTP request resulting in the exception being raised.
+        exc: The exception being raised.
+
+    Returns:
+        A JSON HTTP response through [`general_exception()`][optimade.server.exception_handlers.general_exception].
+
+    """
     return general_exception(request, exc)
 
 
-def validation_exception_handler(request: Request, exc: ValidationError):
+def validation_exception_handler(
+    request: Request, exc: ValidationError
+) -> JSONResponse:
+    """Handle a general pydantic validation error
+
+    The pydantic `ValidationError` usually contains a list of errors,
+    this function extracts them and wraps them in the OPTIMADE specific error resource.
+
+    Parameters:
+        request: The HTTP request resulting in the exception being raised.
+        exc: The exception being raised.
+
+    Returns:
+        A JSON HTTP response through [`general_exception()`][optimade.server.exception_handlers.general_exception].
+
+    """
     status = 500
     title = "ValidationError"
     errors = set()
@@ -91,8 +146,24 @@ def validation_exception_handler(request: Request, exc: ValidationError):
     return general_exception(request, exc, status_code=status, errors=list(errors))
 
 
-def grammar_not_implemented_handler(request: Request, exc: VisitError):
-    """Handle all errors raise by Lark during filter transformation"""
+def grammar_not_implemented_handler(request: Request, exc: VisitError) -> JSONResponse:
+    """Handle an error raised by Lark during filter transformation
+
+    All errors raised during filter transformation are wrapped in the Lark `VisitError`.
+    According to the OPTIMADE specification, these errors are repurposed to be 501 NotImplementedErrors.
+
+    For special exceptions, like [`BadRequest`][optimade.server.exceptions.BadRequest], we pass-through to
+    [`general_exception()`][optimade.server.exception_handlers.general_exception], since they should not
+    return a 501 NotImplementedError.
+
+    Parameters:
+        request: The HTTP request resulting in the exception being raised.
+        exc: The exception being raised.
+
+    Returns:
+        A JSON HTTP response through [`general_exception()`][optimade.server.exception_handlers.general_exception].
+
+    """
     pass_through_exceptions = (BadRequest,)
 
     orig_exc = getattr(exc, "orig_exc", None)
@@ -112,7 +183,17 @@ def grammar_not_implemented_handler(request: Request, exc: VisitError):
     return general_exception(request, exc, status_code=status, errors=[error])
 
 
-def not_implemented_handler(request: Request, exc: NotImplementedError):
+def not_implemented_handler(request: Request, exc: NotImplementedError) -> JSONResponse:
+    """Handle a standard NotImplementedError Python exception
+
+    Parameters:
+        request: The HTTP request resulting in the exception being raised.
+        exc: The exception being raised.
+
+    Returns:
+        A JSON HTTP response through [`general_exception()`][optimade.server.exception_handlers.general_exception].
+
+    """
     status = 501
     title = "NotImplementedError"
     detail = str(exc)
@@ -120,7 +201,19 @@ def not_implemented_handler(request: Request, exc: NotImplementedError):
     return general_exception(request, exc, status_code=status, errors=[error])
 
 
-def general_exception_handler(request: Request, exc: Exception):
+def general_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+    """Catch all Python Exceptions not handled by other exception handlers
+
+    Pass-through directly to [`general_exception()`][optimade.server.exception_handlers.general_exception].
+
+    Parameters:
+        request: The HTTP request resulting in the exception being raised.
+        exc: The exception being raised.
+
+    Returns:
+        A JSON HTTP response through [`general_exception()`][optimade.server.exception_handlers.general_exception].
+
+    """
     return general_exception(request, exc)
 
 

--- a/optimade/server/exception_handlers.py
+++ b/optimade/server/exception_handlers.py
@@ -12,6 +12,7 @@ from fastapi.responses import JSONResponse
 from optimade.models import OptimadeError, ErrorResponse, ErrorSource
 
 from optimade.server.config import CONFIG
+from optimade.server.exceptions import BadRequest
 from optimade.server.logger import LOGGER
 from optimade.server.routers.utils import meta_values
 
@@ -91,6 +92,13 @@ def validation_exception_handler(request: Request, exc: ValidationError):
 
 
 def grammar_not_implemented_handler(request: Request, exc: VisitError):
+    """Handle all errors raise by Lark during filter transformation"""
+    pass_through_exceptions = (BadRequest,)
+
+    orig_exc = getattr(exc, "orig_exc", None)
+    if isinstance(orig_exc, pass_through_exceptions):
+        return general_exception(request, orig_exc)
+
     rule = getattr(exc.obj, "data", getattr(exc.obj, "type", str(exc)))
 
     status = 501

--- a/optimade/server/exceptions.py
+++ b/optimade/server/exceptions.py
@@ -14,7 +14,7 @@ class StrReprMixin(HTTPException):
     """
 
     def __str__(self):
-        return self.__repr__()
+        return self.detail if self.detail is not None else self.__repr__()
 
 
 class BadRequest(StrReprMixin, HTTPException):


### PR DESCRIPTION
There are different causes for filtertransformer failure that need to be treated differently. Mostly its about raising NotImplementedError (-> 501 Not Implemented) if a certain filter language feature is not supported, but there is also the case where the user causes static semantic errors, e.g. using wrong property names, using operators on properties where they are not allowed (-> 400 Bad Request). 

I saw that the mongo transformer was raising a `optimade.server.exception.BadRequest` to indicate a user error and then was copying this for the elastictransformer. However, all exceptions during a lark tree visit are wrapped in a `VisitError` and the exception handler (`optimade.server.exception_handlers.grammar_not_implemented_handler`) is handling all these errors with a 501/Not implemented. 

This PR adds a special treatment for `BadRequest` wrapped in a `VisitError`. 