### PR TITLE
Dependency updates for v0.16.2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     interval: monthly
   # Needs to be larger than the number of total requirements (currently 31)
   open-pull-requests-limit: 50
-  target-branch: master
+  target-branch: dependabot_updates
   labels:
   - dependency_updates
 - package-ecosystem: gitsubmodule

--- a/.github/workflows/publish-on-pypi.yml
+++ b/.github/workflows/publish-on-pypi.yml
@@ -39,7 +39,7 @@ jobs:
       run: .github/workflows/update_docs.sh
 
     - name: Update '${{ env.PUBLISH_UPDATE_BRANCH }}'
-      uses: CasperWA/push-protected@v2.3.0
+      uses: CasperWA/push-protected@v2.4.0
       with:
         token: ${{ secrets.RELEASE_PAT_CASPER }}
         branch: ${{ env.PUBLISH_UPDATE_BRANCH }}

--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -1,5 +1,5 @@
 aiida-core==1.6.4
 ase==3.22.0
-numpy==1.21.0
+numpy==1.21.1
 pymatgen==2021.3.9
 jarvis-tools==2021.7.19

--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -2,4 +2,4 @@ aiida-core==1.6.4
 ase==3.22.0
 numpy==1.21.0
 pymatgen==2021.3.9
-jarvis-tools==2021.6.18
+jarvis-tools==2021.7.19

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,4 +4,4 @@ codecov==2.1.11
 jsondiff==1.3.0
 pylint==2.9.6
 pre-commit==2.13.0
-invoke==1.5.0
+invoke==1.6.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,6 @@ pytest==6.2.4
 pytest-cov==2.12.1
 codecov==2.1.11
 jsondiff==1.3.0
-pylint==2.9.1
+pylint==2.9.6
 pre-commit==2.13.0
 invoke==1.5.0

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,5 +1,5 @@
 mkdocs==1.2.1
 mkdocs-awesome-pages-plugin==2.5.0
-mkdocs-material==7.1.9
+mkdocs-material==7.2.2
 mkdocs-minify-plugin==0.4.0
 mkdocstrings==0.15.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ fastapi==0.65.2
 lark-parser==0.11.3
 pydantic==1.8.2
 email_validator==1.1.3
-requests==2.25.1
+requests==2.26.0
 uvicorn==0.14.0
 pymongo==3.12.0
 mongomock==3.23.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pydantic==1.8.2
 email_validator==1.1.3
 requests==2.25.1
 uvicorn==0.14.0
-pymongo==3.11.4
+pymongo==3.12.0
 mongomock==3.23.0
 elasticsearch-dsl==6.4.0
 Jinja2==3.0.1

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open(module_dir.joinpath("optimade/__init__.py")) as version_file:
 # Dependencies
 # Server minded
 elastic_deps = ["elasticsearch-dsl~=6.4,<7.0"]
-mongo_deps = ["pymongo~=3.11", "mongomock~=3.23"]
+mongo_deps = ["pymongo~=3.12", "mongomock~=3.23"]
 server_deps = [
     "uvicorn~=0.14.0",
     "Jinja2>=2.10,<4.0",
@@ -31,7 +31,7 @@ ase_deps = ["ase~=3.22"]
 cif_deps = ["numpy~=1.21"]
 pdb_deps = cif_deps
 pymatgen_deps = ["pymatgen==2021.3.9"]
-jarvis_deps = ["jarvis-tools==2021.6.18"]
+jarvis_deps = ["jarvis-tools==2021.7.19"]
 client_deps = cif_deps
 
 # General
@@ -49,7 +49,7 @@ testing_deps = [
     "jsondiff~=1.3",
 ] + server_deps
 dev_deps = (
-    ["pylint~=2.9", "pre-commit~=2.13", "invoke~=1.5"]
+    ["pylint~=2.9", "pre-commit~=2.13", "invoke~=1.6"]
     + docs_deps
     + testing_deps
     + client_deps
@@ -86,7 +86,7 @@ setup(
         "fastapi~=0.65.2",
         "pydantic~=1.8,>=1.8.2",
         "email_validator~=1.1",
-        "requests~=2.25",
+        "requests~=2.26",
     ],
     extras_require={
         "all": all_deps,


### PR DESCRIPTION
Trying out a new approach to these dependabot PRs.

I've asked dependabot to make PRs against this new branch `dependabot_updates` and I have enabled automerge and no required reviews for merging into this branch. It still requires someone to go through and click "automerge" for each PR (we could probably find an action to do this), but this should be quicker than the local octopus merge/rebase as dependabot will automatically rebase.

We can then occasionally make the PR directly from this branch to master, with only the setup.py updates required. Let's see how it goes.

Problems with this approach: worst case of N^2 CI runs for N deps, after each dep is successively merged. Should be able to cut down to 2N. UPDATE: I think this is fixed by the auto-merge procedure, provided all PRs are set to auto-merge without any checks taking place, they should all get merged into this branch before the individual CI branch checks get triggered (will have to test this). Another option would be to disable CI runs on dependabot branches, such that deps are only tested in this branch.

Proposed workflow: we keep this PR open (and up to date with more dependabot PRs) until we are ready to release a new version.