### PR TITLE
Allow both Jinja2 v2 and v3

### DIFF
--- a/.github/workflows/deps_lint.yml
+++ b/.github/workflows/deps_lint.yml
@@ -294,7 +294,7 @@ jobs:
         pip install --upgrade setuptools requests
 
     - name: Install package
-      run: pip install -U -e .[all] --use-deprecated=legacy-resolver
+      run: pip install -U -e .[all]
 
     - name: Build source distribution
       run: python ./setup.py sdist

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ elastic_deps = ["elasticsearch-dsl~=6.4,<7.0"]
 mongo_deps = ["pymongo~=3.11", "mongomock~=3.22"]
 server_deps = [
     "uvicorn~=0.13.4",
-    "Jinja2~=3.0.1",
+    "Jinja2>=2.10,<4.0",
     "pyyaml~=5.1",  # Keep at pyyaml 5.1 for aiida-core support
 ] + mongo_deps
 


### PR DESCRIPTION
This is because AiiDA has the dependency `~=2.10`, while OPTIMADE also supports v3 of Jinja2.