### PR TITLE
Make NumPy requirement py version-specific

### DIFF
--- a/docs/getting_started/filtering.md
+++ b/docs/getting_started/filtering.md
@@ -5,7 +5,7 @@ This guide will briefly outline how to parse OPTIMADE filter strings into databa
 
 ## Parsing OPTIMADE filter strings
 
-The [`LarkParser`][optimade.filterparser.LarkParser] class will take an OPTIMADE filter string, supplied by the user, and parse it into a `lark.Tree` instance.
+The [`LarkParser`][optimade.filterparser.lark_parser.LarkParser] class will take an OPTIMADE filter string, supplied by the user, and parse it into a `lark.Tree` instance.
 
 Example use:
 
@@ -68,7 +68,7 @@ filter
 
 ## Flow for parsing a user-supplied filter and converting to a backend query
 
-After the [`LarkParser`][optimade.filterparser.LarkParser] has turned the filter string into a `lark.Tree`, it is fed to a `lark.Transformer` instance, which transforms the 'lark.Tree' into a backend-specific representation of the query.
+After the [`LarkParser`][optimade.filterparser.lark_parser.LarkParser] has turned the filter string into a `lark.Tree`, it is fed to a `lark.Transformer` instance, which transforms the 'lark.Tree' into a backend-specific representation of the query.
 For example, [`MongoTransformer`][optimade.filtertransformers.mongo.MongoTransformer] will turn the tree into something useful for a MongoDB backend:
 
 ```python

--- a/optimade/filterparser/lark_parser.py
+++ b/optimade/filterparser/lark_parser.py
@@ -1,4 +1,4 @@
-"""This submodule implements the [`LarkParser`][optimade.filterparser.LarkParser] class,
+"""This submodule implements the [`LarkParser`][optimade.filterparser.lark_parser.LarkParser] class,
 which uses the lark library to parse filter strings with a defined OPTIMADE filter grammar
 into `Lark.Tree` objects for use by the filter transformers.
 

--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -1,6 +1,6 @@
 aiida-core==1.6.5
 ase==3.22.1
 jarvis-tools==2021.10.3
-numpy==1.21.5;;python_version<'3.8'
+numpy==1.21.5;python_version<'3.8'
 numpy==1.22.0;python_version>='3.8'
 pymatgen==2022.0.16

--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -1,5 +1,6 @@
 aiida-core==1.6.5
 ase==3.22.1
 jarvis-tools==2021.10.3
-numpy==1.21.5
+numpy==1.21.5;;python_version<'3.8'
+numpy==1.22.0;python_version>='3.8'
 pymatgen==2022.0.16


### PR DESCRIPTION
No need to update `setup.py` as the current settings should ensure the
correct version is installed for the respective Python version when
installing through `pip install .` instead of installing the
dependencies through the requirements files.

Fixes #1035 
Fixes #1037 

The commit 426cccc has been cherry-picked and added to this branch,
fixing the issue with the failling Docs CI strict build.