### PR TITLE
Added GitHub CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @CasperWA @ml-evs

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
 * @CasperWA @ml-evs
+*mongo* @ml-evs @shyamd
+*elastic* @ml-evs @markus1978


### PR DESCRIPTION
This is to force a review from either @CasperWA or I on all PRs. It would be great to split the package up a bit so that other contributors have some ownership. We will hopefully discuss this in the meeting today.

In the meeting we decided to also add other owners for mongo and elastic specifically (I won't tag Markus or Shyam again to avoid spam).