### PR TITLE
Fix provider fallbacks

### DIFF
--- a/optimade/server/routers/utils.py
+++ b/optimade/server/routers/utils.py
@@ -30,6 +30,11 @@ BASE_URL_PREFIXES = {
     "patch": f"/v{'.'.join(__api_version__.split('-')[0].split('+')[0].split('.')[:3])}",
 }
 
+PROVIDER_LIST_URLS = (
+    "https://providers.optimade.org/v1/links",
+    "https://raw.githubusercontent.com/Materials-Consortia/providers/master/src/links/v1/providers.json",
+)
+
 
 class JSONAPIResponse(JSONResponse):
     """This class simply patches `fastapi.responses.JSONResponse` to use the
@@ -341,12 +346,7 @@ def get_providers() -> list:
     except ImportError:
         import json
 
-    provider_list_urls = [
-        "https://providers.optimade.org/v1/links",
-        "https://raw.githubusercontent.com/Materials-Consortia/providers/master/src/links/v1/providers.json",
-    ]
-
-    for provider_list_url in provider_list_urls:
+    for provider_list_url in PROVIDER_LIST_URLS:
         try:
             providers = requests.get(provider_list_url).json()
         except (
@@ -371,7 +371,7 @@ def get_providers() -> list:
 {}
     The list of providers will not be included in the `/links`-endpoint.
 """.format(
-                    "".join([f"    * {_}\n" for _ in provider_list_urls])
+                    "".join([f"    * {_}\n" for _ in PROVIDER_LIST_URLS])
                 )
             )
             return []

--- a/optimade/server/routers/utils.py
+++ b/optimade/server/routers/utils.py
@@ -343,8 +343,7 @@ def get_providers() -> list:
 
     provider_list_urls = [
         "https://providers.optimade.org/v1/links",
-        "https://raw.githubusercontent.com/Materials-Consortia/providers",
-        "/master/src/links/v1/providers.json",
+        "https://raw.githubusercontent.com/Materials-Consortia/providers/master/src/links/v1/providers.json",
     ]
 
     for provider_list_url in provider_list_urls:

--- a/tests/server/routers/test_utils.py
+++ b/tests/server/routers/test_utils.py
@@ -76,13 +76,7 @@ def test_get_providers():
 def test_get_providers_warning(caplog, top_dir):
     """Make sure a warning is logged as a last resort."""
     import copy
-    from optimade.server.routers.utils import get_providers
-
-    provider_list_urls = [
-        "https://providers.optimade.org/v1/links",
-        "https://raw.githubusercontent.com/Materials-Consortia/providers",
-        "/master/src/links/v1/providers.json",
-    ]
+    from optimade.server.routers.utils import get_providers, PROVIDER_LIST_URLS
 
     providers_cache = False
     try:
@@ -103,7 +97,7 @@ def test_get_providers_warning(caplog, top_dir):
 {}
     The list of providers will not be included in the `/links`-endpoint.
 """.format(
-                "".join([f"    * {_}\n" for _ in provider_list_urls])
+                "".join([f"    * {_}\n" for _ in PROVIDER_LIST_URLS])
             )
             assert warning_message in caplog.messages
 


### PR DESCRIPTION
In #830 I broke the fallback list after fixing a linter error wittout looking at any of the context of the line I was fixing... (and then rushed through the PR as people were on holiday, my bad)

This PR makes the providers list importable from the `server.routers.utils` module too.

Closes #896.