### PR TITLE
Update pydantic to ~=1.8

### DIFF
--- a/openapi/index_openapi.json
+++ b/openapi/index_openapi.json
@@ -1081,10 +1081,21 @@
             "description": "JSON API links object, pointing to a homepage URL for this implementation"
           },
           "link_type": {
-            "$ref": "#/components/schemas/LinkType"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LinkType"
+              }
+            ],
+            "description": "The type of the linked relation.\nMUST be one of these values: 'child', 'root', 'external', 'providers'."
           },
           "aggregate": {
-            "$ref": "#/components/schemas/Aggregate"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Aggregate"
+              }
+            ],
+            "description": "A string indicating whether a client that is following links to aggregate results from different OPTIMADE implementations should follow this link or not.\nThis flag SHOULD NOT be indicated for links where `link_type` is not `child`.\n\nIf not specified, clients MAY assume that the value is `ok`.\nIf specified, and the value is anything different than `ok`, the client MUST assume that the server is suggesting not to follow the link during aggregation by default (also if the value is not among the known ones, in case a future specification adds new accepted values).\n\nSpecific values indicate the reason why the server is providing the suggestion.\nA client MAY follow the link anyway if it has reason to do so (e.g., if the client is looking for all test databases, it MAY follow the links marked with `aggregate`=`test`).\n\nIf specified, it MUST be one of the values listed in section Link Aggregate Options.",
+            "default": "ok"
           },
           "no_aggregate_reason": {
             "title": "No Aggregate Reason",

--- a/openapi/index_openapi.json
+++ b/openapi/index_openapi.json
@@ -1081,6 +1081,7 @@
             "description": "JSON API links object, pointing to a homepage URL for this implementation"
           },
           "link_type": {
+            "title": "Link Type",
             "allOf": [
               {
                 "$ref": "#/components/schemas/LinkType"
@@ -1089,6 +1090,7 @@
             "description": "The type of the linked relation.\nMUST be one of these values: 'child', 'root', 'external', 'providers'."
           },
           "aggregate": {
+            "title": "Aggregate",
             "allOf": [
               {
                 "$ref": "#/components/schemas/Aggregate"

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -1226,6 +1226,7 @@
             "description": "Defines whether the entry property can be used for sorting with the \"sort\" parameter.\nIf the entry listing endpoint supports sorting, this key MUST be present for sortable properties with value `true`."
           },
           "type": {
+            "title": "Type",
             "allOf": [
               {
                 "$ref": "#/components/schemas/DataType"
@@ -1938,6 +1939,7 @@
             "description": "JSON API links object, pointing to a homepage URL for this implementation"
           },
           "link_type": {
+            "title": "Link Type",
             "allOf": [
               {
                 "$ref": "#/components/schemas/LinkType"
@@ -1946,6 +1948,7 @@
             "description": "The type of the linked relation.\nMUST be one of these values: 'child', 'root', 'external', 'providers'."
           },
           "aggregate": {
+            "title": "Aggregate",
             "allOf": [
               {
                 "$ref": "#/components/schemas/Aggregate"
@@ -2121,7 +2124,7 @@
           1
         ],
         "type": "integer",
-        "description": "An enumeration."
+        "description": "Integer enumeration defining peridocity for dimension_types values"
       },
       "Person": {
         "title": "Person",
@@ -3094,6 +3097,7 @@
             "nullable": true
           },
           "dimension_types": {
+            "title": "Dimension Types",
             "maxItems": 3,
             "minItems": 3,
             "type": "array",
@@ -3172,6 +3176,7 @@
             "description": "A description of groups of sites that are statistically correlated.\n\n- **Type**: list of dictionary with keys:\n    - `sites_in_groups`: list of list of integers (REQUIRED)\n    - `group_probabilities`: list of floats (REQUIRED)\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n    - **Query**: Support for queries on this property is OPTIONAL.\n        If supported, filters MAY support only a subset of comparison operators.\n    - The property SHOULD be `null` for entries that have no partial occupancies.\n    - If present, the correct flag MUST be set in the list `structure_features`.\n    - Client implementations MUST check its presence (as its presence changes the interpretation of the structure).\n    - If present, it MUST be a list of dictionaries, each of which represents an assembly and MUST have the following two keys:\n        - **sites_in_groups**: Index of the sites (0-based) that belong to each group for each assembly.\n\n            Example: `[[1], [2]]`: two groups, one with the second site, one with the third.\n            Example: `[[1,2], [3]]`: one group with the second and third site, one with the fourth.\n\n        - **group_probabilities**: Statistical probability of each group. It MUST have the same length as `sites_in_groups`.\n            It SHOULD sum to one.\n            See below for examples of how to specify the probability of the occurrence of a vacancy.\n            The possible reasons for the values not to sum to one are the same as already specified above for the `concentration` of each `species`.\n\n    - If a site is not present in any group, it means that it is present with 100 % probability (as if no assembly was specified).\n    - A site MUST NOT appear in more than one group.\n\n- **Examples** (for each entry of the assemblies list):\n    - `{\"sites_in_groups\": [[0], [1]], \"group_probabilities: [0.3, 0.7]}`: the first site and the second site never occur at the same time in the unit cell.\n        Statistically, 30 % of the times the first site is present, while 70 % of the times the second site is present.\n    - `{\"sites_in_groups\": [[1,2], [3]], \"group_probabilities: [0.3, 0.7]}`: the second and third site are either present together or not present; they form the first group of atoms for this assembly.\n        The second group is formed by the fourth site.\n        Sites of the first group (the second and the third) are never present at the same time as the fourth site.\n        30 % of times sites 1 and 2 are present (and site 3 is absent); 70 % of times site 3 is present (and sites 1 and 2 are absent).\n\n- **Notes**:\n    - Assemblies are essential to represent, for instance, the situation where an atom can statistically occupy two different positions (sites).\n\n    - By defining groups, it is possible to represent, e.g., the case where a functional molecule (and not just one atom) is either present or absent (or the case where it it is present in two conformations)\n\n    - Considerations on virtual alloys and on vacancies: In the special case of a virtual alloy, these specifications allow two different, equivalent ways of specifying them.\n        For instance, for a site at the origin with 30 % probability of being occupied by Si, 50 % probability of being occupied by Ge, and 20 % of being a vacancy, the following two representations are possible:\n\n        - Using a single species:\n            ```json\n            {\n              \"cartesian_site_positions\": [[0,0,0]],\n              \"species_at_sites\": [\"SiGe-vac\"],\n              \"species\": [\n              {\n                \"name\": \"SiGe-vac\",\n                \"chemical_symbols\": [\"Si\", \"Ge\", \"vacancy\"],\n                \"concentration\": [0.3, 0.5, 0.2]\n              }\n              ]\n              // ...\n            }\n            ```\n\n        - Using multiple species and the assemblies:\n            ```json\n            {\n              \"cartesian_site_positions\": [ [0,0,0], [0,0,0], [0,0,0] ],\n              \"species_at_sites\": [\"Si\", \"Ge\", \"vac\"],\n              \"species\": [\n                { \"name\": \"Si\", \"chemical_symbols\": [\"Si\"], \"concentration\": [1.0] },\n                { \"name\": \"Ge\", \"chemical_symbols\": [\"Ge\"], \"concentration\": [1.0] },\n                { \"name\": \"vac\", \"chemical_symbols\": [\"vacancy\"], \"concentration\": [1.0] }\n              },\n              \"assemblies\": [\n                {\n              \"sites_in_groups\": [ [0], [1], [2] ],\n              \"group_probabilities\": [0.3, 0.5, 0.2]\n                }\n              ]\n              // ...\n            }\n            ```\n\n    - It is up to the database provider to decide which representation to use, typically depending on the internal format in which the structure is stored.\n        However, given a structure identified by a unique ID, the API implementation MUST always provide the same representation for it.\n\n    - The probabilities of occurrence of different assemblies are uncorrelated.\n        So, for instance in the following case with two assemblies:\n        ```json\n        {\n          \"assemblies\": [\n            {\n              \"sites_in_groups\": [ [0], [1] ],\n              \"group_probabilities\": [0.2, 0.8],\n            },\n            {\n              \"sites_in_groups\": [ [2], [3] ],\n              \"group_probabilities\": [0.3, 0.7]\n            }\n          ]\n        }\n        ```\n\n        Site 0 is present with a probability of 20 % and site 1 with a probability of 80 %. These two sites are correlated (either site 0 or 1 is present). Similarly, site 2 is present with a probability of 30 % and site 3 with a probability of 70 %.\n        These two sites are correlated (either site 2 or 3 is present).\n        However, the presence or absence of sites 0 and 1 is not correlated with the presence or absence of sites 2 and 3 (in the specific example, the pair of sites (0, 2) can occur with 0.2*0.3 = 6 % probability; the pair (0, 3) with 0.2*0.7 = 14 % probability; the pair (1, 2) with 0.8*0.3 = 24 % probability; and the pair (1, 3) with 0.8*0.7 = 56 % probability)."
           },
           "structure_features": {
+            "title": "Structure Features",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/StructureFeatures"

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -1226,7 +1226,12 @@
             "description": "Defines whether the entry property can be used for sorting with the \"sort\" parameter.\nIf the entry listing endpoint supports sorting, this key MUST be present for sortable properties with value `true`."
           },
           "type": {
-            "$ref": "#/components/schemas/DataType"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DataType"
+              }
+            ],
+            "description": "The type of the property's value.\nThis MUST be any of the types defined in the Data types section.\nFor the purpose of compatibility with future versions of this specification, a client MUST accept values that are not `string` values specifying any of the OPTIMADE Data types, but MUST then also disregard the `type` field.\nNote, if the value is a nested type, only the outermost type should be reported.\nE.g., for the entry resource `structures`, the `species` property is defined as a list of dictionaries, hence its `type` value would be `list`."
           }
         }
       },
@@ -1933,10 +1938,21 @@
             "description": "JSON API links object, pointing to a homepage URL for this implementation"
           },
           "link_type": {
-            "$ref": "#/components/schemas/LinkType"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LinkType"
+              }
+            ],
+            "description": "The type of the linked relation.\nMUST be one of these values: 'child', 'root', 'external', 'providers'."
           },
           "aggregate": {
-            "$ref": "#/components/schemas/Aggregate"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Aggregate"
+              }
+            ],
+            "description": "A string indicating whether a client that is following links to aggregate results from different OPTIMADE implementations should follow this link or not.\nThis flag SHOULD NOT be indicated for links where `link_type` is not `child`.\n\nIf not specified, clients MAY assume that the value is `ok`.\nIf specified, and the value is anything different than `ok`, the client MUST assume that the server is suggesting not to follow the link during aggregation by default (also if the value is not among the known ones, in case a future specification adds new accepted values).\n\nSpecific values indicate the reason why the server is providing the suggestion.\nA client MAY follow the link anyway if it has reason to do so (e.g., if the client is looking for all test databases, it MAY follow the links marked with `aggregate`=`test`).\n\nIf specified, it MUST be one of the values listed in section Link Aggregate Options.",
+            "default": "ok"
           },
           "no_aggregate_reason": {
             "title": "No Aggregate Reason",
@@ -3078,7 +3094,6 @@
             "nullable": true
           },
           "dimension_types": {
-            "title": "Dimension Types",
             "maxItems": 3,
             "minItems": 3,
             "type": "array",
@@ -3157,7 +3172,6 @@
             "description": "A description of groups of sites that are statistically correlated.\n\n- **Type**: list of dictionary with keys:\n    - `sites_in_groups`: list of list of integers (REQUIRED)\n    - `group_probabilities`: list of floats (REQUIRED)\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n    - **Query**: Support for queries on this property is OPTIONAL.\n        If supported, filters MAY support only a subset of comparison operators.\n    - The property SHOULD be `null` for entries that have no partial occupancies.\n    - If present, the correct flag MUST be set in the list `structure_features`.\n    - Client implementations MUST check its presence (as its presence changes the interpretation of the structure).\n    - If present, it MUST be a list of dictionaries, each of which represents an assembly and MUST have the following two keys:\n        - **sites_in_groups**: Index of the sites (0-based) that belong to each group for each assembly.\n\n            Example: `[[1], [2]]`: two groups, one with the second site, one with the third.\n            Example: `[[1,2], [3]]`: one group with the second and third site, one with the fourth.\n\n        - **group_probabilities**: Statistical probability of each group. It MUST have the same length as `sites_in_groups`.\n            It SHOULD sum to one.\n            See below for examples of how to specify the probability of the occurrence of a vacancy.\n            The possible reasons for the values not to sum to one are the same as already specified above for the `concentration` of each `species`.\n\n    - If a site is not present in any group, it means that it is present with 100 % probability (as if no assembly was specified).\n    - A site MUST NOT appear in more than one group.\n\n- **Examples** (for each entry of the assemblies list):\n    - `{\"sites_in_groups\": [[0], [1]], \"group_probabilities: [0.3, 0.7]}`: the first site and the second site never occur at the same time in the unit cell.\n        Statistically, 30 % of the times the first site is present, while 70 % of the times the second site is present.\n    - `{\"sites_in_groups\": [[1,2], [3]], \"group_probabilities: [0.3, 0.7]}`: the second and third site are either present together or not present; they form the first group of atoms for this assembly.\n        The second group is formed by the fourth site.\n        Sites of the first group (the second and the third) are never present at the same time as the fourth site.\n        30 % of times sites 1 and 2 are present (and site 3 is absent); 70 % of times site 3 is present (and sites 1 and 2 are absent).\n\n- **Notes**:\n    - Assemblies are essential to represent, for instance, the situation where an atom can statistically occupy two different positions (sites).\n\n    - By defining groups, it is possible to represent, e.g., the case where a functional molecule (and not just one atom) is either present or absent (or the case where it it is present in two conformations)\n\n    - Considerations on virtual alloys and on vacancies: In the special case of a virtual alloy, these specifications allow two different, equivalent ways of specifying them.\n        For instance, for a site at the origin with 30 % probability of being occupied by Si, 50 % probability of being occupied by Ge, and 20 % of being a vacancy, the following two representations are possible:\n\n        - Using a single species:\n            ```json\n            {\n              \"cartesian_site_positions\": [[0,0,0]],\n              \"species_at_sites\": [\"SiGe-vac\"],\n              \"species\": [\n              {\n                \"name\": \"SiGe-vac\",\n                \"chemical_symbols\": [\"Si\", \"Ge\", \"vacancy\"],\n                \"concentration\": [0.3, 0.5, 0.2]\n              }\n              ]\n              // ...\n            }\n            ```\n\n        - Using multiple species and the assemblies:\n            ```json\n            {\n              \"cartesian_site_positions\": [ [0,0,0], [0,0,0], [0,0,0] ],\n              \"species_at_sites\": [\"Si\", \"Ge\", \"vac\"],\n              \"species\": [\n                { \"name\": \"Si\", \"chemical_symbols\": [\"Si\"], \"concentration\": [1.0] },\n                { \"name\": \"Ge\", \"chemical_symbols\": [\"Ge\"], \"concentration\": [1.0] },\n                { \"name\": \"vac\", \"chemical_symbols\": [\"vacancy\"], \"concentration\": [1.0] }\n              },\n              \"assemblies\": [\n                {\n              \"sites_in_groups\": [ [0], [1], [2] ],\n              \"group_probabilities\": [0.3, 0.5, 0.2]\n                }\n              ]\n              // ...\n            }\n            ```\n\n    - It is up to the database provider to decide which representation to use, typically depending on the internal format in which the structure is stored.\n        However, given a structure identified by a unique ID, the API implementation MUST always provide the same representation for it.\n\n    - The probabilities of occurrence of different assemblies are uncorrelated.\n        So, for instance in the following case with two assemblies:\n        ```json\n        {\n          \"assemblies\": [\n            {\n              \"sites_in_groups\": [ [0], [1] ],\n              \"group_probabilities\": [0.2, 0.8],\n            },\n            {\n              \"sites_in_groups\": [ [2], [3] ],\n              \"group_probabilities\": [0.3, 0.7]\n            }\n          ]\n        }\n        ```\n\n        Site 0 is present with a probability of 20 % and site 1 with a probability of 80 %. These two sites are correlated (either site 0 or 1 is present). Similarly, site 2 is present with a probability of 30 % and site 3 with a probability of 70 %.\n        These two sites are correlated (either site 2 or 3 is present).\n        However, the presence or absence of sites 0 and 1 is not correlated with the presence or absence of sites 2 and 3 (in the specific example, the pair of sites (0, 2) can occur with 0.2*0.3 = 6 % probability; the pair (0, 3) with 0.2*0.7 = 14 % probability; the pair (1, 2) with 0.8*0.3 = 24 % probability; and the pair (1, 3) with 0.8*0.7 = 56 % probability)."
           },
           "structure_features": {
-            "title": "Structure Features",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/StructureFeatures"

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -2124,7 +2124,7 @@
           1
         ],
         "type": "integer",
-        "description": "Integer enumeration defining peridocity for dimension_types values"
+        "description": "Integer enumeration of dimension_types values"
       },
       "Person": {
         "title": "Person",

--- a/optimade/models/entries.py
+++ b/optimade/models/entries.py
@@ -167,6 +167,7 @@ If the entry listing endpoint supports sorting, this key MUST be present for sor
 
     type: Optional[DataType] = StrictField(
         None,
+        title="Type",
         description="""The type of the property's value.
 This MUST be any of the types defined in the Data types section.
 For the purpose of compatibility with future versions of this specification, a client MUST accept values that are not `string` values specifying any of the OPTIMADE Data types, but MUST then also disregard the `type` field.

--- a/optimade/models/index_metadb.py
+++ b/optimade/models/index_metadb.py
@@ -57,6 +57,7 @@ class IndexInfoResource(BaseInfoResource):
         None, Dict[DefaultRelationship, IndexRelationship]
     ] = StrictField(
         ...,
+        title="Relationships",
         description="""Reference to the Links identifier object under the `links` endpoint that the provider has chosen as their 'default' OPTIMADE API database.
 A client SHOULD present this database as the first choice when an end-user chooses this provider.""",
     )

--- a/optimade/models/links.py
+++ b/optimade/models/links.py
@@ -59,12 +59,14 @@ class LinksResourceAttributes(Attributes):
 
     link_type: LinkType = StrictField(
         ...,
+        title="Link Type",
         description="""The type of the linked relation.
 MUST be one of these values: 'child', 'root', 'external', 'providers'.""",
     )
 
     aggregate: Optional[Aggregate] = StrictField(
         Aggregate.OK,
+        title="Aggregate",
         description="""A string indicating whether a client that is following links to aggregate results from different OPTIMADE implementations should follow this link or not.
 This flag SHOULD NOT be indicated for links where `link_type` is not `child`.
 

--- a/optimade/models/structures.py
+++ b/optimade/models/structures.py
@@ -41,7 +41,7 @@ Vector3D_unknown = conlist(Union[float, None], min_items=3, max_items=3)
 
 
 class Periodicity(IntEnum):
-    """Integer enumeration defining peridocity for dimension_types values"""
+    """Integer enumeration of dimension_types values"""
 
     APERIODIC = 0
     PERIODIC = 1

--- a/optimade/models/structures.py
+++ b/optimade/models/structures.py
@@ -41,6 +41,8 @@ Vector3D_unknown = conlist(Union[float, None], min_items=3, max_items=3)
 
 
 class Periodicity(IntEnum):
+    """Integer enumeration defining peridocity for dimension_types values"""
+
     APERIODIC = 0
     PERIODIC = 1
 
@@ -442,6 +444,7 @@ The proportion number MUST be omitted if it is 1.
         conlist(Periodicity, min_items=3, max_items=3)
     ] = OptimadeField(
         None,
+        title="Dimension Types",
         description="""List of three integers.
 For each of the three directions indicated by the three lattice vectors (see property `lattice_vectors`), this list indicates if the direction is periodic (value `1`) or non-periodic (value `0`).
 Note: the elements in this list each refer to the direction of the corresponding entry in `lattice_vectors` and *not* the Cartesian x, y, z directions.
@@ -757,6 +760,7 @@ The properties of the species are found in the property `species`.
 
     structure_features: List[StructureFeatures] = OptimadeField(
         ...,
+        title="Structure Features",
         description="""A list of strings that flag which special features are used by the structure.
 
 - **Type**: list of strings

--- a/optimade/models/utils.py
+++ b/optimade/models/utils.py
@@ -19,6 +19,8 @@ __all__ = (
 
 
 class SupportLevel(Enum):
+    """OPTIMADE property/field support levels"""
+
     MUST = "must"
     SHOULD = "should"
     OPTIONAL = "optional"

--- a/optimade/server/entry_collections/entry_collections.py
+++ b/optimade/server/entry_collections/entry_collections.py
@@ -101,8 +101,15 @@ class EntryCollection(ABC):
         return fields
 
     def get_attribute_fields(self) -> set:
-        """Get the set of attribute fields from the schema of the
-        resource class, resolving references along the way.
+        """Get the set of attribute fields
+
+        Return only the _first-level_ attribute fields from the schema of the resource class,
+        resolving references along the way if needed.
+
+        Note:
+            It is not needed to take care of other special OpenAPI schema keys than `allOf`,
+            since only `allOf` will be found in this context.
+            Other special keys can be found in [the Swagger documentation](https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/).
 
         Returns:
             Property names.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 fastapi==0.63.0
 lark-parser==0.11.2
-pydantic==1.8
+pydantic==1.8.1
 email_validator==1.1.2
 requests==2.25.1
 uvicorn==0.13.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 fastapi==0.63.0
 lark-parser==0.11.2
-pydantic==1.6.1
+pydantic==1.8
 email_validator==1.1.2
 requests==2.25.1
 uvicorn==0.13.4

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ setup(
     install_requires=[
         "lark-parser~=0.11.2",
         "fastapi~=0.63.0",
-        "pydantic~=1.6.1",
+        "pydantic~=1.8",
         "email_validator~=1.1",
         "requests~=2.25",
         "typing-extensions~=3.7;python_version<'3.8'",

--- a/tests/server/entry_collections/test_entry_collections.py
+++ b/tests/server/entry_collections/test_entry_collections.py
@@ -1,0 +1,26 @@
+"""Test the EntryCollection abstract base class"""
+
+
+def test_get_attribute_fields():
+    """Test get_attribute_fields() method"""
+    from optimade.models import (
+        LinksResourceAttributes,
+        ReferenceResourceAttributes,
+        StructureResourceAttributes,
+    )
+    from optimade.server.routers import ENTRY_COLLECTIONS
+
+    entry_name_attributes = {
+        "links": LinksResourceAttributes,
+        "references": ReferenceResourceAttributes,
+        "structures": StructureResourceAttributes,
+    }
+
+    # Make sure we're hitting all collections
+    assert set(entry_name_attributes.keys()) == set(ENTRY_COLLECTIONS.keys())
+
+    for entry_name, attributes_model in entry_name_attributes.items():
+        assert (
+            set(attributes_model.__fields__.keys())
+            == ENTRY_COLLECTIONS[entry_name].get_attribute_fields()
+        )


### PR DESCRIPTION
Closes #730.

It seems we do not need to support more of the special OpenAPI keys that we're already supporting. Only `allOf` is used in the first-level for the retrieving the "attributes" fields anyway.

This PR also closes #729, since it will update `pydantic`, adding proper support for Python 3.9.