### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/publish-on-pypi.yml
+++ b/.github/workflows/publish-on-pypi.yml
@@ -31,7 +31,7 @@ jobs:
         pip install -U -e .[all] --use-deprecated=legacy-resolver
 
     - name: Update changelog
-      uses: CharMixer/auto-changelog-action@v1.1
+      uses: CharMixer/auto-changelog-action@v1.2
       with:
         token: ${{ secrets.RELEASE_PAT_CASPER }}
 

--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -1,5 +1,5 @@
 aiida-core==1.5.2
-ase==3.20.1
+ase==3.21.1
 numpy==1.19.4
 pymatgen==2020.12.31
 jarvis-tools==2020.11.27

--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -1,5 +1,6 @@
 aiida-core==1.5.2
 ase==3.21.1
-numpy==1.19.4
+numpy==1.20.0 ; python_version > '3.6'
+numpy==1.19.5 ; python_version < '3.7'
 pymatgen==2020.12.31
 jarvis-tools==2020.11.27

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,5 +3,5 @@ pytest-cov==2.10.1
 codecov==2.1.11
 jsondiff==1.2.0
 pylint==2.6.0
-pre-commit==2.9.3
+pre-commit==2.10.0
 invoke==1.5.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
-pytest==6.2.1
-pytest-cov==2.10.1
+pytest==6.2.2
+pytest-cov==2.11.1
 codecov==2.1.11
 jsondiff==1.2.0
 pylint==2.6.0

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,5 +1,5 @@
 mkdocs==1.1.2
 mkdocs-awesome-pages-plugin==2.5.0
-mkdocs-material==6.2.3
-mkdocs-minify-plugin==0.3.0
-mkdocstrings==0.13.6
+mkdocs-material==6.2.7
+mkdocs-minify-plugin==0.4.0
+mkdocstrings==0.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ requests==2.25.1
 uvicorn==0.13.3
 pymongo==3.11.2
 mongomock==3.22.1
-django==3.1.4
+django==3.1.5
 elasticsearch-dsl==7.3.0
 Jinja2==2.11.3
 typing-extensions==3.7.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,8 @@ email_validator==1.1.2
 requests==2.25.1
 uvicorn==0.13.3
 pymongo==3.11.2
-mongomock==3.22.0
+mongomock==3.22.1
 django==3.1.4
 elasticsearch-dsl==7.3.0
-Jinja2==2.11.2
+Jinja2==2.11.3
 typing-extensions==3.7.4.3

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ server_deps = ["uvicorn~=0.13.3", "Jinja2~=2.11"] + mongo_deps
 
 # Client minded
 aiida_deps = ["aiida-core~=1.5.2"]
-ase_deps = ["ase~=3.20"]
+ase_deps = ["ase~=3.21"]
 cif_deps = ["numpy~=1.19"]
 pdb_deps = cif_deps
 pymatgen_deps = ["pymatgen==2020.12.31"]
@@ -36,17 +36,17 @@ docs_deps = [
     "mkdocs~=1.1",
     "mkdocs-awesome-pages-plugin~=2.5",
     "mkdocs-material~=6.2",
-    "mkdocs-minify-plugin~=0.3.0",
-    "mkdocstrings~=0.13.6",
+    "mkdocs-minify-plugin~=0.4.0",
+    "mkdocstrings~=0.14.0",
 ]
 testing_deps = [
     "pytest~=6.2",
-    "pytest-cov~=2.10",
+    "pytest-cov~=2.11",
     "codecov~=2.1",
     "jsondiff~=1.2",
 ] + server_deps
 dev_deps = (
-    ["pylint~=2.6", "pre-commit~=2.9", "invoke~=1.5"]
+    ["pylint~=2.6", "pre-commit~=2.10", "invoke~=1.5"]
     + docs_deps
     + testing_deps
     + client_deps


### PR DESCRIPTION
Update dependencies according to @dependabot.

This includes both Python dependencies as well as updates to CI GitHub Actions.

Currently ~`numpy`~ (as well as `pydantic` and `jarvis-tools`) have been left out. The reason for the latter two can be found in their respective PRs, ~while the `numpy` update is new, but has failed CI checks and may yet still be added to this PR.~

_Edit_: Indeed, the `numpy` issue has been fixed and has been added to this PR.