### PR TITLE
Validator: remove reliance on meta fields and check mandatory queries

### DIFF
--- a/optimade/validator/config.py
+++ b/optimade/validator/config.py
@@ -7,10 +7,10 @@ the hardcoded values.
 
 """
 
-from typing import Dict, Any, Set
+from typing import Dict, Any, Set, List
 from pydantic import BaseSettings, Field
 
-from optimade.models import InfoResponse, IndexInfoResponse, DataType
+from optimade.models import InfoResponse, IndexInfoResponse, DataType, StructureFeatures
 from optimade.validator.utils import (
     ValidatorLinksResponse,
     ValidatorReferenceResponseOne,
@@ -48,6 +48,12 @@ _RESPONSE_CLASSES = {
 _RESPONSE_CLASSES_INDEX = {
     "info": IndexInfoResponse,
     "links": ValidatorLinksResponse,
+}
+
+_ENUM_DUMMY_VALUES = {
+    "structures": {
+        "structure_features": [allowed.value for allowed in StructureFeatures]
+    }
 }
 
 
@@ -157,6 +163,11 @@ class ValidatorConfig(BaseSettings):
     top_level_non_attribute_fields: Set[str] = Field(
         BaseResourceMapper.TOP_LEVEL_NON_ATTRIBUTES_FIELDS,
         description="Field names to treat as top-level",
+    )
+
+    enum_fallback_values: Dict[str, Dict[str, List[str]]] = Field(
+        _ENUM_DUMMY_VALUES,
+        description="Provide fallback values for enum fields to use when validating filters.",
     )
 
 

--- a/optimade/validator/utils.py
+++ b/optimade/validator/utils.py
@@ -275,9 +275,6 @@ def test_case(test_fn: Callable[[Any], Tuple[Any, str]]):
                 and it will not increment the success counter. Errors will be
                 handled in the normal way. This can be used to avoid flooding
                 the output for mutli-stage tests.
-                request: The request that has been performed
-                optional: Whether to count this test as optional
-                multistage
             **kwargs: Extra named arguments passed to the test function.
 
         """
@@ -362,7 +359,8 @@ def test_case(test_fn: Callable[[Any], Tuple[Any, str]]):
 
             # Reset the client request so that it can be properly
             # displayed if the next request fails
-            validator.client.last_request = None
+            if not multistage:
+                validator.client.last_request = None
 
             return result, msg
 

--- a/optimade/validator/validator.py
+++ b/optimade/validator/validator.py
@@ -955,6 +955,15 @@ class ImplementationValidator:
             `True` if successful, with a string summary.
 
         """
+        if (
+            deserialized.meta.data_available is None
+            or deserialized.meta.data_returned is None
+        ):
+            return (
+                None,
+                "`meta->data_available` and/or `meta->data_returned` were not provided.",
+            )
+
         if deserialized.meta.data_available != deserialized.meta.data_returned:
             raise ResponseError(
                 "No query was performed, but `data_returned` != `data_available`."


### PR DESCRIPTION
- [x] Closes #675 by ignoring any checks that require the use of `meta->data_returned` when it is not provided.
- [x] Closes #677 by ignoring checks that require `meta->data_available` when not provided.
- [x] Several improvements to error messages, request displays and robustness to unexpected responses
- [x] Closes #678 by providing fallback query values for enum fields that are normally empty.