### PR TITLE
Robustness improvements to validator

### DIFF
--- a/optimade/validator/validator.py
+++ b/optimade/validator/validator.py
@@ -269,6 +269,8 @@ class ImplementationValidator:
                 "This is required for all further validation, so the validator will now exit."
             )
             self.print_summary()
+            # Set valid to False to ensure error code 1 is raised at CLI
+            self.valid = False
             return
 
         # Grab the provider prefix from base info and use it when looking for provider fields

--- a/optimade/validator/validator.py
+++ b/optimade/validator/validator.py
@@ -271,12 +271,13 @@ class ImplementationValidator:
             self.print_summary()
             return
 
+        # Grab the provider prefix from base info and use it when looking for provider fields
         self.provider_prefix = None
         meta = base_info.get("meta", {})
         if meta.get("provider") is not None:
             self.provider_prefix = meta["provider"].get("prefix")
 
-        # Set the response class for all `/info/entry` endpoints
+        # Set the response class for all `/info/entry` endpoints based on `/info` response
         self.available_json_endpoints, _ = self._get_available_endpoints(base_info)
         for endp in self.available_json_endpoints:
             self._response_classes[f"{info_endp}/{endp}"] = EntryInfoResponse
@@ -287,6 +288,8 @@ class ImplementationValidator:
         self._test_bad_version_returns_553()
 
         # Test that entry info endpoints deserialize correctly
+        # If they do not, the corresponding entry in _entry_info_by_type
+        # is set to False, which must be checked for in further validation
         for endp in self.available_json_endpoints:
             entry_info_endpoint = f"{info_endp}/{endp}"
             self._log.debug("Testing expected info endpoint %s", entry_info_endpoint)

--- a/optimade/validator/validator.py
+++ b/optimade/validator/validator.py
@@ -261,7 +261,7 @@ class ImplementationValidator:
         self._log.debug("Testing base info endpoint of %s", info_endp)
 
         # Get and validate base info to find endpoints
-        # If this is not possible, the exit at this stage
+        # If this is not possible, then exit at this stage
         base_info = self._test_info_or_links_endpoint(info_endp)
         if not base_info:
             self._log.critical(
@@ -291,7 +291,7 @@ class ImplementationValidator:
 
         # Test that entry info endpoints deserialize correctly
         # If they do not, the corresponding entry in _entry_info_by_type
-        # is set to False, which must be checked for in further validation
+        # is set to False, which must be checked for further validation
         for endp in self.available_json_endpoints:
             entry_info_endpoint = f"{info_endp}/{endp}"
             self._log.debug("Testing expected info endpoint %s", entry_info_endpoint)


### PR DESCRIPTION
Following some recent attempts to validate the providers repo and the OQMD, this PR tweaks some things so that the validator can be more robust to "bad" data, e.g. missing provider prefix and missing meta in base info. This PR should prevent some obfuscated crashes and replace them with loud validation failures.

- [x] Give less precedence to provider prefix, i.e. don't worry if its missing if no provider fields are defined
- [x] Cleaner error handling for bad base info
- [x] Better error handling for bad entry info; fail loudly without crashing (raised by @rartino in https://github.com/Materials-Consortia/providers-dashboard/issues/8)