### PR TITLE
Update dependencies

### DIFF
--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -2,5 +2,5 @@ aiida-core==1.5.2
 ase==3.21.1
 numpy==1.20.1 ; python_version > '3.6'
 numpy==1.19.5 ; python_version < '3.7'
-pymatgen==2021.2.8.1
-jarvis-tools==2020.11.27
+pymatgen==2021.2.16
+jarvis-tools==2021.2.22

--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -2,5 +2,6 @@ aiida-core==1.5.2
 ase==3.21.1
 numpy==1.20.1 ; python_version > '3.6'
 numpy==1.19.5 ; python_version < '3.7'
-pymatgen==2021.2.16
+pymatgen==2021.2.16; python_version > '3.6'
+pymatgen==2021.2.8.1; python_version < '3.7'
 jarvis-tools==2021.2.22

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,6 @@ pytest==6.2.2
 pytest-cov==2.11.1
 codecov==2.1.11
 jsondiff==1.2.0
-pylint==2.6.0
+pylint==2.7.2
 pre-commit==2.10.1
 invoke==1.5.0

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -2,4 +2,4 @@ mkdocs==1.1.2
 mkdocs-awesome-pages-plugin==2.5.0
 mkdocs-material==7.0.3
 mkdocs-minify-plugin==0.4.0
-mkdocstrings==0.14.0
+mkdocstrings==0.15.0

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,5 +1,5 @@
 mkdocs==1.1.2
 mkdocs-awesome-pages-plugin==2.5.0
-mkdocs-material==6.2.8
+mkdocs-material==7.0.3
 mkdocs-minify-plugin==0.4.0
 mkdocstrings==0.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
 fastapi==0.63.0
-lark-parser==0.11.1
+lark-parser==0.11.2
 pydantic==1.6.1
 email_validator==1.1.2
 requests==2.25.1
-uvicorn==0.13.3
+uvicorn==0.13.4
 pymongo==3.11.3
 mongomock==3.22.1
-django==3.1.6
+django==3.1.7
 elasticsearch-dsl==7.3.0
 Jinja2==2.11.3
 typing-extensions==3.7.4.3

--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,8 @@ ase_deps = ["ase~=3.21"]
 cif_deps = ["numpy~=1.19"]  # Keep at 1.19 for Python 3.6 support
 pdb_deps = cif_deps
 pymatgen_deps = [
-    'pymatgen==2021.2.8.1;python_version<"3.7"',
-    'pymatgen==2021.2.16;python_version>"3.6"',
+    "pymatgen==2021.2.8.1;python_version<'3.7'",
+    "pymatgen==2021.2.16;python_version>'3.6'",
 ]
 jarvis_deps = ["jarvis-tools==2021.2.22"]
 client_deps = cif_deps
@@ -96,7 +96,7 @@ setup(
         "pydantic~=1.6.1",
         "email_validator~=1.1",
         "requests~=2.25",
-        'typing-extensions~=3.7;python_version<"3.8"',
+        "typing-extensions~=3.7;python_version<'3.8'",
     ],
     extras_require={
         "all": all_deps,

--- a/setup.py
+++ b/setup.py
@@ -20,24 +20,27 @@ with open(module_dir.joinpath("optimade/__init__.py")) as version_file:
 django_deps = ["django>=2.2.9,<4.0"]
 elastic_deps = ["elasticsearch-dsl>=6.4,<8.0"]
 mongo_deps = ["pymongo~=3.11", "mongomock~=3.22"]
-server_deps = ["uvicorn~=0.13.3", "Jinja2~=2.11"] + mongo_deps
+server_deps = ["uvicorn~=0.13.4", "Jinja2~=2.11"] + mongo_deps
 
 # Client minded
 aiida_deps = ["aiida-core~=1.5.2"]
 ase_deps = ["ase~=3.21"]
 cif_deps = ["numpy~=1.19"]  # Keep at 1.19 for Python 3.6 support
 pdb_deps = cif_deps
-pymatgen_deps = ["pymatgen==2021.2.8.1"]
-jarvis_deps = ["jarvis-tools==2020.11.27"]
+pymatgen_deps = [
+    'pymatgen==2021.2.8.1;python_version<"3.7"',
+    'pymatgen==2021.2.16;python_version>"3.6"',
+]
+jarvis_deps = ["jarvis-tools==2021.2.22"]
 client_deps = cif_deps
 
 # General
 docs_deps = [
     "mkdocs~=1.1",
     "mkdocs-awesome-pages-plugin~=2.5",
-    "mkdocs-material~=6.2",
+    "mkdocs-material~=7.0",
     "mkdocs-minify-plugin~=0.4.0",
-    "mkdocstrings~=0.14.0",
+    "mkdocstrings~=0.15.0",
 ]
 testing_deps = [
     "pytest~=6.2",
@@ -46,7 +49,7 @@ testing_deps = [
     "jsondiff~=1.2",
 ] + server_deps
 dev_deps = (
-    ["pylint~=2.6", "pre-commit~=2.10", "invoke~=1.5"]
+    ["pylint~=2.7", "pre-commit~=2.10", "invoke~=1.5"]
     + docs_deps
     + testing_deps
     + client_deps
@@ -88,7 +91,7 @@ setup(
     ],
     python_requires=">=3.6",
     install_requires=[
-        "lark-parser~=0.11.1",
+        "lark-parser~=0.11.2",
         "fastapi~=0.63.0",
         "pydantic~=1.6.1",
         "email_validator~=1.1",

--- a/tests/adapters/structures/utils.py
+++ b/tests/adapters/structures/utils.py
@@ -9,6 +9,6 @@ def get_min_ver(dependency: str) -> str:
         for line in setup_file.readlines():
             min_ver = re.findall(fr'"{dependency}((=|!|<|>|~)=|>|<)(.+)"', line)
             if min_ver:
-                return min_ver[0][2]
+                return min_ver[0][2].split(";")[0]
         else:
             raise RuntimeError(f"Cannot find {dependency} dependency in setup.py")


### PR DESCRIPTION
Update dependencies according to @dependabot.

Update `setup.py` with updated dependencies.
`pymatgen` has had to have the same split as has been done for `numpy`, due to, well, `numpy`.
This was needed both in the `requirements` file as well as `setup.py`.

`jarvis-tools` is no longer fixed to a 1.18 version of `numpy`, so it can now be updated.

`pydantic` is still unable to be updated (see previous PRs on updating `pydantic` from @dependabot for more information).

Also, the latest version of `mkdocs-material` (v7.0) seems to add support for hosting documentation with different versions. I have opened #724 to address updating this. Note, it may be related to an older still open issue also.