### PR TITLE
Always print summary as last thing in validation

### DIFF
--- a/optimade/validator/validator.py
+++ b/optimade/validator/validator.py
@@ -252,6 +252,7 @@ class ImplementationValidator:
             )
             self._test_as_type()
             self.valid = not bool(self.results.failure_count)
+            self.print_summary()
             return
 
         # Test entire implementation
@@ -268,9 +269,9 @@ class ImplementationValidator:
                 f"Unable to deserialize response from introspective {info_endp!r} endpoint. "
                 "This is required for all further validation, so the validator will now exit."
             )
-            self.print_summary()
             # Set valid to False to ensure error code 1 is raised at CLI
             self.valid = False
+            self.print_summary()
             return
 
         # Grab the provider prefix from base info and use it when looking for provider fields


### PR DESCRIPTION
Fixes #699.

This minor change ensures the `print_summary()` method is _always_ called before `return`ing out of the `validate_implementation()` method.
Two changes were needed:
- Add method call to `as_type` "branch".
- Move around order of setting the `valid` property and printing the summary for the "no base info-branch".

I'm not completely sure about the latter change, but it seems to me the `valid` property is used in the printed summary, hence I thought it best to switch these statements around?