### PR TITLE
Test whether we can get away with depless AiiDA install

### DIFF
--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -1,4 +1,4 @@
-aiida-core==1.6.4
+aiida-core==1.6.4 --install-option=no-deps
 ase==3.22.0
 numpy==1.21.0
 pymatgen==2021.3.9


### PR DESCRIPTION
Just seeing if we can optimise our CI by installing AiiDA without its (many) dependencies, as it takes about 25% of the total time in our CI (2 mins per Python test run).