### PR TITLE
Add request --timeout parameter to validator

### DIFF
--- a/optimade/validator/__init__.py
+++ b/optimade/validator/__init__.py
@@ -97,6 +97,12 @@ def validate():  # pragma: no cover
         help="Additional HTTP headers to use for each request, specified as a JSON object.",
     )
 
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        help="Timeout to use for each individual request.",
+    )
+
     args = vars(parser.parse_args())
 
     if os.environ.get("OPTIMADE_VERBOSITY") is not None:
@@ -129,6 +135,7 @@ def validate():  # pragma: no cover
         minimal=args["minimal"],
         page_limit=args["page_limit"],
         http_headers=args["headers"],
+        timeout=args["timeout"],
     )
 
     try:

--- a/optimade/validator/__init__.py
+++ b/optimade/validator/__init__.py
@@ -1,6 +1,7 @@
 """ This module contains the ImplementationValidator class and corresponding command line tools. """
 # pylint: disable=import-outside-toplevel
 from .validator import ImplementationValidator
+from .utils import DEFAULT_CONN_TIMEOUT
 
 __all__ = ["ImplementationValidator", "validate"]
 
@@ -100,7 +101,8 @@ def validate():  # pragma: no cover
     parser.add_argument(
         "--timeout",
         type=float,
-        help="Timeout to use for each individual request.",
+        default=DEFAULT_CONN_TIMEOUT,
+        help=f"Timeout to use for each individual request (DEFAULT: {DEFAULT_CONN_TIMEOUT} s)",
     )
 
     args = vars(parser.parse_args())

--- a/optimade/validator/utils.py
+++ b/optimade/validator/utils.py
@@ -36,7 +36,9 @@ from optimade.models import (
     StructureResource,
 )
 
-DEFAULT_CONN_TIMEOUT = 0.5
+# Default connection timeout allows for one default-sized TCP retransmission window
+# (see https://docs.python-requests.org/en/latest/user/advanced/#timeouts)
+DEFAULT_CONN_TIMEOUT = 3.05
 DEFAULT_READ_TIMEOUT = 300
 
 

--- a/optimade/validator/utils.py
+++ b/optimade/validator/utils.py
@@ -224,7 +224,6 @@ class Client:  # pragma: no cover
         status_code = None
         retries = 0
         errors = []
-        # probably a smarter way to do this with requests, but their documentation 404's...
         while retries < self.max_retries:
             retries += 1
             try:
@@ -235,6 +234,7 @@ class Client:  # pragma: no cover
                 )
 
                 status_code = self.response.status_code
+                # If we hit a 429 Too Many Requests status, then try again in 1 second
                 if status_code != 429:
                     return self.response
 
@@ -249,10 +249,9 @@ class Client:  # pragma: no cover
 
             # If the connection failed, or returned a 429, then wait 1 second before retrying
             time.sleep(1)
-            continue
 
         else:
-            message = f"Hit max (manual) retries on request {self.last_request!r}."
+            message = f"Hit max retries ({self.max_retries}) on request {self.last_request!r}."
             if errors:
                 error_str = "\n\t".join(errors)
                 message += f"\nErrors:\n\t{error_str}"

--- a/optimade/validator/validator.py
+++ b/optimade/validator/validator.py
@@ -105,7 +105,7 @@ class ImplementationValidator:
             index: Whether to validate the implementation as an index meta-database.
             minimal: Whether or not to run only a minimal test set.
             http_headers: Dictionary of additional headers to add to every request.
-            timeout: The connection timeout to use for all requests.
+            timeout: The connection timeout to use for all requests (in seconds).
 
         """
         self.verbosity = verbosity

--- a/optimade/validator/validator.py
+++ b/optimade/validator/validator.py
@@ -76,6 +76,7 @@ class ImplementationValidator:
         index: bool = False,
         minimal: bool = False,
         http_headers: Dict[str, str] = None,
+        timeout: float = None,
     ):
         """Set up the tests to run, based on constants in this module
         for required endpoints.
@@ -104,6 +105,7 @@ class ImplementationValidator:
             index: Whether to validate the implementation as an index meta-database.
             minimal: Whether or not to run only a minimal test set.
             http_headers: Dictionary of additional headers to add to every request.
+            timeout: The timeout to use for all requests (passed to `requests.get`).
 
         """
         self.verbosity = verbosity
@@ -151,7 +153,10 @@ class ImplementationValidator:
                 base_url = base_url[:-1]
             self.base_url = base_url
             self.client = Client(
-                base_url, max_retries=self.max_retries, headers=http_headers
+                base_url,
+                max_retries=self.max_retries,
+                headers=http_headers,
+                timeout=timeout,
             )
 
         self._setup_log()

--- a/optimade/validator/validator.py
+++ b/optimade/validator/validator.py
@@ -23,6 +23,7 @@ import requests
 
 from optimade.models import DataType, EntryInfoResponse, SupportLevel
 from optimade.validator.utils import (
+    DEFAULT_CONN_TIMEOUT,
     Client,
     test_case,
     print_failure,
@@ -76,7 +77,7 @@ class ImplementationValidator:
         index: bool = False,
         minimal: bool = False,
         http_headers: Dict[str, str] = None,
-        timeout: float = None,
+        timeout: float = DEFAULT_CONN_TIMEOUT,
     ):
         """Set up the tests to run, based on constants in this module
         for required endpoints.

--- a/optimade/validator/validator.py
+++ b/optimade/validator/validator.py
@@ -795,10 +795,10 @@ class ImplementationValidator:
                 if query_optional:
                     return (
                         None,
-                        "Optional query {query!r} returned {reversed_response.status_code}.",
+                        "Optional query {query!r} raised the error: {message}.",
                     )
                 raise ResponseError(
-                    f"Unable to perform mandatory query {query!r}: responded with status code {response.status_code}"
+                    f"Unable to perform mandatory query {query!r}, which raised the error: {message}"
                 )
 
             response = response.json()
@@ -853,10 +853,10 @@ class ImplementationValidator:
                     if query_optional:
                         return (
                             None,
-                            "Optional query {query!r} returned {reversed_response.status_code}.",
+                            "Optional query {reversed_query!r} raised the error: {message}.",
                         )
                     raise ResponseError(
-                        f"Unable to perform mandatory query {query!r}: responded with status code {reversed_response.status_code}"
+                        f"Unable to perform mandatory query {reversed_query!r}, which raised the error: {message}"
                     )
 
                 reversed_response = reversed_response.json()

--- a/optimade/validator/validator.py
+++ b/optimade/validator/validator.py
@@ -105,7 +105,7 @@ class ImplementationValidator:
             index: Whether to validate the implementation as an index meta-database.
             minimal: Whether or not to run only a minimal test set.
             http_headers: Dictionary of additional headers to add to every request.
-            timeout: The timeout to use for all requests (passed to `requests.get`).
+            timeout: The connection timeout to use for all requests.
 
         """
         self.verbosity = verbosity


### PR DESCRIPTION
Closes #681.

Encouraged by the fact that the providers dashboard build failed with a 6 hour timeout, as [by default `requests.get()` has no timeout](https://docs.python-requests.org/en/master/user/quickstart/#timeouts).

The new default is a 0.5 second connection timeout (which is still retried 5 times), then a 300 second read timeout (required for some big queries).