### PR TITLE
Deprecate Python 3.6 support, v0.14 last supported version

### DIFF
--- a/optimade/__init__.py
+++ b/optimade/__init__.py
@@ -4,17 +4,18 @@ __api_version__ = "1.0.1"
 
 import sys
 
-
-class OptimadeDeprecationWarning(Warning):
-    """Special deprecation warning"""
-
-
 if sys.version_info.minor == 6:
     # Python 3.6
     import warnings
 
+    warnings.filterwarnings(
+        action="once",
+        message=r"v0\.14 of the `optimade` package.*",
+        category=DeprecationWarning,
+        append=False,
+    )
     warnings.warn(
         "v0.14 of the `optimade` package will be the last to support Python 3.6. "
         "Please upgrade to Python 3.7+ to use v0.15 and later versions of `optimade`.",
-        OptimadeDeprecationWarning,
+        DeprecationWarning,
     )

--- a/optimade/__init__.py
+++ b/optimade/__init__.py
@@ -1,2 +1,20 @@
 __version__ = "0.13.3"
 __api_version__ = "1.0.1"
+
+
+import sys
+
+
+class OptimadeDeprecationWarning(Warning):
+    """Special deprecation warning"""
+
+
+if sys.version_info.minor == 6:
+    # Python 3.6
+    import warnings
+
+    warnings.warn(
+        "v0.14 of the `optimade` package will be the last to support Python 3.6. "
+        "Please upgrade to Python 3.7+ to use v0.15 and later versions of `optimade`.",
+        OptimadeDeprecationWarning,
+    )

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,6 @@
 from pathlib import Path
 import re
 from setuptools import setup, find_packages
-import sys
-
-if sys.version_info.minor == 6:
-    # Python 3.6
-    print(
-        "`optimade` is deprecating support for Python 3.6 !\n"
-        "  v0.14 of the `optimade` package will be the last to support Python 3.6. "
-        "  Please upgrade to Python 3.7+ to use v0.15 and later versions of `optimade`."
-    )
 
 module_dir = Path(__file__).resolve().parent
 

--- a/setup.py
+++ b/setup.py
@@ -5,16 +5,11 @@ import sys
 
 if sys.version_info.minor == 6:
     # Python 3.6
-    import warnings
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("always")
-        warnings.warn(
-            DeprecationWarning(
-                "v0.14 of the `optimade` package will be the last to support Python 3.6. "
-                "Please upgrade to Python 3.7+ to use v0.15 and later versions of `optimade`."
-            )
-        )
+    print(
+        "`optimade` is deprecating Pythonr 3.6 usage!\n"
+        "  v0.14 of the `optimade` package will be the last to support Python 3.6. "
+        "  Please upgrade to Python 3.7+ to use v0.15 and later versions of `optimade`."
+    )
 
 module_dir = Path(__file__).resolve().parent
 

--- a/setup.py
+++ b/setup.py
@@ -7,12 +7,14 @@ if sys.version_info.minor == 6:
     # Python 3.6
     import warnings
 
-    warnings.warn(
-        DeprecationWarning(
-            "v0.14 of the `optimade` package will be the last to support Python 3.6. "
-            "Please upgrade to Python 3.7+ to get v0.15 an later versions of `optimade`."
+    with warnings.catch_warnings():
+        warnings.simplefilter("always")
+        warnings.warn(
+            DeprecationWarning(
+                "v0.14 of the `optimade` package will be the last to support Python 3.6. "
+                "Please upgrade to Python 3.7+ to get v0.15 an later versions of `optimade`."
+            )
         )
-    )
 
 module_dir = Path(__file__).resolve().parent
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import sys
 if sys.version_info.minor == 6:
     # Python 3.6
     print(
-        "`optimade` is deprecating Pythonr 3.6 usage!\n"
+        "`optimade` is deprecating support for Python 3.6 !\n"
         "  v0.14 of the `optimade` package will be the last to support Python 3.6. "
         "  Please upgrade to Python 3.7+ to use v0.15 and later versions of `optimade`."
     )

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,18 @@
 from pathlib import Path
 import re
 from setuptools import setup, find_packages
+import sys
+
+if sys.version_info.minor == 6:
+    # Python 3.6
+    import warnings
+
+    warnings.warn(
+        DeprecationWarning(
+            "v0.14 of the `optimade` package will be the last to support Python 3.6. "
+            "Please upgrade to Python 3.7+ to get v0.15 an later versions of `optimade`."
+        )
+    )
 
 module_dir = Path(__file__).resolve().parent
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ if sys.version_info.minor == 6:
         warnings.warn(
             DeprecationWarning(
                 "v0.14 of the `optimade` package will be the last to support Python 3.6. "
-                "Please upgrade to Python 3.7+ to get v0.15 an later versions of `optimade`."
+                "Please upgrade to Python 3.7+ to use v0.15 and later versions of `optimade`."
             )
         )
 


### PR DESCRIPTION
Since it's not critical to drop Python 3.6 anymore, it's nicer with a grace period. Even though it may be short.

This PR implements a `DeprecationWarning` explaining that v0.14 will be the last version to support Python 3.6, and that one should update to Python 3.7+ to receive v0.15 and onwards.