### PR TITLE
Disable all floating-point comparisons during validation

### DIFF
--- a/optimade/validator/config.py
+++ b/optimade/validator/config.py
@@ -71,7 +71,7 @@ _INCLUSIVE_OPERATORS = {
         "ENDS",
     ),
     DataType.TIMESTAMP: (
-        # "=" and "<=" are disabled due to issue with microseconds stored in database vs API response (see Materials-Consortia/optimade-python-tools/#606)
+        # N.B. "=" and "<=" are disabled due to issue with microseconds stored in database vs API response (see Materials-Consortia/optimade-python-tools/#606)
         # ">=" is fine as all microsecond trimming will round times down
         # "=",
         # "<=",
@@ -82,11 +82,7 @@ _INCLUSIVE_OPERATORS = {
         "<=",
         ">=",
     ),
-    DataType.FLOAT: (
-        "=",
-        "<=",
-        ">=",
-    ),
+    DataType.FLOAT: (),
     DataType.LIST: ("HAS", "HAS ALL", "HAS ANY"),
 }
 
@@ -95,7 +91,7 @@ exclusive_ops = ("!=", "<", ">")
 _EXCLUSIVE_OPERATORS = {
     DataType.STRING: exclusive_ops,
     DataType.TIMESTAMP: (),
-    DataType.FLOAT: exclusive_ops,
+    DataType.FLOAT: (),
     DataType.INTEGER: exclusive_ops,
     DataType.LIST: (),
 }

--- a/optimade/validator/validator.py
+++ b/optimade/validator/validator.py
@@ -701,6 +701,16 @@ class ImplementationValidator:
                 self._log.warning(msg)
                 return None, msg
 
+            # Try to infer if the test value is a float from its string representation
+            # and decide whether to do inclusive/exclusive query tests
+            try:
+                float(test_value[0])
+                msg = f"Not testing filters on field {prop} of type {prop_type} containing float values."
+                self._log.warning(msg)
+                return None, msg
+            except ValueError:
+                pass
+
         if prop_type in (DataType.DICTIONARY,):
             msg = f"Not testing queries on field {prop} of type {prop_type}."
             self._log.warning(msg)

--- a/tests/server/test_server_validation.py
+++ b/tests/server/test_server_validation.py
@@ -13,7 +13,6 @@ def test_with_validator(both_fake_remote_clients):
     validator = ImplementationValidator(
         client=both_fake_remote_clients,
         index=both_fake_remote_clients.app == app,
-        verbosity=5,
     )
 
     validator.validate_implementation()
@@ -33,14 +32,13 @@ def test_with_validator_json_response(both_fake_remote_clients, capsys):
 
     captured = capsys.readouterr()
     json_response = json.loads(captured.out)
-    assert json_response["failure_count"] == 0
-    assert json_response["internal_failure_count"] == 0
-    assert json_response["optional_failure_count"] == 0
-    assert validator.results.failure_count == 0
-    assert validator.results.internal_failure_count == 0
-    assert validator.results.optional_failure_count == 0
-    assert dataclasses.asdict(validator.results) == json_response
-
+    assert json_response["failure_count"] == 0, json_response
+    assert json_response["internal_failure_count"] == 0, json_response
+    assert json_response["optional_failure_count"] == 0, json_response
+    assert validator.results.failure_count == 0, json_response
+    assert validator.results.internal_failure_count == 0, json_response
+    assert validator.results.optional_failure_count == 0, json_response
+    assert dataclasses.asdict(validator.results) == json_response, json_response
     assert validator.valid
 
 


### PR DESCRIPTION
Closes #735 by disabling floating point comparisons for float fields, and for fields that are inferred to be lists of floats.

