### PR TITLE
Attempt to fix syntax for actions workflow

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -40,7 +40,7 @@ jobs:
       with:
         token: ${{ secrets.RELEASE_PAT_CASPER }}
         release_branch: ${{ env.PUBLISH_UPDATE_BRANCH }}
-        exclude_tags: ["dependency_updates"]
+        exclude_tags: "dependency_updates"
 
     - name: Update API Reference docs and version - Commit changes and update tag
       run: .github/utils/update_docs.sh
@@ -65,7 +65,7 @@ jobs:
         release_branch: ${{ env.PUBLISH_UPDATE_BRANCH }}
         since_tag: "${{ env.PREVIOUS_VERSION }}"
         output: "release_changelog.md"
-        exclude_tags: ["dependency_updates"]
+        exclude_tags: "dependency_updates"
 
     - name: Append changelog to release body
       run: |


### PR DESCRIPTION
The release workflow failed when generating the changelog due to a syntax error. This PR should fix it.

I have tagged it with `dependency_updates` so it is also excluded from the changelog. Will self-merge and try again.