### PR TITLE
Use proper pip dependency resolver in publish workflow

### DIFF
--- a/.github/workflows/publish-on-pypi.yml
+++ b/.github/workflows/publish-on-pypi.yml
@@ -28,7 +28,7 @@ jobs:
       run: |
         python -m pip install -U pip
         pip install -U setuptools
-        pip install -U -e .[all] --use-deprecated=legacy-resolver
+        pip install -U -e .[all]
 
     - name: Update changelog
       uses: CharMixer/auto-changelog-action@v1.4


### PR DESCRIPTION
Closes #625.

Looks like the initial problem has fixed itself as our deps have updated themselves.