### PR TITLE
Overhaul of filter transformers, mappers and response fields

### DIFF
--- a/.github/workflows/deps_lint.yml
+++ b/.github/workflows/deps_lint.yml
@@ -276,7 +276,7 @@ jobs:
     - name: Build
       run: |
         invoke create-api-reference-docs
-        mkdocs build --strict --verbose
+        mkdocs build --strict
 
   test_build:
     runs-on: ubuntu-latest

--- a/optimade/filtertransformers/__init__.py
+++ b/optimade/filtertransformers/__init__.py
@@ -4,6 +4,9 @@ given backend.
 
 """
 
-from optimade.filtertransformers.base_transformer import BaseTransformer
+from optimade.filtertransformers.base_transformer import BaseTransformer, Quantity
 
-__all__ = ("BaseTransformer",)
+__all__ = (
+    "BaseTransformer",
+    "Quantity",
+)

--- a/optimade/filtertransformers/base_transformer.py
+++ b/optimade/filtertransformers/base_transformer.py
@@ -253,10 +253,8 @@ class BaseTransformer(abc.ABC, Transformer):
             # Following [Handling unknown property names](https://github.com/Materials-Consortia/OPTIMADE/blob/master/optimade.rst#handling-unknown-property-names)
             if self.mapper and quantity_name.startswith("_"):
                 prefix = quantity_name.split("_")[1]
-                if not any(prefix == p for p in self.mapper.SUPPORTED_PREFIXES):
-                    if not any(
-                        prefix == p for p in self.mapper.KNOWN_PROVIDER_PREFIXES
-                    ):
+                if prefix not in self.mapper.SUPPORTED_PREFIXES:
+                    if prefix not in self.mapper.KNOWN_PROVIDER_PREFIXES:
                         warnings.warn(
                             UnknownProviderProperty(
                                 f"Field {quantity_name!r} has an unrecognised prefix: this property has been treated as UNKNOWN."

--- a/optimade/filtertransformers/elasticsearch.py
+++ b/optimade/filtertransformers/elasticsearch.py
@@ -1,35 +1,23 @@
-from typing import List
-
+from typing import Dict, Union, Type
 from lark import v_args
 from elasticsearch_dsl import Q, Text, Keyword, Integer, Field
-from optimade.filtertransformers import BaseTransformer
-from optimade.server.exceptions import BadRequest
+
+from optimade.filtertransformers import BaseTransformer, Quantity
+from optimade.server.mappers import BaseResourceMapper
 
 __all__ = ("ElasticTransformer",)
 
 
-_cmp_operators = {">": "gt", ">=": "gte", "<": "lt", "<=": "lte"}
-_rev_cmp_operators = {">": "<", ">=": "<=", "<": ">", "<=": ">=", "=": "=", "!=": "!="}
-_has_operators = {"ALL": "must", "ANY": "should"}
-_length_quantities = {
-    "elements": "nelements",
-    "elements_ratios": "nelements",
-    "dimension_types": "dimension_types",
-}
-
-
-class Quantity:
-    """Class to provide information about available quantities to the transformer.
-
-    The elasticsearch transformer will use `Quantity`s to (a) do some semantic checks,
-    (b) map quantities to the underlying elastic index.
+class ElasticsearchQuantity(Quantity):
+    """Elasticsearch-specific extension of the underlying
+    [`Quantity`][optimade.filtertransformers.base_transformer.Quantity] class.
 
     Attributes:
         name: The name of the quantity as used in the filter expressions.
-        es_field: The name of the field for this quanity in elastic search, will be
+        backend_field: The name of the field for this quanity in elastic search, will be
             ``name`` by default.
-        elastic_mapping_type: A decendent of an elasticsearch_dsl Field that denotes which
-            mapping was used in the elastic search index.
+        elastic_mapping_type: A decendent of an `elasticsearch_dsl.Field` that denotes which
+            mapping type was used in the Elasticsearch index.
         length_quantity: Elasticsearch does not support length of arrays, but we can
             map fields with array to other fields with ints about the array length. The
             LENGTH operator will only be supported for quantities with this attribute.
@@ -47,56 +35,99 @@ class Quantity:
 
     def __init__(
         self,
-        name,
-        es_field: str = None,
+        name: str,
+        backend_field: str = None,
+        length_quantity: "ElasticsearchQuantity" = None,
         elastic_mapping_type: Field = None,
-        length_quantity: "Quantity" = None,
-        has_only_quantity: "Quantity" = None,
-        nested_quantity: "Quantity" = None,
+        has_only_quantity: "ElasticsearchQuantity" = None,
+        nested_quantity: "ElasticsearchQuantity" = None,
     ):
 
-        self.name = name
-        self.es_field = es_field if es_field is not None else name
+        super().__init__(name, backend_field, length_quantity)
+
         self.elastic_mapping_type = (
             Keyword if elastic_mapping_type is None else elastic_mapping_type
         )
-        self.length_quantity = length_quantity
         self.has_only_quantity = has_only_quantity
         self.nested_quantity = nested_quantity
 
-    def __repr__(self):
-        return self.name
-
 
 class ElasticTransformer(BaseTransformer):
-    """Transformer that transforms ``v0.10.1`` grammar parse trees into queries.
+    """Transformer that transforms ``v0.10.1``/`v1.0` grammar parse
+    trees into Elasticsearch queries.
 
-    Uses elasticsearch_dsl and will produce a `Q` instance.
+    Uses elasticsearch_dsl and will produce an `elasticsearch_dsl.Q` instance.
+
     """
 
-    def __init__(self, quantities: List[Quantity]):
-        """
-        Arguments:
-            quantities: A list of :class:`Quantity`s that describe how optimade (and other)
-                quantities are mapped to the elasticsearch index.
-        """
-        self.index_mapping = {quantity.name: quantity for quantity in quantities}
-        super().__init__()
+    operator_map = {
+        "<": "lt",
+        "<=": "lte",
+        ">": "gt",
+        ">=": "gte",
+    }
 
-    def _field(self, quantity, nested=None):
+    __quantity_type: Type[ElasticsearchQuantity] = ElasticsearchQuantity
+
+    def __init__(
+        self, mapper: BaseResourceMapper = None, quantities: Dict[str, Quantity] = None
+    ):
+        if quantities is not None:
+            self.quantities = quantities
+
+        super().__init__(mapper=mapper)
+
+    def _field(self, quantity: Union[str, Quantity], nested: Quantity = None) -> str:
+        """Used to unwrap from `property` to the string backend field name.
+
+        If passed a `Quantity` (or a derived `ElasticsearchQuantity`), this method
+        returns the backend field name, modulo some handling of nested fields.
+
+        If passed a string quantity name:
+        - Check that the name does not match a relationship type,
+          raising a `NotImplementedError` if it does. If the
+        - If the string is prefixed by an underscore, assume this is a
+          provider-specific field from another provider and simply return it.
+          The original `property` rule would have already filtered out provider
+          fields for this backend appropriately as `Quantity` objects.
+
+        Returns:
+            The field name to use for database queries.
+
+        """
+
+        if (
+            isinstance(quantity, str)
+            and quantity in self.mapper.RELATIONSHIP_ENTRY_TYPES
+        ):
+            raise NotImplementedError(
+                f"Unable to filter on relationships with type {quantity!r}"
+            )
+
         if nested is not None:
-            return "%s.%s" % (nested.es_field, quantity.name)
+            return "%s.%s" % (nested.backend_field, quantity.name)
 
-        return quantity.es_field
+        return quantity.backend_field
 
-    def _query_op(self, quantity, op, value, nested=None):
-        """
-        Return a range, match, or term query for the given quantity, comparison
-        operator, and value
+    def _query_op(
+        self,
+        quantity: Union[ElasticsearchQuantity, str],
+        op: str,
+        value: Union[str, float, int],
+        nested: ElasticsearchQuantity = None,
+    ) -> Q:
+        """Return a range, match, or term query for the given quantity, comparison
+        operator, and value.
+
+        Returns:
+            An elasticsearch_dsl query.
+
+        Raises:
+            BadRequest: If the query is not well-defined or is not supported.
         """
         field = self._field(quantity, nested=nested)
-        if op in _cmp_operators:
-            return Q("range", **{field: {_cmp_operators[op]: value}})
+        if op in self.operator_map:
+            return Q("range", **{field: {self.operator_map[op]: value}})
 
         if quantity.elastic_mapping_type == Text:
             query_type = "match"
@@ -109,16 +140,15 @@ class ElasticTransformer(BaseTransformer):
             return Q(query_type, **{field: value})
 
         if op == "!=":
-            # != queries must also include an existence check
+            # != queries must also include an existence/v check
             # Note that for MongoDB, `$exists` will include null-valued fields,
             # where as in ES `exists` excludes them.
             # pylint: disable=invalid-unary-operand-type
             return ~Q(query_type, **{field: value}) & Q("exists", field=field)
 
     def _has_query_op(self, quantities, op, predicate_zip_list):
-        """
-        Returns a bool query that combines the operator queries ():func:`_query_op`)
-        for each predicate and zipped quantity pericates combinations.
+        """Returns a bool query that combines the operator calls `_query_op`
+        for each predicate and zipped quantity predicate combination.
         """
         if op == "HAS":
             kind = "must"  # in case of HAS we do a must over the "list" of the one given element
@@ -258,7 +288,7 @@ class ElasticTransformer(BaseTransformer):
         if not isinstance(quantity, Quantity):
             raise TypeError("Only quantities can be compared to constant values.")
 
-        return self._query_op(quantity, _rev_cmp_operators[op], value)
+        return self._query_op(quantity, self._reversed_operator_map[op], value)
 
     @v_args(inline=True)
     def value_op_rhs(self, op, value):
@@ -276,7 +306,7 @@ class ElasticTransformer(BaseTransformer):
         def query(quantity):
             if quantity.length_quantity is None:
                 raise NotImplementedError(
-                    "LENGTH is not supported for %s" % quantity.name
+                    "LENGTH is not supported for '%s'" % quantity.name
                 )
             quantity = quantity.length_quantity
             return self._query_op(quantity, op, value)
@@ -367,19 +397,6 @@ class ElasticTransformer(BaseTransformer):
             wildcard = "*%s" % value
 
         return lambda quantity: Q("wildcard", **{self._field(quantity): wildcard})
-
-    def property(self, args):
-        # property: IDENTIFIER ( "." IDENTIFIER )*
-        quantity_name = args[0]
-
-        if quantity_name not in self.index_mapping:
-            raise BadRequest(detail=f"{quantity_name} is not a searchable quantity")
-
-        quantity = self.index_mapping.get(quantity_name, None)
-        if quantity is None:
-            quantity = Quantity(name=quantity_name)
-
-        return quantity
 
     @v_args(inline=True)
     def string(self, string):

--- a/optimade/filtertransformers/mongo.py
+++ b/optimade/filtertransformers/mongo.py
@@ -503,5 +503,3 @@ def recursive_postprocessing(filter_, condition, replacement):
         return _cached_filter
 
     return filter_
-
-    return filter_

--- a/optimade/filtertransformers/mongo.py
+++ b/optimade/filtertransformers/mongo.py
@@ -186,6 +186,7 @@ class MongoTransformer(BaseTransformer):
         quantity = super().property(args)
         if isinstance(quantity, Quantity):
             quantity = quantity.backend_field
+
         return ".".join([quantity] + args[1:])
 
     def length_op_rhs(self, arg):
@@ -500,5 +501,7 @@ def recursive_postprocessing(filter_, condition, replacement):
                     recursive_postprocessing(q, condition, replacement) for q in expr
                 ]
         return _cached_filter
+
+    return filter_
 
     return filter_

--- a/optimade/filtertransformers/mongo.py
+++ b/optimade/filtertransformers/mongo.py
@@ -116,12 +116,6 @@ class MongoTransformer(BaseTransformer):
 
                 return final_query
 
-            # Another workaround: in the case that there is no length alias, and the field
-            # itself does not exist in the database, then `{"$size": 1}` matches all documents,
-            # so we must add another existence check
-            if "$exists" not in query:
-                query["$exists"] = True
-
         return {quantity: query}
 
     def constant_first_comparison(self, arg):
@@ -316,7 +310,6 @@ class MongoTransformer(BaseTransformer):
                         {
                             f"relationships.{_prop}.data": {
                                 "$size": expr.pop("$size"),
-                                "$exists": expr.pop("$exists"),
                             }
                         },
                         {f"relationships.{_prop}.data.{_field}": expr},

--- a/optimade/filtertransformers/mongo.py
+++ b/optimade/filtertransformers/mongo.py
@@ -109,8 +109,8 @@ class MongoTransformer(BaseTransformer):
                 if query:
                     final_query = {quantity: query}
                 for q in size_query:
-                    if q in query:
-                        query[q].update(size_query[q])
+                    if q in final_query:
+                        final_query[q].update(size_query[q])
                     else:
                         final_query[q] = size_query[q]
 

--- a/optimade/server/entry_collections/elasticsearch.py
+++ b/optimade/server/entry_collections/elasticsearch.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Tuple, List, Optional, Dict, Any, Iterable, Union
 
 from optimade.filterparser import LarkParser
-from optimade.filtertransformers.elasticsearch import ElasticTransformer, Quantity
+from optimade.filtertransformers.elasticsearch import ElasticTransformer
 from optimade.server.config import CONFIG
 from optimade.server.logger import LOGGER
 from optimade.models import EntryResource
@@ -46,26 +46,7 @@ class ElasticCollection(EntryCollection):
         self.provider_fields = CONFIG.provider_fields.get(resource_mapper.ENDPOINT, [])
         self.parser = LarkParser()
 
-        quantities = {}
-        for field in self.all_fields:
-            alias = self.resource_mapper.get_backend_field(field)
-            length_alias = self.resource_mapper.length_alias_for(field)
-
-            quantities[field] = Quantity(name=field, es_field=alias)
-            if length_alias is not None:
-                quantities[length_alias] = Quantity(name=length_alias)
-                quantities[field].length_quantity = quantities[length_alias]
-
-        if "elements" in quantities:
-            quantities["elements"].has_only_quantity = Quantity(name="elements_only")
-            quantities["elements"].nested_quantity = quantities["elements_ratios"]
-
-        if "elements_ratios" in quantities:
-            quantities["elements_ratios"].nested_quantity = quantities[
-                "elements_ratios"
-            ]
-
-        self.transformer = ElasticTransformer(quantities=quantities.values())
+        self.transformer = ElasticTransformer(mapper=self.resource_mapper)
 
         self.name = name
 

--- a/optimade/server/entry_collections/elasticsearch.py
+++ b/optimade/server/entry_collections/elasticsearch.py
@@ -2,7 +2,6 @@ import json
 from pathlib import Path
 from typing import Tuple, List, Optional, Dict, Any, Iterable, Union
 
-from optimade.filterparser import LarkParser
 from optimade.filtertransformers.elasticsearch import ElasticTransformer
 from optimade.server.config import CONFIG
 from optimade.server.logger import LOGGER
@@ -38,16 +37,13 @@ class ElasticCollection(EntryCollection):
             client: A preconfigured Elasticsearch client.
 
         """
+        super().__init__(
+            resource_cls=resource_cls,
+            resource_mapper=resource_mapper,
+            transformer=ElasticTransformer(mapper=resource_mapper),
+        )
+
         self.client = client if client else CLIENT
-
-        self.resource_cls = resource_cls
-        self.resource_mapper = resource_mapper
-        self.provider_prefix = CONFIG.provider.prefix
-        self.provider_fields = CONFIG.provider_fields.get(resource_mapper.ENDPOINT, [])
-        self.parser = LarkParser()
-
-        self.transformer = ElasticTransformer(mapper=self.resource_mapper)
-
         self.name = name
 
         # If we are creating a new collection from scratch, also create the index,

--- a/optimade/server/entry_collections/entry_collections.py
+++ b/optimade/server/entry_collections/entry_collections.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod, ABC
-from typing import Tuple, List, Union, Dict, Any
+from typing import Tuple, List, Union, Dict, Any, Set
 import warnings
 import re
 
@@ -173,13 +173,7 @@ class EntryCollection(ABC):
             )
 
         if results:
-            if isinstance(results, dict):
-                results = self.resource_cls(**self.resource_mapper.map_back(results))
-            else:
-                results = [
-                    self.resource_cls(**self.resource_mapper.map_back(doc))
-                    for doc in results
-                ]
+            results = self.resource_mapper.deserialize(results)
 
         return (
             results,
@@ -225,7 +219,7 @@ class EntryCollection(ABC):
 
         return fields
 
-    def get_attribute_fields(self) -> set:
+    def get_attribute_fields(self) -> Set[str]:
         """Get the set of attribute fields
 
         Return only the _first-level_ attribute fields from the schema of the resource class,

--- a/optimade/server/mappers/entries.py
+++ b/optimade/server/mappers/entries.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Optional, Type, Set
+from typing import Tuple, Optional, Type, Set, Dict, Any, Union, List, Iterable
 import warnings
 
 from optimade.models.entries import EntryResource
@@ -9,10 +9,20 @@ __all__ = ("BaseResourceMapper",)
 class classproperty(property):
     """A simple extension of the property decorator that binds to types
     rather than instances.
+
+    Modelled on this [StackOverflow answer](https://stackoverflow.com/a/5192374)
+    with some tweaks to allow mkdocstrings to do its thing.
+
     """
 
-    def __get__(self, obj, objtype=None):
-        return super(classproperty, self).__get__(objtype)
+    def __init__(self, func):
+        self.__name__ = func.__name__
+        self.__module__ = func.__module__
+        self.__doc__ = func.__doc__
+        self.__wrapped__ = func
+
+    def __get__(self, _, owner):
+        return self.__wrapped__(owner)
 
 
 class BaseResourceMapper:
@@ -32,10 +42,15 @@ class BaseResourceMapper:
         ENTRY_RESOURCE_CLASS: The entry type that this mapper corresponds to.
         PROVIDER_FIELDS: a tuple of extra field names that this
             mapper should support when querying with the database prefix.
-        REQUIRED_FIELDS: the set of fieldnames to return
-            when mapping to the OPTIMADE format.
         TOP_LEVEL_NON_ATTRIBUTES_FIELDS: the set of top-level
             field names common to all endpoints.
+        SUPPORTED_PREFIXES: The set of prefixes registered by this mapper.
+        ALL_ATTRIBUTES: The set of attributes defined across the entry
+            resource class and the server configuration.
+        ENTRY_RESOURCE_ATTRIBUTES: A dictionary of attributes and their definitions
+            defined by the schema of the entry resource class.
+        ENDPOINT: The expected endpoint name for this resource, as defined by
+            the `type` in the schema of the entry resource class.
 
     """
 
@@ -55,7 +70,10 @@ class BaseResourceMapper:
     ENTRY_RESOURCE_CLASS: Type[EntryResource] = EntryResource
     RELATIONSHIP_ENTRY_TYPES: Set[str] = {"references", "structures"}
     TOP_LEVEL_NON_ATTRIBUTES_FIELDS: Set[str] = {"id", "type", "relationships", "links"}
-    REQUIRED_FIELDS: set = set()
+    SUPPORTED_PREFIXES: Set[str]
+    ALL_ATTRIBUTES: Set[str]
+    ENTRY_RESOURCE_ATTRIBUTES: Dict[str, Any]
+    ENDPOINT: str
 
     @classmethod
     def all_aliases(cls) -> Tuple[Tuple[str, str]]:
@@ -88,10 +106,10 @@ class BaseResourceMapper:
         """A set of prefixes handled by this entry type.
 
         !!! note
-        This implementation only includes the provider prefix,
-        but in the future this property may be extended to include other
-        namespaces (for serving fields from, e.g., other providers or
-        domain-specific terms).
+            This implementation only includes the provider prefix,
+            but in the future this property may be extended to include other
+            namespaces (for serving fields from, e.g., other providers or
+            domain-specific terms).
 
         """
         from optimade.server.config import CONFIG
@@ -113,13 +131,18 @@ class BaseResourceMapper:
         )
 
     @classproperty
-    def ENTRY_RESOURCE_ATTRIBUTES(cls) -> Set[str]:
+    def ENTRY_RESOURCE_ATTRIBUTES(cls) -> Dict[str, Any]:
+        """Returns the dictionary of attributes defined by the underlying entry resource class."""
         from optimade.server.schemas import retrieve_queryable_properties
 
         return retrieve_queryable_properties(cls.ENTRY_RESOURCE_CLASS.schema())
 
     @classproperty
     def ENDPOINT(cls) -> str:
+        """Returns the expected endpoint for this mapper, corresponding
+        to the `type` property of the resource class.
+
+        """
         return (
             cls.ENTRY_RESOURCE_CLASS.schema()
             .get("properties", {})
@@ -268,9 +291,7 @@ class BaseResourceMapper:
             REQUIRED response fields.
 
         """
-        res = cls.TOP_LEVEL_NON_ATTRIBUTES_FIELDS.copy()
-        res.update(cls.REQUIRED_FIELDS)
-        return res
+        return cls.TOP_LEVEL_NON_ATTRIBUTES_FIELDS
 
     @classmethod
     def map_back(cls, doc: dict) -> dict:
@@ -315,3 +336,12 @@ class BaseResourceMapper:
         newdoc["attributes"] = attributes
 
         return newdoc
+
+    @classmethod
+    def deserialize(
+        cls, results: Union[dict, Iterable[dict]]
+    ) -> Union[List[EntryResource], EntryResource]:
+        if isinstance(results, dict):
+            return cls.ENTRY_RESOURCE_CLASS(**cls.map_back(results))
+
+        return [cls.ENTRY_RESOURCE_CLASS(**cls.map_back(doc)) for doc in results]

--- a/optimade/server/mappers/links.py
+++ b/optimade/server/mappers/links.py
@@ -1,4 +1,5 @@
 from optimade.server.mappers.entries import BaseResourceMapper
+from optimade.models.links import LinksResource
 
 __all__ = ("LinksMapper",)
 
@@ -6,6 +7,8 @@ __all__ = ("LinksMapper",)
 class LinksMapper(BaseResourceMapper):
 
     ENDPOINT = "links"
+
+    ENTRY_RESOURCE_CLASS = LinksResource
 
     @classmethod
     def map_back(cls, doc: dict) -> dict:

--- a/optimade/server/mappers/references.py
+++ b/optimade/server/mappers/references.py
@@ -1,8 +1,9 @@
 from optimade.server.mappers.entries import BaseResourceMapper
+from optimade.models.references import ReferenceResource
 
 __all__ = ("ReferenceMapper",)
 
 
 class ReferenceMapper(BaseResourceMapper):
 
-    ENDPOINT = "references"
+    ENTRY_RESOURCE_CLASS = ReferenceResource

--- a/optimade/server/mappers/structures.py
+++ b/optimade/server/mappers/structures.py
@@ -1,11 +1,10 @@
 from optimade.server.mappers.entries import BaseResourceMapper
+from optimade.models.structures import StructureResource
 
 __all__ = ("StructureMapper",)
 
 
 class StructureMapper(BaseResourceMapper):
-
-    ENDPOINT = "structures"
 
     LENGTH_ALIASES = (
         ("elements", "nelements"),
@@ -13,3 +12,4 @@ class StructureMapper(BaseResourceMapper):
         ("cartesian_site_positions", "nsites"),
         ("species_at_sites", "nsites"),
     )
+    ENTRY_RESOURCE_CLASS = StructureResource

--- a/optimade/server/routers/utils.py
+++ b/optimade/server/routers/utils.py
@@ -2,7 +2,7 @@
 import re
 import urllib
 from datetime import datetime
-from typing import Union, List, Dict
+from typing import Union, List, Dict, Set
 
 from fastapi import HTTPException, Request
 from starlette.datastructures import URL as StarletteURL
@@ -63,7 +63,9 @@ def meta_values(
 
 
 def handle_response_fields(
-    results: Union[List[EntryResource], EntryResource], exclude_fields: set
+    results: Union[List[EntryResource], EntryResource],
+    exclude_fields: Set[str],
+    include_fields: Set[str],
 ) -> dict:
     """Handle query parameter ``response_fields``
 
@@ -71,26 +73,28 @@ def handle_response_fields(
     This is due to all other top-level fields are REQUIRED in the response.
 
     :param exclude_fields: Fields under ``attributes`` to be excluded from the response.
+    :param include_fields: Fields under `attributes` that were requested that should be
+        set to null if missing in the entry.
     """
     if not isinstance(results, list):
         results = [results]
 
     new_results = []
     while results:
-        entry = results.pop(0)
+        new_entry = results.pop(0).dict(exclude_unset=True)
 
-        # TODO: re-enable exclude_unset when proper handling of known/unknown fields
-        # has been implemented (relevant issue: https://github.com/Materials-Consortia/optimade-python-tools/issues/263)
-        # Have to handle top level fields explicitly here for now
-        new_entry = entry.dict(exclude_unset=False)
-        for field in ("relationships", "links", "meta", "type", "id"):
-            if field in new_entry and new_entry[field] is None:
-                del new_entry[field]
-
+        # Remove fields excluded by their omission in `reponse_fields`
         for field in exclude_fields:
             if field in new_entry["attributes"]:
                 del new_entry["attributes"][field]
+
+        # Include missing fields that were requested in `response_fields`
+        for field in include_fields:
+            if field not in new_entry["attributes"]:
+                new_entry["attributes"][field] = None
+
         new_results.append(new_entry)
+
     return new_results
 
 
@@ -164,7 +168,7 @@ def get_included_relationships(
         )
 
         # still need to handle pagination
-        ref_results, _, _, _ = ENTRY_COLLECTIONS[entry_type].find(params)
+        ref_results, _, _, _, _ = ENTRY_COLLECTIONS[entry_type].find(params)
         included[entry_type] = ref_results
 
     # flatten dict by endpoint to list
@@ -201,7 +205,13 @@ def get_entries(
     """Generalized /{entry} endpoint getter"""
     from optimade.server.routers import ENTRY_COLLECTIONS
 
-    results, data_returned, more_data_available, fields = collection.find(params)
+    (
+        results,
+        data_returned,
+        more_data_available,
+        fields,
+        include_fields,
+    ) = collection.find(params)
 
     include = []
     if getattr(params, "include", False):
@@ -219,8 +229,8 @@ def get_entries(
     else:
         links = ToplevelLinks(next=None)
 
-    if fields:
-        results = handle_response_fields(results, fields)
+    if fields or include_fields:
+        results = handle_response_fields(results, fields, include_fields)
 
     return response(
         links=links,
@@ -245,7 +255,13 @@ def get_single_entry(
     from optimade.server.routers import ENTRY_COLLECTIONS
 
     params.filter = f'id="{entry_id}"'
-    results, data_returned, more_data_available, fields = collection.find(params)
+    (
+        results,
+        data_returned,
+        more_data_available,
+        fields,
+        include_fields,
+    ) = collection.find(params)
 
     include = []
     if getattr(params, "include", False):
@@ -260,8 +276,8 @@ def get_single_entry(
 
     links = ToplevelLinks(next=None)
 
-    if fields and results is not None:
-        results = handle_response_fields(results, fields)[0]
+    if fields or include_fields and results is not None:
+        results = handle_response_fields(results, fields, include_fields)[0]
 
     return response(
         links=links,

--- a/optimade/server/routers/utils.py
+++ b/optimade/server/routers/utils.py
@@ -66,15 +66,21 @@ def handle_response_fields(
     results: Union[List[EntryResource], EntryResource],
     exclude_fields: Set[str],
     include_fields: Set[str],
-) -> dict:
-    """Handle query parameter ``response_fields``
+) -> List[dict]:
+    """Handle query parameter `response_fields`.
 
-    It is assumed that all fields are under ``attributes``.
+    It is assumed that all fields are under `attributes`.
     This is due to all other top-level fields are REQUIRED in the response.
 
-    :param exclude_fields: Fields under ``attributes`` to be excluded from the response.
-    :param include_fields: Fields under `attributes` that were requested that should be
-        set to null if missing in the entry.
+    Parameters:
+        exclude_fields: Fields under `attributes` to be excluded from the response.
+        include_fields: Fields under `attributes` that were requested that should be
+            set to null if missing in the entry.
+
+    Returns:
+        List of resulting resources as dictionaries after pruning according to
+        the `response_fields` OPTIMADE URL query parameter.
+
     """
     if not isinstance(results, list):
         results = [results]
@@ -83,7 +89,7 @@ def handle_response_fields(
     while results:
         new_entry = results.pop(0).dict(exclude_unset=True)
 
-        # Remove fields excluded by their omission in `reponse_fields`
+        # Remove fields excluded by their omission in `response_fields`
         for field in exclude_fields:
             if field in new_entry["attributes"]:
                 del new_entry["attributes"][field]

--- a/optimade/server/schemas.py
+++ b/optimade/server/schemas.py
@@ -6,7 +6,9 @@ ENTRY_INFO_SCHEMAS = {
 }
 
 
-def retrieve_queryable_properties(schema: dict, queryable_properties: list) -> dict:
+def retrieve_queryable_properties(
+    schema: dict, queryable_properties: list = None
+) -> dict:
     """Recurisvely loops through the schema of a pydantic model and
     resolves all references, returning a dictionary of all the
     OPTIMADE-queryable properties of that model.
@@ -23,7 +25,7 @@ def retrieve_queryable_properties(schema: dict, queryable_properties: list) -> d
     """
     properties = {}
     for name, value in schema["properties"].items():
-        if name in queryable_properties:
+        if not queryable_properties or name in queryable_properties:
             if "$ref" in value:
                 path = value["$ref"].split("/")[1:]
                 sub_schema = schema.copy()
@@ -44,7 +46,7 @@ def retrieve_queryable_properties(schema: dict, queryable_properties: list) -> d
                 properties[name]["sortable"] = value.get("sortable", True)
                 # Try to get OpenAPI-specific "format" if possible, else get "type"; a mandatory OpenAPI key.
                 properties[name]["type"] = DataType.from_json_type(
-                    value.get("format", value["type"])
+                    value.get("format", value.get("type"))
                 )
 
     return properties

--- a/optimade/server/schemas.py
+++ b/optimade/server/schemas.py
@@ -9,7 +9,7 @@ ENTRY_INFO_SCHEMAS = {
 def retrieve_queryable_properties(
     schema: dict, queryable_properties: list = None
 ) -> dict:
-    """Recurisvely loops through the schema of a pydantic model and
+    """Recursively loops through the schema of a pydantic model and
     resolves all references, returning a dictionary of all the
     OPTIMADE-queryable properties of that model.
 

--- a/optimade/server/warnings.py
+++ b/optimade/server/warnings.py
@@ -49,3 +49,10 @@ class TimestampNotRFCCompliant(OptimadeWarning):
     RFC 3339 compliant. This may cause undefined behaviour in the query results.
 
     """
+
+
+class UnknownProviderProperty(OptimadeWarning):
+    """A provider-specific property has been requested via `response_fields` or as in a `filter` that is not
+    recognised by this implementation.
+
+    """

--- a/tests/filtertransformers/test_base.py
+++ b/tests/filtertransformers/test_base.py
@@ -1,0 +1,27 @@
+from optimade.filtertransformers import BaseTransformer
+
+
+def test_quantity_builder(mapper):
+    class DummyTransformer(BaseTransformer):
+        pass
+
+    class AwkwardMapper(mapper("StructureMapper")):
+
+        ALIASES = (("elements", "my_elements"), ("nelements", "nelem"))
+        LENGTH_ALIASES = (
+            ("chemsys", "nelements"),
+            ("cartesian_site_positions", "nsites"),
+            ("elements", "nelements"),
+        )
+        PROVIDER_FIELDS = ("chemsys",)
+
+    m = AwkwardMapper
+    t = DummyTransformer(mapper=m)
+
+    assert "_exmpl_chemsys" in t.quantities
+    assert t.quantities["_exmpl_chemsys"].name == "_exmpl_chemsys"
+    assert t.quantities["_exmpl_chemsys"].backend_field == "chemsys"
+    assert t.quantities["_exmpl_chemsys"].length_quantity.name == "nelements"
+    assert t.quantities["_exmpl_chemsys"].length_quantity.backend_field == "nelem"
+
+    assert t.quantities["elements"].length_quantity.backend_field == "nelem"

--- a/tests/filtertransformers/test_elasticsearch.py
+++ b/tests/filtertransformers/test_elasticsearch.py
@@ -62,6 +62,7 @@ test_queries = [
     ("nelements > 1 OR elements LENGTH = 1 AND nelements = 2", 4),
     ("(nelements > 1 OR elements LENGTH = 1) AND nelements = 2", 3),
     ("NOT elements LENGTH = 1", 3),
+    ("_exmpl2_field = 2", 1),
 ]
 
 
@@ -75,7 +76,7 @@ def test_parse_n_transform(query, parser, transformer):
 def test_bad_queries(parser, transformer):
     filter_ = "unknown_field = 0"
     with pytest.raises(
-        Exception, match="'unknown_field' is not a searchable quantity"
+        Exception, match="'unknown_field' is not a known or searchable quantity"
     ) as exc_info:
         transformer.transform(parser.parse(filter_))
     assert exc_info.type.__name__ == "VisitError"
@@ -83,6 +84,13 @@ def test_bad_queries(parser, transformer):
     filter_ = "dimension_types LENGTH = 0"
     with pytest.raises(
         Exception, match="LENGTH is not supported for 'dimension_types'"
+    ) as exc_info:
+        transformer.transform(parser.parse(filter_))
+    assert exc_info.type.__name__ == "VisitError"
+
+    filter_ = "_exmpl_field = 1"
+    with pytest.raises(
+        Exception, match="'_exmpl_field' is not a known or searchable quantity"
     ) as exc_info:
         transformer.transform(parser.parse(filter_))
     assert exc_info.type.__name__ == "VisitError"

--- a/tests/filtertransformers/test_mongo.py
+++ b/tests/filtertransformers/test_mongo.py
@@ -506,7 +506,11 @@ class TestMongoTransformer:
         from optimade.filtertransformers.mongo import MongoTransformer
 
         class MyMapper(mapper("StructureMapper")):
-            ALIASES = (("elements", "my_elements"), ("nelements", "nelem"))
+            ALIASES = (
+                ("elements", "my_elements"),
+                ("nelements", "nelem"),
+                ("elements_ratios", "ratios"),
+            )
             LENGTH_ALIASES = (
                 ("chemsys", "nelements"),
                 ("cartesian_site_positions", "nsites"),
@@ -530,6 +534,11 @@ class TestMongoTransformer:
         assert transformer.transform(
             parser.parse("cartesian_site_positions LENGTH 3")
         ) == {"nsites": 3}
+
+        assert transformer.transform(parser.parse("elements_ratios LENGTH 3")) == {
+            "ratios": {"$size": 3, "$exists": True}
+        }
+
         assert transformer.transform(
             parser.parse("cartesian_site_positions LENGTH >= 10")
         ) == {"nsites": {"$gte": 10}}

--- a/tests/filtertransformers/test_mongo.py
+++ b/tests/filtertransformers/test_mongo.py
@@ -291,7 +291,7 @@ class TestMongoTransformer:
 
         assert t.transform(p.parse('structures.id HAS ONLY "dummy/2019"')) == {
             "$and": [
-                {"relationships.structures.data": {"$size": 1, "$exists": True}},
+                {"relationships.structures.data": {"$size": 1}},
                 {"relationships.structures.data.id": {"$all": ["dummy/2019"]}},
             ]
         }
@@ -307,7 +307,6 @@ class TestMongoTransformer:
                         {
                             "relationships.structures.data": {
                                 "$size": 1,
-                                "$exists": True,
                             }
                         },
                         {"relationships.structures.data.id": {"$all": ["dummy/2019"]}},
@@ -346,9 +345,7 @@ class TestMongoTransformer:
         with pytest.raises(VisitError, match="not implemented"):
             self.transform("list HAS ANY > 3, < 6")
 
-        assert self.transform("list LENGTH 3") == {
-            "list": {"$size": 3, "$exists": True}
-        }
+        assert self.transform("list LENGTH 3") == {"list": {"$size": 3}}
 
         with pytest.raises(VisitError):
             self.transform("list:list HAS >=2:<=5")
@@ -461,7 +458,7 @@ class TestMongoTransformer:
             "cartesian_site_positions.3": {"$exists": False}
         }
         assert self.transform("cartesian_site_positions LENGTH 3") == {
-            "cartesian_site_positions": {"$size": 3, "$exists": True}
+            "cartesian_site_positions": {"$size": 3}
         }
         assert self.transform("cartesian_site_positions LENGTH >= 10") == {
             "cartesian_site_positions.10": {"$exists": True}
@@ -536,7 +533,7 @@ class TestMongoTransformer:
         ) == {"nsites": 3}
 
         assert transformer.transform(parser.parse("elements_ratios LENGTH 3")) == {
-            "ratios": {"$size": 3, "$exists": True}
+            "ratios": {"$size": 3}
         }
 
         assert transformer.transform(
@@ -612,7 +609,7 @@ class TestMongoTransformer:
     def test_list_properties(self):
         """Test the HAS ALL, ANY and optional ONLY queries."""
         assert self.transform('elements HAS ONLY "H","He","Ga","Ta"') == {
-            "elements": {"$all": ["H", "He", "Ga", "Ta"], "$size": 4, "$exists": True}
+            "elements": {"$all": ["H", "He", "Ga", "Ta"], "$size": 4}
         }
 
         assert self.transform('elements HAS ANY "H","He","Ga","Ta"') == {
@@ -634,7 +631,6 @@ class TestMongoTransformer:
                     "elements": {
                         "$all": ["H", "He", "Ga", "Ta"],
                         "$size": 4,
-                        "$exists": True,
                     }
                 },
                 {"elements": {"$in": ["H", "He", "Ga", "Ta"]}},

--- a/tests/filtertransformers/test_mongo.py
+++ b/tests/filtertransformers/test_mongo.py
@@ -317,6 +317,19 @@ class TestMongoTransformer:
             ],
         }
 
+    def test_other_provider_fields(self, mapper):
+        """Test that fields from other providers generate
+        queries that treat the value of the field as `null`.
+
+        """
+        from optimade.filtertransformers.mongo import MongoTransformer
+
+        t = MongoTransformer(mapper=mapper("StructureMapper"))
+        p = LarkParser(version=self.version, variant=self.variant)
+        assert t.transform(p.parse("_other_provider_field > 1")) == {
+            "_other_provider_field": {"$gt": 1}
+        }
+
     def test_not_implemented(self):
         """Test that list properties that are currently not implemented
         give a sensible response.

--- a/tests/filtertransformers/test_mongo.py
+++ b/tests/filtertransformers/test_mongo.py
@@ -35,12 +35,14 @@ class TestMongoTransformer:
         with pytest.raises(BadRequest):
             self.transform("BadLuck IS KNOWN")  # contains upper-case letters
 
+    def test_provider_property_name(self):
         # database-provider-specific prefixes
         assert self.transform("_exmpl_formula_sum = 1") == {
             "_exmpl_formula_sum": {"$eq": 1}
         }
         assert self.transform("_exmpl_band_gap = 1") == {"_exmpl_band_gap": {"$eq": 1}}
 
+    def test_nested_property_names(self):
         # Nested property names
         assert self.transform("identifier1.identifierd2 = 42") == {
             "identifier1.identifierd2": {"$eq": 42}
@@ -260,34 +262,44 @@ class TestMongoTransformer:
         with pytest.raises(VisitError):
             self.transform('"some string" > "some other string"')
 
-    def test_filtering_on_relationships(self):
+    def test_filtering_on_relationships(self, mapper):
         """Test the nested properties with special names
         like "structures", "references" etc. are applied
         to the relationships field.
 
         """
+        from optimade.filtertransformers.mongo import MongoTransformer
 
-        assert self.transform('references.id HAS "dummy/2019"') == {
+        t = MongoTransformer(mapper=mapper("StructureMapper"))
+        p = LarkParser(version=self.version, variant=self.variant)
+
+        assert t.transform(p.parse('references.id HAS "dummy/2019"')) == {
             "relationships.references.data.id": {"$in": ["dummy/2019"]}
         }
 
-        assert self.transform('structures.id HAS ANY "dummy/2019", "dijkstra1968"') == {
+        assert t.transform(
+            p.parse('structures.id HAS ANY "dummy/2019", "dijkstra1968"')
+        ) == {
             "relationships.structures.data.id": {"$in": ["dummy/2019", "dijkstra1968"]}
         }
 
-        assert self.transform('structures.id HAS ALL "dummy/2019", "dijkstra1968"') == {
+        assert t.transform(
+            p.parse('structures.id HAS ALL "dummy/2019", "dijkstra1968"')
+        ) == {
             "relationships.structures.data.id": {"$all": ["dummy/2019", "dijkstra1968"]}
         }
 
-        assert self.transform('structures.id HAS ONLY "dummy/2019"') == {
+        assert t.transform(p.parse('structures.id HAS ONLY "dummy/2019"')) == {
             "$and": [
                 {"relationships.structures.data": {"$size": 1}},
                 {"relationships.structures.data.id": {"$all": ["dummy/2019"]}},
             ]
         }
 
-        assert self.transform(
-            'structures.id HAS ONLY "dummy/2019" AND structures.id HAS "dummy/2019"'
+        assert t.transform(
+            p.parse(
+                'structures.id HAS ONLY "dummy/2019" AND structures.id HAS "dummy/2019"'
+            )
         ) == {
             "$and": [
                 {
@@ -346,7 +358,7 @@ class TestMongoTransformer:
     def test_list_length_aliases(self, mapper):
         from optimade.filtertransformers.mongo import MongoTransformer
 
-        transformer = MongoTransformer(mapper=mapper("StructureMapper")())
+        transformer = MongoTransformer(mapper=mapper("StructureMapper"))
         parser = LarkParser(version=self.version, variant=self.variant)
 
         assert transformer.transform(parser.parse("elements LENGTH 3")) == {
@@ -411,7 +423,7 @@ class TestMongoTransformer:
         class MyMapper(mapper("StructureMapper")):
             ALIASES = (("last_modified", "ctime"),)
 
-        transformer = MongoTransformer(mapper=MyMapper())
+        transformer = MongoTransformer(mapper=MyMapper)
         parser = LarkParser(version=self.version, variant=self.variant)
 
         assert transformer.transform(
@@ -447,7 +459,7 @@ class TestMongoTransformer:
         class MyMapper(mapper("StructureMapper")):
             ALIASES = (("immutable_id", "_id"),)
 
-        transformer = MongoTransformer(mapper=MyMapper())
+        transformer = MongoTransformer(mapper=MyMapper)
         parser = LarkParser(version=self.version, variant=self.variant)
 
         assert transformer.transform(
@@ -482,7 +494,8 @@ class TestMongoTransformer:
             )
             PROVIDER_FIELDS = ("chemsys",)
 
-        transformer = MongoTransformer(mapper=MyMapper())
+        m = MyMapper
+        transformer = MongoTransformer(mapper=m)
         parser = LarkParser(version=self.version, variant=self.variant)
 
         assert transformer.transform(
@@ -492,7 +505,7 @@ class TestMongoTransformer:
             parser.parse("cartesian_site_positions LENGTH < 3")
         ) == {"nsites": {"$lt": 3}}
         assert transformer.transform(
-            parser.parse("cartesian_site_positions LENGTH 3")
+            parser.parse("cartesian_site_positions LENGTH = 3")
         ) == {"nsites": 3}
         assert transformer.transform(
             parser.parse("cartesian_site_positions LENGTH 3")
@@ -515,48 +528,56 @@ class TestMongoTransformer:
             "my_elements": {"$in": ["Ag"]}
         }
 
-        assert transformer.transform(parser.parse("chemsys LENGTH 3")) == {"nelem": 3}
+        assert transformer.transform(parser.parse("_exmpl_chemsys LENGTH 3")) == {
+            "nelem": 3
+        }
 
     def test_aliases(self, mapper):
         """Test that valid aliases are allowed, but do not affect r-values."""
         from optimade.filtertransformers.mongo import MongoTransformer
 
-        class MyStructureMapper(mapper("BaseResourceMapper")):
+        class MyStructureMapper(mapper("StructureMapper")):
             ALIASES = (
                 ("elements", "my_elements"),
                 ("A", "D"),
+                ("property_a", "D"),
                 ("B", "E"),
                 ("C", "F"),
                 ("_exmpl_nested_field", "nested_field"),
             )
 
-        mapper = MyStructureMapper()
+            PROVIDER_FIELDS = ("D", "E", "F", "nested_field")
+
+        mapper = MyStructureMapper
         t = MongoTransformer(mapper=mapper)
+        p = LarkParser(version=self.version, variant=self.variant)
 
         assert mapper.get_backend_field("elements") == "my_elements"
-
-        test_filter = {"elements": {"$in": ["A", "B", "C"]}}
-        assert t.postprocess(test_filter) == {"my_elements": {"$in": ["A", "B", "C"]}}
-        test_filter = {"$and": [{"elements": {"$in": ["A", "B", "C"]}}]}
-        assert t.postprocess(test_filter) == {
-            "$and": [{"my_elements": {"$in": ["A", "B", "C"]}}]
+        test_filter = 'elements HAS "A"'
+        assert t.transform(p.parse(test_filter)) == {"my_elements": {"$in": ["A"]}}
+        test_filter = 'elements HAS ANY "A","B","C" AND elements HAS "D"'
+        assert t.transform(p.parse(test_filter)) == {
+            "$and": [
+                {"my_elements": {"$in": ["A", "B", "C"]}},
+                {"my_elements": {"$in": ["D"]}},
+            ]
         }
-        test_filter = {"elements": "A"}
-        assert t.postprocess(test_filter) == {"my_elements": "A"}
-        test_filter = ["A", "B", "C"]
-        assert t.postprocess(test_filter) == ["A", "B", "C"]
+        test_filter = 'elements = "A"'
+        assert t.transform(p.parse(test_filter)) == {"my_elements": {"$eq": "A"}}
+        test_filter = 'property_a HAS "B"'
+        assert t.transform(p.parse(test_filter)) == {"D": {"$in": ["B"]}}
 
-        test_filter = ["A", "elements", "C"]
-        assert t.postprocess(test_filter) == ["A", "elements", "C"]
-
-        test_filter = {"_exmpl_nested_field.sub_property": {"$gt": 1234.5}}
-        assert t.postprocess(test_filter) == {
+        test_filter = "_exmpl_nested_field.sub_property > 1234.5"
+        assert t.transform(p.parse(test_filter)) == {
             "nested_field.sub_property": {"$gt": 1234.5}
         }
 
-        test_filter = {"_exmpl_nested_field.sub_property.x": {"$exists": False}}
-        assert t.postprocess(test_filter) == {
-            "nested_field.sub_property.x": {"$exists": False}
+        test_filter = "_exmpl_nested_field.sub_property.x IS UNKNOWN"
+        assert t.transform(p.parse(test_filter)) == {
+            "$or": [
+                {"nested_field.sub_property.x": {"$exists": False}},
+                {"nested_field.sub_property.x": {"$eq": None}},
+            ]
         }
 
     def test_list_properties(self):

--- a/tests/filtertransformers/test_mongo.py
+++ b/tests/filtertransformers/test_mongo.py
@@ -291,7 +291,7 @@ class TestMongoTransformer:
 
         assert t.transform(p.parse('structures.id HAS ONLY "dummy/2019"')) == {
             "$and": [
-                {"relationships.structures.data": {"$size": 1}},
+                {"relationships.structures.data": {"$size": 1, "$exists": True}},
                 {"relationships.structures.data.id": {"$all": ["dummy/2019"]}},
             ]
         }
@@ -304,7 +304,12 @@ class TestMongoTransformer:
             "$and": [
                 {
                     "$and": [
-                        {"relationships.structures.data": {"$size": 1}},
+                        {
+                            "relationships.structures.data": {
+                                "$size": 1,
+                                "$exists": True,
+                            }
+                        },
                         {"relationships.structures.data.id": {"$all": ["dummy/2019"]}},
                     ]
                 },
@@ -328,7 +333,9 @@ class TestMongoTransformer:
         with pytest.raises(VisitError, match="not implemented"):
             self.transform("list HAS ANY > 3, < 6")
 
-        assert self.transform("list LENGTH 3") == {"list": {"$size": 3}}
+        assert self.transform("list LENGTH 3") == {
+            "list": {"$size": 3, "$exists": True}
+        }
 
         with pytest.raises(VisitError):
             self.transform("list:list HAS >=2:<=5")
@@ -441,7 +448,7 @@ class TestMongoTransformer:
             "cartesian_site_positions.3": {"$exists": False}
         }
         assert self.transform("cartesian_site_positions LENGTH 3") == {
-            "cartesian_site_positions": {"$size": 3}
+            "cartesian_site_positions": {"$size": 3, "$exists": True}
         }
         assert self.transform("cartesian_site_positions LENGTH >= 10") == {
             "cartesian_site_positions.10": {"$exists": True}
@@ -583,7 +590,7 @@ class TestMongoTransformer:
     def test_list_properties(self):
         """Test the HAS ALL, ANY and optional ONLY queries."""
         assert self.transform('elements HAS ONLY "H","He","Ga","Ta"') == {
-            "elements": {"$all": ["H", "He", "Ga", "Ta"], "$size": 4}
+            "elements": {"$all": ["H", "He", "Ga", "Ta"], "$size": 4, "$exists": True}
         }
 
         assert self.transform('elements HAS ANY "H","He","Ga","Ta"') == {
@@ -601,7 +608,13 @@ class TestMongoTransformer:
             "$and": [
                 {"elements": {"$in": ["H"]}},
                 {"elements": {"$all": ["H", "He", "Ga", "Ta"]}},
-                {"elements": {"$all": ["H", "He", "Ga", "Ta"], "$size": 4}},
+                {
+                    "elements": {
+                        "$all": ["H", "He", "Ga", "Ta"],
+                        "$size": 4,
+                        "$exists": True,
+                    }
+                },
                 {"elements": {"$in": ["H", "He", "Ga", "Ta"]}},
             ]
         }

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, Dict
 
 import pytest
 
@@ -109,6 +109,7 @@ def check_response(get_good_response):
         page_limit: int = CONFIG.page_limit,
         expected_return: int = None,
         expected_as_is: bool = False,
+        expected_warnings: List[Dict[str, str]] = None,
         server: Union[str, OptimadeTestClient] = "regular",
     ):
         response = get_good_response(request, server)
@@ -127,6 +128,16 @@ def check_response(get_good_response):
             assert expected_ids[:page_limit] == response_ids
         else:
             assert expected_ids == response_ids
+
+        expected_warnings = expected_warnings if expected_warnings else []
+        if expected_warnings:
+            assert "warnings" in response["meta"]
+            assert len(expected_warnings) == len(response["meta"]["warnings"])
+            for ind, warn in enumerate(expected_warnings):
+                for key in warn:
+                    assert response["meta"]["warnings"][ind][key] == warn[key]
+        else:
+            assert "warnings" not in response["meta"]
 
     return inner
 

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -129,7 +129,7 @@ def check_response(get_good_response):
         else:
             assert expected_ids == response_ids
 
-        expected_warnings = expected_warnings if expected_warnings else []
+        expected_warnings = expected_warnings or []
         if expected_warnings:
             assert "warnings" in response["meta"]
             assert len(expected_warnings) == len(response["meta"]["warnings"])

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -129,7 +129,6 @@ def check_response(get_good_response):
         else:
             assert expected_ids == response_ids
 
-        expected_warnings = expected_warnings or []
         if expected_warnings:
             assert "warnings" in response["meta"]
             assert len(expected_warnings) == len(response["meta"]["warnings"])

--- a/tests/server/query_params/conftest.py
+++ b/tests/server/query_params/conftest.py
@@ -74,10 +74,10 @@ def check_required_fields_response(get_good_response):
         expected_fields |= (
             get_mapper[endpoint].get_required_fields() - known_unused_fields
         )
-        expected_fields.add("attributes")
         request = f"/{endpoint}?response_fields={','.join(expected_fields)}"
 
         response = get_good_response(request, server)
+        expected_fields.add("attributes")
 
         response_fields = set()
         for entry in response["data"]:

--- a/tests/server/query_params/test_filter.py
+++ b/tests/server/query_params/test_filter.py
@@ -149,7 +149,7 @@ def test_list_length_comparisons_aliased(check_response, check_error_response):
             request,
             expected_status=501,
             expected_title="NotImplementedError",
-            expected_detail="LENGTH is not supported for nsites",
+            expected_detail="LENGTH is not supported for 'nsites'",
         )
     else:
         check_response(request, expected_ids)
@@ -189,6 +189,10 @@ def test_list_has_only(check_response):
     check_response(request, expected_ids)
 
     request = '/structures?filter=elements HAS ONLY "Ac"'
+    expected_ids = ["mpf_1"]
+    check_response(request, expected_ids)
+
+    request = '/structures?filter=elements HAS ONLY "Ac" AND nelements IS KNOWN'
     expected_ids = ["mpf_1"]
     check_response(request, expected_ids)
 
@@ -378,9 +382,9 @@ def test_filter_on_relationships(check_response, check_error_response):
     if CONFIG.database_backend == SupportedBackend.ELASTIC:
         check_error_response(
             request,
-            expected_status=400,
-            expected_title="Bad Request",
-            expected_detail="references is not a searchable quantity",
+            expected_status=501,
+            expected_title="NotImplementedError",
+            expected_detail="Unable to filter on relationships with type 'references'",
         )
         pytest.xfail("Elasticsearch backend does not support relationship filtering.")
     check_response(request, expected_ids)

--- a/tests/server/query_params/test_filter.py
+++ b/tests/server/query_params/test_filter.py
@@ -425,6 +425,13 @@ def test_filter_on_relationships(check_response, check_error_response):
     )
 
 
+@pytest.mark.xfail(
+    CONFIG.database_backend == SupportedBackend.MONGOMOCK,
+    reason=(
+        "mongomock<=3.22.1 has a bug that causes {'$size': 1} queries on missing fields to match all documents: "
+        "(https://github.com/mongomock/mongomock/issues/710). This check can be removed once mongomock 3.22.2 has been released."
+    ),
+)
 def test_filter_on_unknown_fields(check_response, check_error_response):
 
     request = "/structures?filter=unknown_field = 1"

--- a/tests/server/query_params/test_response_fields.py
+++ b/tests/server/query_params/test_response_fields.py
@@ -25,3 +25,43 @@ def test_required_fields_structures(check_required_fields_response):
     non_used_top_level_fields = {"links"}
     expected_fields = {"elements", "nelements"}
     check_required_fields_response(endpoint, non_used_top_level_fields, expected_fields)
+
+
+def test_unknown_field_structures(
+    check_required_fields_response, check_error_response, check_response, structures
+):
+    """Check that unknown fields are returned as `null` in entries."""
+    endpoint = "structures"
+    non_used_top_level_fields = {"links"}
+
+    expected_fields = {"_optimade_field"}
+    check_required_fields_response(endpoint, non_used_top_level_fields, expected_fields)
+
+    expected_fields = {"optimade_field"}
+    check_error_response(
+        request=f"/{endpoint}?response_fields={','.join(expected_fields)}",
+        expected_status=400,
+        expected_title="Bad Request",
+        expected_detail="Unrecognised OPTIMADE field(s) in requested `response_fields`: {'optimade_field'}.",
+    )
+
+    expected_fields = {"_exmpl_optimade_field"}
+    expected_ids = [doc["task_id"] for doc in structures]
+    expected_warnings = [
+        {
+            "title": "UnknownProviderProperty",
+            "detail": "Unrecognised field(s) for this provider requested in `response_fields`: {'_exmpl_optimade_field'}.",
+        }
+    ]
+    check_response(
+        request=f"/{endpoint}?response_fields={','.join(expected_fields)}",
+        expected_ids=expected_ids,
+        expected_warnings=expected_warnings,
+    )
+
+    expected_fields = {"_exmpl123_optimade_field"}
+    expected_ids = [doc["task_id"] for doc in structures]
+    check_response(
+        request=f"/{endpoint}?response_fields={','.join(expected_fields)}",
+        expected_ids=expected_ids,
+    )

--- a/tests/server/routers/test_structures.py
+++ b/tests/server/routers/test_structures.py
@@ -183,3 +183,27 @@ class TestStructuresWithNullFieldsMatchUnknownFilter(RegularEndpointTests):
     def test_structures_endpoint_data(self):
         """Check that all structures are returned."""
         assert len(self.json_response["data"]) == 17
+
+
+class TestStructuresWithUnknownResponseFields(RegularEndpointTests):
+    """Tests that structures with e.g., `'assemblies':null` do get
+    returned for queries testing for "UNKNOWN" fields.
+
+    """
+
+    request_str = "/structures?filter=assemblies IS UNKNOWN&response_fields=assemblies,_other_provider_field,chemical_formula_anonymous"
+    response_cls = StructureResponseMany
+
+    def test_structures_endpoint_data(self):
+        """Check that all structures are returned."""
+        assert len(self.json_response["data"]) == 17
+        keys = ("_other_provider_field", "assemblies", "chemical_formula_anonymous")
+        for key in keys:
+            assert all(key in doc["attributes"] for doc in self.json_response["data"])
+        assert all(
+            doc["attributes"]["_other_provider_field"] is None
+            for doc in self.json_response["data"]
+        )
+        assert all(
+            len(doc["attributes"]) == len(keys) for doc in self.json_response["data"]
+        )


### PR DESCRIPTION
This PR lays the groundwork for dealing with some outstanding issues:

1. Returning `None` for "unknown unknown" properties (e.g. `_other_implementation_band_gap`) (closes #516) and the raising of errors for "known unknown" properties in filters (e.g. `unprefixed_optimade_field`) (closes #263).
2. Abstraction of the aliasing code so that "Quantities" can be defined independent of the backend (closes #743).
3. Definition of provider fields via pydantic models so that they can be filtered appropriately
4. ~MongoDB `$size: 1` queries match non-existent fields (closes #807)~ Removed, as this is actually a mongomock bug

It does so by:

- [x] Moving aliasing code from individual transformers out to the base transformer, by making use of the `Quantity` classes defined for elasticsearch.
- [x] Adding a `ENTRY_RESOURCE_ATTRIBUTE_CLASS` class attribute to the mappers, such that model schemas can be accessed.

Still to-do:
- [x] Add passthrough for "other provider" fields so that querying for `_exmpl2_band_gap` does not fail for provider `_exmpl1_`.
- [x] Emit warning if provider prefix is unknown and allow through if provider is registered with OPTIMADE
    - This is done via the providers submodule (rather than the get_providers) request. We could consider making this a configuration option instead.
- [x] Handle unknown `response_fields`
    - Return any requested, missing field as `None` if present in `response_fields`
    - Raise an error if an unknown, unprefixed field is requested in `response_fields` (e.g. `fractional_coordinates`)
    - Emit a warning if a provider-specific field is requested that does not exist (e.g. `_exmpl_test`)
    - Passthrough other-provider-specific fields as if they were missing from the entry (i.e. replace them with `null`)