### PR TITLE
Update dependabot config and changelog generation

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -65,6 +65,7 @@ jobs:
         release_branch: ${{ env.PUBLISH_UPDATE_BRANCH }}
         since_tag: "${{ env.PREVIOUS_VERSION }}"
         output: "release_changelog.md"
+        exclude_tags: ["dependency_updates"]
 
     - name: Append changelog to release body
       run: |

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -40,6 +40,7 @@ jobs:
       with:
         token: ${{ secrets.RELEASE_PAT_CASPER }}
         release_branch: ${{ env.PUBLISH_UPDATE_BRANCH }}
+        exclude_tags: ["dependency_updates"]
 
     - name: Update API Reference docs and version - Commit changes and update tag
       run: .github/utils/update_docs.sh

--- a/.github/workflows/ci_dependabot.yml
+++ b/.github/workflows/ci_dependabot.yml
@@ -1,6 +1,7 @@
 name: CI - Single Dependabot PR
 
 on:
+  workflow_dispatch:
   schedule:
     # At 6:30 UTC on the first of every month
     - cron: "30 6 1 * *"

--- a/.github/workflows/ci_dependabot.yml
+++ b/.github/workflows/ci_dependabot.yml
@@ -2,10 +2,8 @@ name: CI - Single Dependabot PR
 
 on:
   schedule:
-    # At 6:30 UTC every Wednesday
-    # Dependabot runs once a week (every Monday) (pip)
-    # and every day (GH Actions) at 5:00 UTC
-    - cron: "30 6 * * 3"
+    # At 6:30 UTC on the first of every month
+    - cron: "30 6 1 * *"
 
 jobs:
 


### PR DESCRIPTION
Closes #1038 by:
- making the dependabot PR only once a month
- allowing manual triggers via the GitHub web interface/API before a release (via `workflow_dispatch`)
- excluding PRs tagged with `dependency_updates` from the changelog (tagging this PR as an extra test) - we will only see this on the next release