### PR TITLE
Fixed bug in check_anonymous_formula which caused `chemical_formula_anonymous = AB2` to pass validation.

### DIFF
--- a/optimade/models/structures.py
+++ b/optimade/models/structures.py
@@ -872,7 +872,8 @@ The properties of the species are found in the property `species`.
             return v
 
         elements = tuple(re.findall(r"[A-Z][a-z]*", v))
-        numbers = [int(n.strip()) for n in re.split(r"[A-Z][a-z]*", v) if n.strip()]
+        numbers = re.split(r"[A-Z][a-z]*", v)[1:]
+        numbers = [int(i) if i else 1 for i in numbers]
 
         expected_labels = ANONYMOUS_ELEMENTS[: len(elements)]
         expected_numbers = sorted(numbers, reverse=True)

--- a/tests/models/test_structures.py
+++ b/tests/models/test_structures.py
@@ -103,8 +103,8 @@ deformities = (
         "'chemical_formula_anonymous' A2B90 has wrong order: elements with highest proportion should appear first: [2, 90] vs expected [90, 2]",
     ),
     (
-        {"chemical_formula_anonymous": "A2B10"},
-        "'chemical_formula_anonymous' A2B10 has wrong order: elements with highest proportion should appear first: [2, 10] vs expected [10, 2]",
+        {"chemical_formula_anonymous": "AB10"},
+        "'chemical_formula_anonymous' AB10 has wrong order: elements with highest proportion should appear first: [1, 10] vs expected [10, 1]",
     ),
     (
         {"chemical_formula_hill": "SiGe"},


### PR DESCRIPTION
I noticed that in OQMD structure [4061139](http://oqmd.org/optimade/v1/structures?id=4061139) has an invalid chemical_formula_anonymous. i.e. "ABCD4" for "CsHoS4Si" instead of "A4BCD"
On the Optimade providers list, there was however no error for this wrong behaviour. 
So here I have tried to fix the validator so this wrong formatting no longer passes. 

Closes #1002.