### PR TITLE
Dependency updates for v0.16.4

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
   target-branch: dependabot_updates
   labels:
   - dependency_updates
+  # Turn off automatic rebases so that auto-merge can work without needed N**2 CI runs
+  rebase-strategy: "disabled"
 - package-ecosystem: gitsubmodule
   directory: "/"
   schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,6 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-  target-branch: master
+  target-branch: dependabot_updates
   labels:
   - CI

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,7 @@ updates:
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: daily
+    interval: monthly
   target-branch: dependabot_updates
   labels:
   - CI

--- a/.github/workflows/deps_lint.yml
+++ b/.github/workflows/deps_lint.yml
@@ -236,7 +236,7 @@ jobs:
 
     - name: Upload coverage to Codecov
       if: matrix.python-version == 3.8 && github.repository == 'Materials-Consortia/optimade-python-tools'
-      uses: codecov/codecov-action@v2.0.2
+      uses: codecov/codecov-action@v2.0.3
       with:
         name: project
         file: ./coverage.xml
@@ -244,7 +244,7 @@ jobs:
 
     - name: Upload validator coverage to Codecov
       if: matrix.python-version == 3.8 && github.repository == 'Materials-Consortia/optimade-python-tools'
-      uses: codecov/codecov-action@v2.0.2
+      uses: codecov/codecov-action@v2.0.3
       with:
         name: validator
         file: ./validator_cov.xml

--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -1,5 +1,5 @@
 aiida-core==1.6.5
 ase==3.22.0
-numpy==1.21.1
+numpy==1.21.2
 pymatgen==2021.3.9
 jarvis-tools==2021.8.18

--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -1,4 +1,4 @@
-aiida-core==1.6.4
+aiida-core==1.6.5
 ase==3.22.0
 numpy==1.21.1
 pymatgen==2021.3.9

--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -2,4 +2,4 @@ aiida-core==1.6.5
 ase==3.22.0
 numpy==1.21.1
 pymatgen==2021.3.9
-jarvis-tools==2021.7.19
+jarvis-tools==2021.8.18

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 pytest==6.2.4
 pytest-cov==2.12.1
-codecov==2.1.11
+codecov==2.1.12
 jsondiff==1.3.0
 pylint==2.9.6
 pre-commit==2.13.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,5 +3,5 @@ pytest-cov==2.12.1
 codecov==2.1.12
 jsondiff==1.3.0
 pylint==2.10.2
-pre-commit==2.13.0
+pre-commit==2.14.1
 invoke==1.6.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,6 @@ pytest==6.2.4
 pytest-cov==2.12.1
 codecov==2.1.12
 jsondiff==1.3.0
-pylint==2.9.6
+pylint==2.10.2
 pre-commit==2.13.0
 invoke==1.6.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-pytest==6.2.4
+pytest==6.2.5
 pytest-cov==2.12.1
 codecov==2.1.12
 jsondiff==1.3.0

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,5 +1,5 @@
 mkdocs==1.2.2
 mkdocs-awesome-pages-plugin==2.5.0
-mkdocs-material==7.2.2
+mkdocs-material==7.2.5
 mkdocs-minify-plugin==0.4.0
 mkdocstrings==0.15.2

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,5 +1,5 @@
 mkdocs==1.2.2
 mkdocs-awesome-pages-plugin==2.5.0
-mkdocs-material==7.2.5
+mkdocs-material==7.2.6
 mkdocs-minify-plugin==0.4.0
 mkdocstrings==0.15.2

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,4 +1,4 @@
-mkdocs==1.2.1
+mkdocs==1.2.2
 mkdocs-awesome-pages-plugin==2.5.0
 mkdocs-material==7.2.2
 mkdocs-minify-plugin==0.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ pymongo==3.12.0
 mongomock==3.23.0
 elasticsearch-dsl==6.4.0
 Jinja2==3.0.1
-typing-extensions==3.10.0.0
+typing-extensions==3.10.0.1
 pyyaml==5.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ pymongo==3.12.0
 mongomock==3.23.0
 elasticsearch-dsl==6.4.0
 Jinja2==3.0.1
-typing-extensions==3.10.0.1
+typing-extensions==3.10.0.2
 pyyaml==5.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ lark-parser==0.11.3
 pydantic==1.8.2
 email_validator==1.1.3
 requests==2.26.0
-uvicorn==0.14.0
+uvicorn==0.15.0
 pymongo==3.12.0
 mongomock==3.23.0
 elasticsearch-dsl==6.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 fastapi==0.65.2
-lark-parser==0.11.3
+lark-parser==0.12.0
 pydantic==1.8.2
 email_validator==1.1.3
 requests==2.26.0

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ with open(module_dir.joinpath("optimade/__init__.py")) as version_file:
 elastic_deps = ["elasticsearch-dsl~=6.4,<7.0"]
 mongo_deps = ["pymongo~=3.12", "mongomock~=3.23"]
 server_deps = [
-    "uvicorn~=0.14.0",
+    "uvicorn~=0.15",
     "Jinja2>=2.10,<4.0",
     "pyyaml~=5.1",  # Keep at pyyaml 5.1 for aiida-core support
 ] + mongo_deps
@@ -31,14 +31,14 @@ ase_deps = ["ase~=3.22"]
 cif_deps = ["numpy~=1.21"]
 pdb_deps = cif_deps
 pymatgen_deps = ["pymatgen==2021.3.9"]
-jarvis_deps = ["jarvis-tools==2021.7.19"]
+jarvis_deps = ["jarvis-tools==2021.8.18"]
 client_deps = cif_deps
 
 # General
 docs_deps = [
     "mkdocs~=1.2",
     "mkdocs-awesome-pages-plugin~=2.5",
-    "mkdocs-material~=7.1",
+    "mkdocs-material~=7.2",
     "mkdocs-minify-plugin~=0.4.0",
     "mkdocstrings~=0.15.2",
 ]
@@ -49,7 +49,7 @@ testing_deps = [
     "jsondiff~=1.3",
 ] + server_deps
 dev_deps = (
-    ["pylint~=2.9", "pre-commit~=2.13", "invoke~=1.6"]
+    ["pylint~=2.10", "pre-commit~=2.14", "invoke~=1.6"]
     + docs_deps
     + testing_deps
     + client_deps
@@ -82,7 +82,7 @@ setup(
     ],
     python_requires=">=3.7",
     install_requires=[
-        "lark-parser~=0.11.3",
+        "lark-parser~=0.12",
         "fastapi~=0.65.2",
         "pydantic~=1.8,>=1.8.2",
         "email_validator~=1.1",


### PR DESCRIPTION
This PR is for staging dependency updates for the next release.

Some other dependency related stuff:

- [x] Also make actions update PRs against this branch
- [x] Disable automatic rebasing from dependabot (which then triggers another CI run). This means that successive automerges should all work (currently it depends on whether dependabot auto-rebase is faster than GitHub auto-merge...)