### PR TITLE
Clarify installation methods by use-case

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,11 +1,17 @@
 # Installation
 
+This package can be installed from PyPI, or by cloning the repository, depending on your use-case.
+
+1. To use the `optimade` Python package as a library, (e.g., using the models for validation, parsing filters with the grammar, or using the command-line tool `optimade-validator` tool), it is recommended that you install the latest release of the package from PyPI with `pip install optimade`.
+2. If you want to run, use or modify the reference server implementation, then it is recommended that you clone this repository and install it from your local files (with `pip install .`, or `pip install -e .` for an editable installation).
+
 ## The index meta-database
 
 This package may be used to setup and run an [OPTIMADE index meta-database](https://github.com/Materials-Consortia/OPTIMADE/blob/develop/optimade.rst#index-meta-database).
-Install the package via `pip install optimade[server]`.
+Clone this repository and install the package locally with `pip install -e .[server]`.
 
-There is a built-in index meta-database set up to populate a `mongomock` in-memory database with resources from a static `json` file containing the `child` resources you, as a database provider, want to serve under this index meta-database. The location of that `json` file is controllable using the `index_links_path` property of the configuration or setting via the environment variable `optimade_index_links_path`.
+There is a built-in index meta-database set up to populate a `mongomock` in-memory database with resources from a static `json` file containing the `child` resources you, as a database provider, want to serve under this index meta-database.
+The location of that `json` file is controllable using the `index_links_path` property of the configuration or setting via the environment variable `optimade_index_links_path`.
 
 Running the index meta-database is then as simple as writing `./run.sh index` in a terminal from the root of this package.
 You can find it at the base URL: <http://localhost:5001/v1>.
@@ -21,7 +27,7 @@ Here is an example of how it may look to start your server:
 
 The dependencies of this package can be found in `setup.py` with their latest supported versions.
 By default, a minimal set of requirements are installed to work with the filter language and the `pydantic` models.
-The install mode `server` (i.e. `pip install .[server]`) is sufficient to run a `uvicorn` server using the `mongomock` backend (or MongoDB with `pymongo`, if present).
+After cloning the repository, the install mode `server` (i.e. `pip install .[server]`) is sufficient to run a `uvicorn` server using the `mongomock` backend (or MongoDB with `pymongo`, if present).
 The suite of development and testing tools are installed with via the install modes `dev` and `testing`.
 There are additionally two backend-specific install modes, `elastic` and `mongo`, as well as the `all` mode, which installs all dependencies.
 All contributed Python code, must use the [black](https://github.com/ambv/black) code formatter, and must pass the [flake8](http://flake8.pycqa.org/en/latest/) linter that is run automatically on all PRs.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This document, guides, and the full module API documentation can be found online
 
 ## Installation
 
-Detailed instructions for installing and running the index meta-database and the main API can be found in [the installation documentation](INSTALL.md).
+Detailed installation instructions for different use cases (e.g., using the library or running a server) in [the installation documentation](INSTALL.md).
 
 The latest stable version of this package can be obtained from [PyPI](https://pypi.org/project/optimade) `pip install optimade`.
 The latest development version of this package can be installed from the master branch of this repository `git clone https://github.com/Materials-Consortia/optimade-python-tools`.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This document, guides, and the full module API documentation can be found online
 
 ## Installation
 
-Detailed installation instructions for different use cases (e.g., using the library or running a server) in [the installation documentation](INSTALL.md).
+Detailed installation instructions for different use cases (e.g., using the library or running a server) can be found in [the installation documentation](INSTALL.md).
 
 The latest stable version of this package can be obtained from [PyPI](https://pypi.org/project/optimade) `pip install optimade`.
 The latest development version of this package can be installed from the master branch of this repository `git clone https://github.com/Materials-Consortia/optimade-python-tools`.


### PR DESCRIPTION
This PR clarifies when the package should be installed from PyPI vs cloning (which is required to use the `run.sh` script).

Closes #904.