### PR TITLE
Some validation QoL tweaks

### DIFF
--- a/optimade/models/structures.py
+++ b/optimade/models/structures.py
@@ -5,7 +5,6 @@ import sys
 import math
 from functools import reduce
 from enum import IntEnum, Enum
-from sys import float_info
 from typing import List, Optional, Union
 
 from pydantic import BaseModel, validator, root_validator, conlist
@@ -36,7 +35,8 @@ __all__ = (
 )
 
 
-EPS = float_info.epsilon
+# Use machine epsilon for single point floating precision
+EPS = 2 ** -23
 
 
 Vector3D = conlist(float, min_items=3, max_items=3)
@@ -944,7 +944,7 @@ The properties of the species are found in the property `species`.
 
         if abs(sum(v) - 1) > EPS:
             raise ValueError(
-                f"elements_ratios MUST sum to 1 within floating point accuracy. It sums to: {sum(v)}"
+                f"elements_ratios MUST sum to 1 within (at least single precision) floating point accuracy. It sums to: {sum(v)}"
             )
         return v
 

--- a/optimade/models/structures.py
+++ b/optimade/models/structures.py
@@ -21,7 +21,7 @@ from optimade.models.utils import (
 )
 from optimade.server.warnings import MissingExpectedField
 
-EXTENDED_CHEMICAL_SYMBOLS = CHEMICAL_SYMBOLS + EXTRA_SYMBOLS
+EXTENDED_CHEMICAL_SYMBOLS = set(CHEMICAL_SYMBOLS + EXTRA_SYMBOLS)
 
 
 __all__ = (
@@ -145,8 +145,10 @@ Note: With regards to "source database", we refer to the immediate source being 
 
     @validator("chemical_symbols", each_item=True)
     def validate_chemical_symbols(cls, v):
-        if not (v in EXTENDED_CHEMICAL_SYMBOLS):
-            raise ValueError(f"{v} MUST be in {EXTENDED_CHEMICAL_SYMBOLS}")
+        if v not in EXTENDED_CHEMICAL_SYMBOLS:
+            raise ValueError(
+                f'{v!r} MUST be an element symbol, e.g., "C", "He", or a special symbol from {EXTRA_SYMBOLS}.'
+            )
         return v
 
     @validator("concentration", "mass")

--- a/optimade/validator/validator.py
+++ b/optimade/validator/validator.py
@@ -1436,14 +1436,18 @@ class ImplementationValidator:
         if isinstance(expected_status_code, int):
             expected_status_code = [expected_status_code]
 
-        if response.status_code not in expected_status_code:
-            message = f"Request to '{request_str}' returned HTTP code {response.status_code} and not the allowed {expected_status_code}."
-            message += "\nAdditional details:"
+        message = f"received expected response: {response}."
+
+        if response.status_code != 200:
+            message = f"Request to '{request_str}' returned HTTP status code {response.status_code}."
+            message += "\nAdditional details from implementation:"
             try:
                 for error in response.json().get("errors", []):
                     message += f'\n  {error.get("title", "N/A")}: {error.get("detail", "N/A")} ({error.get("source", {}).get("pointer", "N/A")})'
             except json.JSONDecodeError:
                 message += f"\n  Could not parse response as JSON. Content type was {response.headers.get('content-type')!r}."
-            raise ResponseError(message)
 
-        return response, f"received expected response: {response}."
+            if response.status_code not in expected_status_code:
+                raise ResponseError(message)
+
+        return response, message


### PR DESCRIPTION
This PR addresses a few ergonomics/QoL concerns with the validator:

- [x] Use single precision FP mach eps for `elements_ratios` validator (closes #947)
- [x] ~Use set operations in some of the chemical symbol field validators (might revert as it doesn't do quite what I wanted to, doubt there's any real speed boost)~ Dropped this for now.
- [x] Tweak how 501 errors are handled in validator error messages - try to only give one error that uses the details from the implementation itself
- [x] Simplify invalid chemical symbol error message by not printing the list of all elements. 