### PR TITLE
Update response model information for routes

### DIFF
--- a/openapi/index_openapi.json
+++ b/openapi/index_openapi.json
@@ -19,15 +19,77 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Response Get Info Info Get",
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/IndexInfoResponse"
-                    },
-                    {
-                      "$ref": "#/components/schemas/ErrorResponse"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/IndexInfoResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Not Implemented",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "553": {
+            "description": "Version Not Supported",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -216,25 +278,77 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Response Get Links Links Get",
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/LinksResponse"
-                    },
-                    {
-                      "$ref": "#/components/schemas/ErrorResponse"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/LinksResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
           },
           "422": {
-            "description": "Validation Error",
+            "description": "Unprocessable Entity",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Not Implemented",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "553": {
+            "description": "Version Not Supported",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -627,19 +741,6 @@
           }
         },
         "description": "an object containing references to the source of the error"
-      },
-      "HTTPValidationError": {
-        "title": "HTTPValidationError",
-        "type": "object",
-        "properties": {
-          "detail": {
-            "title": "Detail",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ValidationError"
-            }
-          }
-        }
       },
       "Implementation": {
         "title": "Implementation",
@@ -1739,32 +1840,6 @@
           }
         },
         "description": "A set of Links objects, possibly including pagination"
-      },
-      "ValidationError": {
-        "title": "ValidationError",
-        "required": [
-          "loc",
-          "msg",
-          "type"
-        ],
-        "type": "object",
-        "properties": {
-          "loc": {
-            "title": "Location",
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "msg": {
-            "title": "Message",
-            "type": "string"
-          },
-          "type": {
-            "title": "Error Type",
-            "type": "string"
-          }
-        }
       },
       "Warnings": {
         "title": "Warnings",

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -19,15 +19,77 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Response Get Info Info Get",
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/InfoResponse"
-                    },
-                    {
-                      "$ref": "#/components/schemas/ErrorResponse"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/InfoResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Not Implemented",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "553": {
+            "description": "Version Not Supported",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -59,25 +121,77 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Response Get Entry Info Info  Entry  Get",
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/EntryInfoResponse"
-                    },
-                    {
-                      "$ref": "#/components/schemas/ErrorResponse"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/EntryInfoResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
           },
           "422": {
-            "description": "Validation Error",
+            "description": "Unprocessable Entity",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Not Implemented",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "553": {
+            "description": "Version Not Supported",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -266,25 +380,77 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Response Get Links Links Get",
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/LinksResponse"
-                    },
-                    {
-                      "$ref": "#/components/schemas/ErrorResponse"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/LinksResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
           },
           "422": {
-            "description": "Validation Error",
+            "description": "Unprocessable Entity",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Not Implemented",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "553": {
+            "description": "Version Not Supported",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -473,25 +639,77 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Response Get References References Get",
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/ReferenceResponseMany"
-                    },
-                    {
-                      "$ref": "#/components/schemas/ErrorResponse"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/ReferenceResponseMany"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
           },
           "422": {
-            "description": "Validation Error",
+            "description": "Unprocessable Entity",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Not Implemented",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "553": {
+            "description": "Version Not Supported",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -586,25 +804,77 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Response Get Single Reference References  Entry Id  Get",
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/ReferenceResponseOne"
-                    },
-                    {
-                      "$ref": "#/components/schemas/ErrorResponse"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/ReferenceResponseOne"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
           },
           "422": {
-            "description": "Validation Error",
+            "description": "Unprocessable Entity",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Not Implemented",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "553": {
+            "description": "Version Not Supported",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -793,25 +1063,77 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Response Get Structures Structures Get",
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/StructureResponseMany"
-                    },
-                    {
-                      "$ref": "#/components/schemas/ErrorResponse"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/StructureResponseMany"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
           },
           "422": {
-            "description": "Validation Error",
+            "description": "Unprocessable Entity",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Not Implemented",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "553": {
+            "description": "Version Not Supported",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -906,25 +1228,77 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Response Get Single Structure Structures  Entry Id  Get",
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/StructureResponseOne"
-                    },
-                    {
-                      "$ref": "#/components/schemas/ErrorResponse"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/StructureResponseOne"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
           },
           "422": {
-            "description": "Validation Error",
+            "description": "Unprocessable Entity",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Not Implemented",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "553": {
+            "description": "Version Not Supported",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1618,19 +1992,6 @@
           }
         },
         "description": "an object containing references to the source of the error"
-      },
-      "HTTPValidationError": {
-        "title": "HTTPValidationError",
-        "type": "object",
-        "properties": {
-          "detail": {
-            "title": "Detail",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ValidationError"
-            }
-          }
-        }
       },
       "Implementation": {
         "title": "Implementation",
@@ -3443,32 +3804,6 @@
           }
         },
         "description": "A set of Links objects, possibly including pagination"
-      },
-      "ValidationError": {
-        "title": "ValidationError",
-        "required": [
-          "loc",
-          "msg",
-          "type"
-        ],
-        "type": "object",
-        "properties": {
-          "loc": {
-            "title": "Location",
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "msg": {
-            "title": "Message",
-            "type": "string"
-          },
-          "type": {
-            "title": "Error Type",
-            "type": "string"
-          }
-        }
       },
       "Warnings": {
         "title": "Warnings",

--- a/optimade/server/exceptions.py
+++ b/optimade/server/exceptions.py
@@ -4,6 +4,10 @@ __all__ = (
     "BadRequest",
     "VersionNotSupported",
     "Forbidden",
+    "NotFound",
+    "UnprocessableEntity",
+    "NotImplementedResponse",
+    "POSSIBLE_ERRORS",
 )
 
 
@@ -20,40 +24,107 @@ class StrReprMixin(HTTPException):
 class BadRequest(StrReprMixin, HTTPException):
     """400 Bad Request"""
 
+    status_code: int = 400
+    title: str = "Bad Request"
+
     def __init__(
         self,
-        status_code: int = 400,
         detail: str = None,
         headers: dict = None,
-        title: str = "Bad Request",
     ) -> None:
-        super().__init__(status_code=status_code, detail=detail, headers=headers)
-        self.title = title
+        super().__init__(status_code=self.status_code, detail=detail, headers=headers)
 
 
 class VersionNotSupported(StrReprMixin, HTTPException):
     """553 Version Not Supported"""
 
+    status_code: int = 553
+    title: str = "Version Not Supported"
+
     def __init__(
         self,
-        status_code: int = 553,
         detail: str = None,
         headers: dict = None,
-        title: str = "Version Not Supported",
     ) -> None:
-        super().__init__(status_code=status_code, detail=detail, headers=headers)
-        self.title = title
+        super().__init__(status_code=self.status_code, detail=detail, headers=headers)
 
 
 class Forbidden(StrReprMixin, HTTPException):
     """403 Forbidden"""
 
+    status_code: int = 403
+    title: str = "Forbidden"
+
     def __init__(
         self,
-        status_code: int = 403,
         detail: str = None,
         headers: dict = None,
-        title: str = "Forbidden",
     ) -> None:
-        super().__init__(status_code=status_code, detail=detail, headers=headers)
-        self.title = title
+        super().__init__(status_code=self.status_code, detail=detail, headers=headers)
+
+
+class NotFound(StrReprMixin, HTTPException):
+    """404 Not Found"""
+
+    status_code: int = 404
+    title: str = "Not Found"
+
+    def __init__(
+        self,
+        detail: str = None,
+        headers: dict = None,
+    ) -> None:
+        super().__init__(status_code=self.status_code, detail=detail, headers=headers)
+
+
+class UnprocessableEntity(StrReprMixin, HTTPException):
+    """422 Unprocessable Entity"""
+
+    status_code: int = 422
+    title: str = "Unprocessable Entity"
+
+    def __init__(
+        self,
+        detail: str = None,
+        headers: dict = None,
+    ) -> None:
+        super().__init__(status_code=self.status_code, detail=detail, headers=headers)
+
+
+class InternalServerError(StrReprMixin, HTTPException):
+    """500 Internal Server Error"""
+
+    status_code: int = 500
+    title: str = "Internal Server Error"
+
+    def __init__(
+        self,
+        detail: str = None,
+        headers: dict = None,
+    ) -> None:
+        super().__init__(status_code=self.status_code, detail=detail, headers=headers)
+
+
+class NotImplementedResponse(StrReprMixin, HTTPException):
+    """501 Not Implemented"""
+
+    status_code: int = 501
+    title: str = "Not Implemented"
+
+    def __init__(
+        self,
+        detail: str = None,
+        headers: dict = None,
+    ) -> None:
+        super().__init__(status_code=self.status_code, detail=detail, headers=headers)
+
+
+POSSIBLE_ERRORS = (
+    BadRequest,
+    Forbidden,
+    NotFound,
+    UnprocessableEntity,
+    InternalServerError,
+    NotImplementedResponse,
+    VersionNotSupported,
+)

--- a/optimade/server/routers/index_info.py
+++ b/optimade/server/routers/index_info.py
@@ -1,21 +1,16 @@
-from typing import Union
-
 from fastapi import APIRouter, Request
 
 from optimade import __api_version__
-
 from optimade.models import (
-    ErrorResponse,
     IndexInfoResponse,
     IndexInfoAttributes,
     IndexInfoResource,
     IndexRelationship,
     RelatedLinksResource,
 )
-
 from optimade.server.config import CONFIG
-
 from optimade.server.routers.utils import meta_values, get_base_url
+from optimade.server.schemas import ERROR_RESPONSES
 
 
 router = APIRouter(redirect_slashes=True)
@@ -23,11 +18,12 @@ router = APIRouter(redirect_slashes=True)
 
 @router.get(
     "/info",
-    response_model=Union[IndexInfoResponse, ErrorResponse],
+    response_model=IndexInfoResponse,
     response_model_exclude_unset=True,
     tags=["Info"],
+    responses=ERROR_RESPONSES,
 )
-def get_info(request: Request):
+def get_info(request: Request) -> IndexInfoResponse:
     return IndexInfoResponse(
         meta=meta_values(request.url, 1, 1, more_data_available=False),
         data=IndexInfoResource(

--- a/optimade/server/routers/info.py
+++ b/optimade/server/routers/info.py
@@ -1,20 +1,13 @@
-from typing import Union
-
 from fastapi import APIRouter, Request
 from fastapi.exceptions import StarletteHTTPException
 
 from optimade import __api_version__
-
-from optimade.models import (
-    ErrorResponse,
-    InfoResponse,
-    EntryInfoResponse,
-)
-from optimade.server.schemas import ENTRY_INFO_SCHEMAS, retrieve_queryable_properties
-
-from optimade.server.routers.utils import (
-    meta_values,
-    get_base_url,
+from optimade.models import InfoResponse, EntryInfoResponse
+from optimade.server.routers.utils import meta_values, get_base_url
+from optimade.server.schemas import (
+    ENTRY_INFO_SCHEMAS,
+    ERROR_RESPONSES,
+    retrieve_queryable_properties,
 )
 
 
@@ -23,11 +16,12 @@ router = APIRouter(redirect_slashes=True)
 
 @router.get(
     "/info",
-    response_model=Union[InfoResponse, ErrorResponse],
+    response_model=InfoResponse,
     response_model_exclude_unset=True,
     tags=["Info"],
+    responses=ERROR_RESPONSES,
 )
-def get_info(request: Request):
+def get_info(request: Request) -> InfoResponse:
     from optimade.models import BaseInfoResource, BaseInfoAttributes
 
     return InfoResponse(
@@ -54,11 +48,12 @@ def get_info(request: Request):
 
 @router.get(
     "/info/{entry}",
-    response_model=Union[EntryInfoResponse, ErrorResponse],
+    response_model=EntryInfoResponse,
     response_model_exclude_unset=True,
     tags=["Info"],
+    responses=ERROR_RESPONSES,
 )
-def get_entry_info(request: Request, entry: str):
+def get_entry_info(request: Request, entry: str) -> EntryInfoResponse:
     from optimade.models import EntryInfoResource
 
     valid_entry_info_endpoints = ENTRY_INFO_SCHEMAS.keys()

--- a/optimade/server/routers/links.py
+++ b/optimade/server/routers/links.py
@@ -1,14 +1,12 @@
-from typing import Union
-
 from fastapi import APIRouter, Depends, Request
 
-from optimade.models import ErrorResponse, LinksResponse, LinksResource
+from optimade.models import LinksResponse, LinksResource
 from optimade.server.config import CONFIG
 from optimade.server.entry_collections import create_collection
 from optimade.server.mappers import LinksMapper
 from optimade.server.query_params import EntryListingQueryParams
-
 from optimade.server.routers.utils import get_entries
+from optimade.server.schemas import ERROR_RESPONSES
 
 router = APIRouter(redirect_slashes=True)
 
@@ -21,11 +19,14 @@ links_coll = create_collection(
 
 @router.get(
     "/links",
-    response_model=Union[LinksResponse, ErrorResponse],
+    response_model=LinksResponse,
     response_model_exclude_unset=True,
     tags=["Links"],
+    responses=ERROR_RESPONSES,
 )
-def get_links(request: Request, params: EntryListingQueryParams = Depends()):
+def get_links(
+    request: Request, params: EntryListingQueryParams = Depends()
+) -> LinksResponse:
     return get_entries(
         collection=links_coll, response=LinksResponse, request=request, params=params
     )

--- a/optimade/server/routers/references.py
+++ b/optimade/server/routers/references.py
@@ -1,9 +1,6 @@
-from typing import Union
-
 from fastapi import APIRouter, Depends, Request
 
 from optimade.models import (
-    ErrorResponse,
     ReferenceResource,
     ReferenceResponseMany,
     ReferenceResponseOne,
@@ -12,8 +9,8 @@ from optimade.server.config import CONFIG
 from optimade.server.entry_collections import create_collection
 from optimade.server.mappers import ReferenceMapper
 from optimade.server.query_params import EntryListingQueryParams, SingleEntryQueryParams
-
 from optimade.server.routers.utils import get_entries, get_single_entry
+from optimade.server.schemas import ERROR_RESPONSES
 
 
 router = APIRouter(redirect_slashes=True)
@@ -27,11 +24,14 @@ references_coll = create_collection(
 
 @router.get(
     "/references",
-    response_model=Union[ReferenceResponseMany, ErrorResponse],
+    response_model=ReferenceResponseMany,
     response_model_exclude_unset=True,
     tags=["References"],
+    responses=ERROR_RESPONSES,
 )
-def get_references(request: Request, params: EntryListingQueryParams = Depends()):
+def get_references(
+    request: Request, params: EntryListingQueryParams = Depends()
+) -> ReferenceResponseMany:
     return get_entries(
         collection=references_coll,
         response=ReferenceResponseMany,
@@ -42,13 +42,14 @@ def get_references(request: Request, params: EntryListingQueryParams = Depends()
 
 @router.get(
     "/references/{entry_id:path}",
-    response_model=Union[ReferenceResponseOne, ErrorResponse],
+    response_model=ReferenceResponseOne,
     response_model_exclude_unset=True,
     tags=["References"],
+    responses=ERROR_RESPONSES,
 )
 def get_single_reference(
     request: Request, entry_id: str, params: SingleEntryQueryParams = Depends()
-):
+) -> ReferenceResponseOne:
     return get_single_entry(
         collection=references_coll,
         entry_id=entry_id,

--- a/optimade/server/routers/structures.py
+++ b/optimade/server/routers/structures.py
@@ -1,9 +1,6 @@
-from typing import Union
-
 from fastapi import APIRouter, Depends, Request
 
 from optimade.models import (
-    ErrorResponse,
     StructureResource,
     StructureResponseMany,
     StructureResponseOne,
@@ -12,8 +9,8 @@ from optimade.server.config import CONFIG
 from optimade.server.entry_collections import create_collection
 from optimade.server.mappers import StructureMapper
 from optimade.server.query_params import EntryListingQueryParams, SingleEntryQueryParams
-
 from optimade.server.routers.utils import get_entries, get_single_entry
+from optimade.server.schemas import ERROR_RESPONSES
 
 router = APIRouter(redirect_slashes=True)
 
@@ -26,11 +23,14 @@ structures_coll = create_collection(
 
 @router.get(
     "/structures",
-    response_model=Union[StructureResponseMany, ErrorResponse],
+    response_model=StructureResponseMany,
     response_model_exclude_unset=True,
     tags=["Structures"],
+    responses=ERROR_RESPONSES,
 )
-def get_structures(request: Request, params: EntryListingQueryParams = Depends()):
+def get_structures(
+    request: Request, params: EntryListingQueryParams = Depends()
+) -> StructureResponseMany:
     return get_entries(
         collection=structures_coll,
         response=StructureResponseMany,
@@ -41,13 +41,14 @@ def get_structures(request: Request, params: EntryListingQueryParams = Depends()
 
 @router.get(
     "/structures/{entry_id:path}",
-    response_model=Union[StructureResponseOne, ErrorResponse],
+    response_model=StructureResponseOne,
     response_model_exclude_unset=True,
     tags=["Structures"],
+    responses=ERROR_RESPONSES,
 )
 def get_single_structure(
     request: Request, entry_id: str, params: SingleEntryQueryParams = Depends()
-):
+) -> StructureResponseOne:
     return get_single_entry(
         collection=structures_coll,
         entry_id=entry_id,

--- a/optimade/server/routers/versions.py
+++ b/optimade/server/routers/versions.py
@@ -15,7 +15,7 @@ class CsvResponse(Response):
     tags=["Versions"],
     response_class=CsvResponse,
 )
-def get_versions(request: Request):
+def get_versions(request: Request) -> CsvResponse:
     """Respond with the text/csv representation for the served versions."""
     version = BASE_URL_PREFIXES["major"].replace("/v", "")
     response = f"version\n{version}"

--- a/optimade/server/schemas.py
+++ b/optimade/server/schemas.py
@@ -4,6 +4,7 @@ from optimade.models import (
     StructureResource,
     ReferenceResource,
 )
+from optimade.server.exceptions import POSSIBLE_ERRORS
 
 ENTRY_INFO_SCHEMAS = {
     "structures": StructureResource.schema,
@@ -11,10 +12,9 @@ ENTRY_INFO_SCHEMAS = {
 }
 
 ERROR_RESPONSES = {
-    status_code: {"model": ErrorResponse}
-    for status_code in [400, 403, 404, 422, 500, 501, 553]
+    err.status_code: {"model": ErrorResponse, "description": err.title}
+    for err in POSSIBLE_ERRORS
 }
-ERROR_RESPONSES[553].update({"description": "Version Not Supported"})
 
 
 def retrieve_queryable_properties(

--- a/optimade/server/schemas.py
+++ b/optimade/server/schemas.py
@@ -1,9 +1,20 @@
-from optimade.models import DataType, StructureResource, ReferenceResource
+from optimade.models import (
+    DataType,
+    ErrorResponse,
+    StructureResource,
+    ReferenceResource,
+)
 
 ENTRY_INFO_SCHEMAS = {
     "structures": StructureResource.schema,
     "references": ReferenceResource.schema,
 }
+
+ERROR_RESPONSES = {
+    status_code: {"model": ErrorResponse}
+    for status_code in [400, 403, 404, 422, 500, 501, 553]
+}
+ERROR_RESPONSES[553].update({"description": "Version Not Supported"})
 
 
 def retrieve_queryable_properties(


### PR DESCRIPTION
Use a single pydantic model for all routes' `response_model` and add a
dictionary of erroneous status codes with the `ErrorResponse` model to
all routes' `responses` property, updating the OpenAPI schemas with the
correct mapping of response models to status codes.

Fixes #763 