### PR TITLE
Lower validator default read timeout and allow it to be customised

### DIFF
--- a/optimade/validator/utils.py
+++ b/optimade/validator/utils.py
@@ -39,7 +39,7 @@ from optimade.models import (
 # Default connection timeout allows for one default-sized TCP retransmission window
 # (see https://docs.python-requests.org/en/latest/user/advanced/#timeouts)
 DEFAULT_CONN_TIMEOUT = 3.05
-DEFAULT_READ_TIMEOUT = 300
+DEFAULT_READ_TIMEOUT = 30
 
 
 class ResponseError(Exception):
@@ -172,6 +172,7 @@ class Client:  # pragma: no cover
         max_retries: int = 5,
         headers: Dict[str, str] = None,
         timeout: Optional[float] = DEFAULT_CONN_TIMEOUT,
+        read_timeout: Optional[float] = DEFAULT_READ_TIMEOUT,
     ) -> None:
         """Initialises the Client with the given `base_url` without testing
         if it is valid.
@@ -190,6 +191,7 @@ class Client:  # pragma: no cover
             max_retries: The maximum number of attempts to make for each query.
             headers: Dictionary of additional headers to add to every request.
             timeout: Connection timeout in seconds.
+            read_timeout: Read timeout in seconds.
 
         """
         self.base_url = base_url
@@ -198,6 +200,7 @@ class Client:  # pragma: no cover
         self.max_retries = max_retries
         self.headers = headers or {}
         self.timeout = timeout or DEFAULT_CONN_TIMEOUT
+        self.read_timeout = read_timeout or DEFAULT_READ_TIMEOUT
 
     def get(self, request: str):
         """Makes the given request, with a number of retries if being rate limited. The
@@ -232,7 +235,7 @@ class Client:  # pragma: no cover
                 self.response = requests.get(
                     self.last_request,
                     headers=self.headers,
-                    timeout=(self.timeout, DEFAULT_READ_TIMEOUT),
+                    timeout=(self.timeout, self.read_timeout),
                 )
 
                 status_code = self.response.status_code

--- a/optimade/validator/validator.py
+++ b/optimade/validator/validator.py
@@ -24,6 +24,7 @@ import requests
 from optimade.models import DataType, EntryInfoResponse, SupportLevel
 from optimade.validator.utils import (
     DEFAULT_CONN_TIMEOUT,
+    DEFAULT_READ_TIMEOUT,
     Client,
     test_case,
     print_failure,
@@ -78,6 +79,7 @@ class ImplementationValidator:
         minimal: bool = False,
         http_headers: Dict[str, str] = None,
         timeout: float = DEFAULT_CONN_TIMEOUT,
+        read_timeout: float = DEFAULT_READ_TIMEOUT,
     ):
         """Set up the tests to run, based on constants in this module
         for required endpoints.
@@ -107,6 +109,7 @@ class ImplementationValidator:
             minimal: Whether or not to run only a minimal test set.
             http_headers: Dictionary of additional headers to add to every request.
             timeout: The connection timeout to use for all requests (in seconds).
+            read_timeout: The read timeout to use for all requests (in seconds).
 
         """
         self.verbosity = verbosity
@@ -158,6 +161,7 @@ class ImplementationValidator:
                 max_retries=self.max_retries,
                 headers=http_headers,
                 timeout=timeout,
+                read_timeout=read_timeout,
             )
 
         self._setup_log()


### PR DESCRIPTION
As above.

Related to issue with the provider dashboard (https://github.com/Materials-Consortia/providers-dashboard/issues/80), caused by an implementation that accepts the connection within the timeout but then very slowly returns the data (hours+).