### PR TITLE
Test all setup.py deps versions for every pull request, plus some deps updates

### DIFF
--- a/.github/workflows/deps_lint.yml
+++ b/.github/workflows/deps_lint.yml
@@ -294,7 +294,7 @@ jobs:
         pip install --upgrade setuptools requests
 
     - name: Install package
-      run: pip install -e .
+      run: pip install -e .[all]
 
     - name: Build source distribution
       run: python ./setup.py sdist

--- a/.github/workflows/deps_lint.yml
+++ b/.github/workflows/deps_lint.yml
@@ -294,7 +294,7 @@ jobs:
         pip install --upgrade setuptools requests
 
     - name: Install package
-      run: pip install -e .[all]
+      run: pip install -U -e .[all] --use-deprecated=legacy-resolver
 
     - name: Build source distribution
       run: python ./setup.py sdist

--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -1,5 +1,5 @@
 aiida-core==1.6.3
 ase==3.21.1
-numpy==1.20.2
+numpy==1.20.3
 pymatgen==2021.3.9
 jarvis-tools==2021.5.28

--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -2,4 +2,4 @@ aiida-core==1.6.3
 ase==3.21.1
 numpy==1.20.3
 pymatgen==2021.3.9
-jarvis-tools==2021.5.28
+jarvis-tools==2021.5.31

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ testing_deps = [
     "jsondiff~=1.3",
 ] + server_deps
 dev_deps = (
-    ["pylint~=2.8", "pre-commit~=2.31", "invoke~=1.5"]
+    ["pylint~=2.8", "pre-commit~=2.13", "invoke~=1.5"]
     + docs_deps
     + testing_deps
     + client_deps


### PR DESCRIPTION
Some dependencies were not updated correctly in #751, and this was not caught by the tests due to #834.

This PR fixes that, and also makes sure that ALL of the setup.py deps versions are tested in PR builds, not just the default install pathway (via `pip install -e .[all]`).

Closes #834.