### PR TITLE
Use `diff` for checking PR body

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,32 @@ on:
 
 jobs:
 
+  temp_job:
+    name: TEMPORARY job
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Test comparisons for PR body
+      run: |
+        git fetch origin
+
+        DEPENDENCY_PR_BODY="$(gh api /repos/${{ github.repository}}/pulls/998 -X GET --jq '.body')"
+        RANDOM_PR_BODY="$(gh api /repos/${{ github.repository}}/pulls/986 -X GET --jq '.body')"
+        cat .github/utils/single_dependency_pr_body.txt | head -8 > .tmp_file.txt
+        echo "DEPENDENCY_PR_BODY: ${DEPENDENCY_PR_BODY}"
+        echo ".tmp_file.txt: $(cat .tmp_file.txt)"
+        echo "diff w/DEPENDENCY_PR_BODY (function within slashes): /$(printf '%s\n' "${DEPENDENCY_PR_BODY}" | head -8 | diff - .tmp_file.txt --strip-trailing-cr)/"
+        echo "RANDOM_PR_BODY: ${RANDOM_PR_BODY}"
+        echo "diff w/RANDOM_PR_BODY (function within slashes): /$(printf '%s\n' "${RANDOM_PR_BODY}" | head -8 | diff - .tmp_file.txt --strip-trailing-cr)/"
+        if [ -z "$(printf '%s\n' "${DEPENDENCY_PR_BODY}" | head -8 | diff - .tmp_file.txt --strip-trailing-cr)" ]; then
+          echo "WILL NOT BE DONE: The dependencies have just been updated! Reset to master."
+        else
+          echo "WILL NOT BE DONE: Merge new updates to master into dependabot_updates"
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   lint:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,32 +9,6 @@ on:
 
 jobs:
 
-  temp_job:
-    name: TEMPORARY job
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Test comparisons for PR body
-      run: |
-        git fetch origin
-
-        DEPENDENCY_PR_BODY="$(gh api /repos/${{ github.repository}}/pulls/998 -X GET --jq '.body')"
-        RANDOM_PR_BODY="$(gh api /repos/${{ github.repository}}/pulls/986 -X GET --jq '.body')"
-        cat .github/utils/single_dependency_pr_body.txt | head -8 > .tmp_file.txt
-        echo "DEPENDENCY_PR_BODY: ${DEPENDENCY_PR_BODY}"
-        echo ".tmp_file.txt: $(cat .tmp_file.txt)"
-        echo "diff w/DEPENDENCY_PR_BODY (function within slashes): /$(printf '%s\n' "${DEPENDENCY_PR_BODY}" | head -8 | diff - .tmp_file.txt --strip-trailing-cr)/"
-        echo "RANDOM_PR_BODY: ${RANDOM_PR_BODY}"
-        echo "diff w/RANDOM_PR_BODY (function within slashes): /$(printf '%s\n' "${RANDOM_PR_BODY}" | head -8 | diff - .tmp_file.txt --strip-trailing-cr)/"
-        if [ -z "$(printf '%s\n' "${DEPENDENCY_PR_BODY}" | head -8 | diff - .tmp_file.txt --strip-trailing-cr)" ]; then
-          echo "WILL NOT BE DONE: The dependencies have just been updated! Reset to master."
-        else
-          echo "WILL NOT BE DONE: Merge new updates to master into dependabot_updates"
-        fi
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   lint:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci_cd_updated_master.yml
+++ b/.github/workflows/ci_cd_updated_master.yml
@@ -96,7 +96,8 @@ jobs:
         git fetch origin
 
         LATEST_PR_BODY="$(gh api /repos/${{ github.repository}}/pulls -X GET -f state=closed -f per_page=1 -f sort=updated -f direction=desc --jq '.[].body')"
-        if [ "$(printf '%s\n' "${LATEST_PR_BODY}" | head -8)" == "$(cat .github/utils/single_dependency_pr_body.txt | head -8)" ]; then
+        cat .github/utils/single_dependency_pr_body.txt | head -8 > .tmp_file.txt
+        if [ -z "$(printf '%s\n' "${LATEST_PR_BODY}" | head -8 | diff - .tmp_file.txt --strip-trailing-cr)" ]; then
           # The dependency branch has just been merged into ${DEFAULT_REPO_BRANCH}
           # The dependency branch should be reset to ${DEFAULT_REPO_BRANCH}
           echo "The dependencies have just been updated! Reset to ${{ env.DEFAULT_REPO_BRANCH }}."


### PR DESCRIPTION
Fixes #995 

This tries to use `diff` instead to check whether the first 8 lines of the latest PR body text is equal to the first 8 lines of `.github/utils/single_dependency_pr_body.txt`.
This test is the basis for whether the `dependabot_updates` branch should be reset to `master` (when it has been utilized to update dependencies) or `master` should just be merged into `dependabot_updates` (when any other PR is merged into `master`).

I've added a single commit here that will be reverted, but it implements a temporary CI test to check the new method.
It retrieves the PR body for the latest PR that should initiate resetting `dependabot_updates`, and it also retrieves a PR body for another random PR that should initiate the merge.
Then it uses the `diff` approach for both and finally uses it within an `if`-sentence as is intended.