### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/deps_lint.yml
+++ b/.github/workflows/deps_lint.yml
@@ -204,9 +204,8 @@ jobs:
       run: |
         pip install -r requirements-client.txt
         # AiiDA-specific
-        # sqlalchemy install is temporary and has been fixed in aiidateam/aiida-core#4809,
-        # but is still not released in a new AiiDA version.
-        pip install sqlalchemy==1.3.23
+        # sqlalchemy install is temporary and has not been fixed for Python 3.6 versions
+        if [ "${{ matrix.python-version }}" == "3.6" ]; then pip install sqlalchemy==1.3.23; fi
         reentry scan
 
     - name: Setup up environment for AiiDA

--- a/.github/workflows/publish-on-pypi.yml
+++ b/.github/workflows/publish-on-pypi.yml
@@ -61,7 +61,7 @@ jobs:
       run: mkdocs build
 
     - name: Deploy
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v3.8.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_branch: gh-pages

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     - id: end-of-file-fixer
 
   - repo: https://gitlab.com/pycqa/flake8
-    rev: '3.8.4'
+    rev: '3.9.0'
     hooks:
     -   id: flake8
 

--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -1,4 +1,5 @@
-aiida-core==1.6.0
+aiida-core==1.6.0 ; python_version > '3.6'
+aiida-core==1.5.2 ; python_version < '3.7'
 ase==3.21.1
 numpy==1.20.1 ; python_version > '3.6'
 numpy==1.19.5 ; python_version < '3.7'

--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -1,7 +1,7 @@
-aiida-core==1.5.2
+aiida-core==1.6.0
 ase==3.21.1
 numpy==1.20.1 ; python_version > '3.6'
 numpy==1.19.5 ; python_version < '3.7'
-pymatgen==2021.3.4; python_version > '3.6'
+pymatgen==2022.0.5; python_version > '3.6'
 pymatgen==2021.2.8.1; python_version < '3.7'
-jarvis-tools==2021.2.22
+jarvis-tools==2021.3.13

--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -3,6 +3,6 @@ aiida-core==1.5.2 ; python_version < '3.7'
 ase==3.21.1
 numpy==1.20.1 ; python_version > '3.6'
 numpy==1.19.5 ; python_version < '3.7'
-pymatgen==2022.0.5; python_version > '3.6'
+pymatgen==2021.3.5; python_version > '3.6'
 pymatgen==2021.2.8.1; python_version < '3.7'
 jarvis-tools==2021.3.13

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,5 +3,5 @@ pytest-cov==2.11.1
 codecov==2.1.11
 jsondiff==1.2.0
 pylint==2.7.2
-pre-commit==2.10.1
+pre-commit==2.11.1
 invoke==1.5.0

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,5 +1,5 @@
 mkdocs==1.1.2
 mkdocs-awesome-pages-plugin==2.5.0
-mkdocs-material==7.0.4
+mkdocs-material==7.0.6
 mkdocs-minify-plugin==0.4.0
 mkdocstrings==0.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ django==3.1.7
 elasticsearch-dsl==6.4.0
 Jinja2==2.11.3
 typing-extensions==3.7.4.3
-pyyaml==5.1.2
+pyyaml==5.4.1

--- a/setup.py
+++ b/setup.py
@@ -20,18 +20,22 @@ with open(module_dir.joinpath("optimade/__init__.py")) as version_file:
 django_deps = ["django>=2.2.9,<4.0"]
 elastic_deps = ["elasticsearch-dsl~=6.4,<7.0"]
 mongo_deps = ["pymongo~=3.11", "mongomock~=3.22"]
-server_deps = ["uvicorn~=0.13.4", "Jinja2~=2.11", "pyyaml~=5.1"] + mongo_deps
+server_deps = [
+    "uvicorn~=0.13.4",
+    "Jinja2~=2.11",
+    "pyyaml~=5.1",  # Keep at pyyaml 5.1 for aiida-core support
+] + mongo_deps
 
 # Client minded
-aiida_deps = ["aiida-core~=1.5.2"]
+aiida_deps = ["aiida-core~=1.5"]  # Keep at 1.5 for Python 3.6 support
 ase_deps = ["ase~=3.21"]
 cif_deps = ["numpy~=1.19"]  # Keep at 1.19 for Python 3.6 support
 pdb_deps = cif_deps
 pymatgen_deps = [
     "pymatgen==2021.2.8.1;python_version<'3.7'",
-    "pymatgen==2021.3.4;python_version>'3.6'",
+    "pymatgen==2022.0.5;python_version>'3.6'",
 ]
-jarvis_deps = ["jarvis-tools==2021.2.22"]
+jarvis_deps = ["jarvis-tools==2021.3.13"]
 client_deps = cif_deps
 
 # General
@@ -49,7 +53,7 @@ testing_deps = [
     "jsondiff~=1.2",
 ] + server_deps
 dev_deps = (
-    ["pylint~=2.7", "pre-commit~=2.10", "invoke~=1.5"]
+    ["pylint~=2.7", "pre-commit~=2.11", "invoke~=1.5"]
     + docs_deps
     + testing_deps
     + client_deps

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ cif_deps = ["numpy~=1.19"]  # Keep at 1.19 for Python 3.6 support
 pdb_deps = cif_deps
 pymatgen_deps = [
     "pymatgen==2021.2.8.1;python_version<'3.7'",
-    "pymatgen==2022.0.5;python_version>'3.6'",
+    "pymatgen==2021.3.5;python_version>'3.6'",
 ]
 jarvis_deps = ["jarvis-tools==2021.3.13"]
 client_deps = cif_deps


### PR DESCRIPTION
Update Python dependencies and GH Actions according to @dependabot.

Split `aiida-core` version due to drop of Python 3.6 support in v1.6 (something that will be of reversed for v0.15 of `optimade`).

Updated pre-commit hook `flake8` version.