### PR TITLE
Put docs release deployment in separate job

### DIFF
--- a/.github/utils/update_docs.sh
+++ b/.github/utils/update_docs.sh
@@ -2,8 +2,8 @@
 set -e
 
 echo -e "\n-o- Setting commit user -o-"
-git config --global user.email "dev@optimade.org"
-git config --global user.name "OPTIMADE Developers"
+git config --global user.email "${GIT_USER_EMAIL}"
+git config --global user.name "${GIT_USER_NAME}"
 
 echo -e "\n-o- Update 'API Reference' docs -o-"
 invoke create-api-reference-docs --pre-clean

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -5,14 +5,17 @@ on:
     types:
     - published
 
+env:
+  PUBLISH_UPDATE_BRANCH: master
+  GIT_USER_NAME: OPTIMADE Developers
+  GIT_USER_EMAIL: "dev@optimade.org"
+
 jobs:
 
   publish:
     name: Publish OPTIMADE Python tools
     runs-on: ubuntu-latest
     if: github.repository == 'Materials-Consortia/optimade-python-tools' && startsWith(github.ref, 'refs/tags/v')
-    env:
-      PUBLISH_UPDATE_BRANCH: master
 
     steps:
     - name: Checkout repository
@@ -78,6 +81,35 @@ jobs:
       with:
         user: __token__
         password: ${{ secrets.PYPI_PASSWORD }}
+
+  docs:
+    name: Deploy documentation
+    needs: publish
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+        fetch-depth: 0
+        ref: ${{ env.PUBLISH_UPDATE_BRANCH }}
+
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - name: Install Python dependencies
+      run: |
+        python -m pip install -U pip
+        pip install -U setuptools
+        pip install -U -e .[all]
+
+    - name: Set git config
+      run: |
+        git config --global user.name "${{ env.GIT_USER_NAME }}"
+        git config --global user.email "${{ env.GIT_USER_EMAIL }}"
 
     - name: Deploy documentation
       run: |


### PR DESCRIPTION
This should fix part 1 of #976.

There seems to be a permission issue, I believe, after using the [push-protected](https://github.com/CasperWA/push-protected) action, however, it may also be due to other things.
In any case, when using `mike deploy` as the last step in the publish workflow, the workflow fails (see [this run](https://github.com/Materials-Consortia/optimade-python-tools/runs/3927308819?check_suite_focus=true#step:16:10)).
Separating this step into a subsequent job should solve this issue (I saw the same thing for OPTIMADE Gateway, forgot, and needed to do the same there, after which it worked).