### PR TITLE
Improve semver validation error messsage

### DIFF
--- a/optimade/models/utils.py
+++ b/optimade/models/utils.py
@@ -146,7 +146,7 @@ class SemanticVersion(str):
     def validate(cls, v: str):
         if not cls.regex.match(v):
             raise ValueError(
-                f"Unable to validate the version string {v!r} as a semantic version (<major.minor.patch>)."
+                f"Unable to validate the version string {v!r} as a semantic version (expected <major>.<minor>.<patch>)."
                 "See https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string for more information."
             )
 

--- a/optimade/models/utils.py
+++ b/optimade/models/utils.py
@@ -145,7 +145,10 @@ class SemanticVersion(str):
     @classmethod
     def validate(cls, v: str):
         if not cls.regex.match(v):
-            raise ValueError(f"Unable to validate version {v} as a semver.")
+            raise ValueError(
+                f"Unable to validate the version string {v!r} as a semantic version (<major.minor.patch>)."
+                "See https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string for more information."
+            )
 
         return v
 

--- a/tests/models/test_baseinfo.py
+++ b/tests/models/test_baseinfo.py
@@ -15,6 +15,8 @@ def test_available_api_versions():
     ]
     bad_versions = [
         {"url": "https://example.com/v0", "version": "v0.1.9"},
+        {"url": "https://example.com/v0", "version": "0.1"},
+        {"url": "https://example.com/v1", "version": "1.0"},
         {"url": "https://example.com/v1.0.2", "version": "v1.0.2"},
         {"url": "https://example.com/optimade/v1.2", "version": "v1.2.3"},
         {"url": "https://example.com/v1.0.0", "version": "1.asdfaf.0-rc55"},
@@ -48,7 +50,8 @@ def test_available_api_versions():
         with pytest.raises(ValueError) as exc:
             AvailableApiVersion(**data)
         assert (
-            f"Unable to validate version {data['version']} as a semver" in exc.exconly()
+            f"Unable to validate version string {data['version']!r} as a semantic version (<major>.<minor>.<patch>)"
+            in exc.exconly()
         ), f"SemVer validator not triggered as it should.\nException message: {exc.exconly()}.\nInputs: {data}"
 
     for data in bad_combos:

--- a/tests/models/test_baseinfo.py
+++ b/tests/models/test_baseinfo.py
@@ -50,7 +50,7 @@ def test_available_api_versions():
         with pytest.raises(ValueError) as exc:
             AvailableApiVersion(**data)
         assert (
-            f"Unable to validate version string {data['version']!r} as a semantic version (<major>.<minor>.<patch>)"
+            f"Unable to validate the version string {data['version']!r} as a semantic version (expected <major>.<minor>.<patch>)"
             in exc.exconly()
         ), f"SemVer validator not triggered as it should.\nException message: {exc.exconly()}.\nInputs: {data}"
 


### PR DESCRIPTION
Minor fix arising from some validation of AFLOW yesterday (that "1.0" is not a valid semver, and also that semver may not be well known as an abbreviation).