### PR TITLE
Remove Python 3.9 support until pydantic>=1.7

### DIFF
--- a/.github/workflows/deps_lint.yml
+++ b/.github/workflows/deps_lint.yml
@@ -137,7 +137,7 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8]
 
     services:
       mongo:

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
+        # "Programming Language :: Python :: 3.9",
         "Intended Audience :: Developers",
         "Topic :: Database",
         "Topic :: Database :: Database Engines/Servers",


### PR DESCRIPTION
As explained in #728, support for Python 3.9 in the `optimade` package is essentially invalid until we support `pydantic>=1.7`.