### PR TITLE
remove the dependency on mkdocs-minify because of issue #938.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,8 +41,6 @@ markdown_extensions:
 plugins:
   - search:
       lang: en
-  - minify:
-      minify_html: true
   - mkdocstrings:
       default_handler: python
       handlers:

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,5 +1,4 @@
 mkdocs==1.2.2
 mkdocs-awesome-pages-plugin==2.5.0
 mkdocs-material==7.2.6
-mkdocs-minify-plugin==0.4.0
 mkdocstrings==0.15.2

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ docs_deps = [
     "mkdocs~=1.2",
     "mkdocs-awesome-pages-plugin~=2.5",
     "mkdocs-material~=7.2",
-    "mkdocs-minify-plugin~=0.4.0",
     "mkdocstrings~=0.15.2",
 ]
 testing_deps = [


### PR DESCRIPTION
I removed the references to minify because of Matthews remark in #938

Closes #938. 