### PR TITLE
Run full API docs invoke task for every PR

### DIFF
--- a/.github/workflows/deps_lint.yml
+++ b/.github/workflows/deps_lint.yml
@@ -271,10 +271,13 @@ jobs:
         pip install -U setuptools
         pip install -e .
         pip install -r requirements.txt
+        pip install -r requirements-dev.txt
         pip install -r requirements-docs.txt
 
     - name: Build
-      run: mkdocs build --strict --verbose
+      run: |
+        invoke create-api-reference-docs
+        mkdocs build --strict --verbose
 
   test_build:
     runs-on: ubuntu-latest

--- a/docs/api_reference/server/entry_collections/elasticsearch.md
+++ b/docs/api_reference/server/entry_collections/elasticsearch.md
@@ -1,0 +1,3 @@
+# elasticsearch
+
+::: optimade.server.entry_collections.elasticsearch

--- a/optimade/server/entry_collections/elasticsearch.py
+++ b/optimade/server/entry_collections/elasticsearch.py
@@ -26,7 +26,7 @@ class ElasticCollection(EntryCollection):
         name: str,
         resource_cls: EntryResource,
         resource_mapper: BaseResourceMapper,
-        client: Optional[Elasticsearch] = None,
+        client: Optional["Elasticsearch"] = None,
     ):
         """Initialize the ElasticCollection for the given parameters.
 


### PR DESCRIPTION
Closes #747.

It looks like the Elasticsearch docs will need to be fixed as part of this PR as it uses a deferred type hint. This may require switching to Python 3.9 for docs builds.