### PR TITLE
Validator changes: always check unversioned '/versions' and handle rich HTML pages

### DIFF
--- a/optimade/validator/utils.py
+++ b/optimade/validator/utils.py
@@ -289,13 +289,7 @@ def test_case(test_fn: Callable[[Any], Tuple[Any, str]]):
                 else:
                     result, msg = test_fn(validator, *args, **kwargs)
 
-            except json.JSONDecodeError as exc:
-                msg = (
-                    "Critical: unable to parse server response as JSON. "
-                    f"{exc.__class__.__name__}: {exc}"
-                )
-                raise exc
-            except (ResponseError, ValidationError) as exc:
+            except (json.JSONDecodeError, ResponseError, ValidationError) as exc:
                 msg = f"{exc.__class__.__name__}: {exc}"
                 raise exc
             except Exception as exc:

--- a/optimade/validator/validator.py
+++ b/optimade/validator/validator.py
@@ -1212,9 +1212,12 @@ class ImplementationValidator:
 
         if response.status_code not in expected_status_code:
             message = f"Request to '{request_str}' returned HTTP code {response.status_code} and not expected {expected_status_code}."
-            message += "\nError(s):"
-            for error in response.json().get("errors", []):
-                message += f'\n  {error.get("title", "N/A")}: {error.get("detail", "N/A")} ({error.get("source", {}).get("pointer", "N/A")})'
+            message += "\nAdditional details:"
+            try:
+                for error in response.json().get("errors", []):
+                    message += f'\n  {error.get("title", "N/A")}: {error.get("detail", "N/A")} ({error.get("source", {}).get("pointer", "N/A")})'
+            except json.JSONDecodeError:
+                message += f"\n  Could not parse response as JSON. Content type was {response.headers.get('content-type')!r}."
             raise ResponseError(message)
 
         return response, f"received expected response: {response}."

--- a/tests/validator/test_utils.py
+++ b/tests/validator/test_utils.py
@@ -164,17 +164,14 @@ def test_expected_failure_test_case():
     assert validator.results.internal_failure_count == 0
 
     assert output[0] is None
-    assert (
-        output[1]
-        == "Critical: unable to parse server response as JSON. JSONDecodeError: Dummy JSON error: line 1 column 1 (char 0)"
-    )
+    assert output[1] == "JSONDecodeError: Dummy JSON error: line 1 column 1 (char 0)"
     assert (
         validator.results.optional_failure_messages[-1][0]
         == "http://example.org/test_request - dummy_test_case - failed with error"
     )
     assert (
         validator.results.optional_failure_messages[-1][1]
-        == "Critical: unable to parse server response as JSON. JSONDecodeError: Dummy JSON error: line 1 column 1 (char 0)"
+        == "JSONDecodeError: Dummy JSON error: line 1 column 1 (char 0)"
     )
 
 


### PR DESCRIPTION
This PR does two things:
- Some services e.g. netlify have rich 404 pages which yield unhelpful error messages, those error messages are now improved.
- Following discussion in #662, this PR always checks the existence of the unversioned `/versions` endpoint, even when passed a versioned URL