### PR TITLE
Properly exclude dependency updates from changelog, and add unreleased changelog

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -40,7 +40,7 @@ jobs:
       with:
         token: ${{ secrets.RELEASE_PAT_CASPER }}
         release_branch: ${{ env.PUBLISH_UPDATE_BRANCH }}
-        exclude_tags: "dependency_updates"
+        exclude_labels: "duplicate,question,invalid,wontfix,dependency_updates"
 
     - name: Update API Reference docs and version - Commit changes and update tag
       run: .github/utils/update_docs.sh
@@ -65,7 +65,7 @@ jobs:
         release_branch: ${{ env.PUBLISH_UPDATE_BRANCH }}
         since_tag: "${{ env.PREVIOUS_VERSION }}"
         output: "release_changelog.md"
-        exclude_tags: "dependency_updates"
+        exclude_labels: "duplicate,question,invalid,wontfix,dependency_updates"
 
     - name: Append changelog to release body
       run: |

--- a/.github/workflows/ci_cd_updated_master.yml
+++ b/.github/workflows/ci_cd_updated_master.yml
@@ -67,6 +67,13 @@ jobs:
           exit 1
         fi
 
+    - name: Update changelog with unreleased changes
+      uses: CharMixer/auto-changelog-action@v1
+      with:
+        token: ${{ secrets.RELEASE_PAT_CASPER }}
+        release_branch: ${{ env.PUBLISH_UPDATE_BRANCH }}
+        exclude_labels: "duplicate,question,invalid,wontfix,dependency_updates"
+
     - name: Deploy documentation
       if: env.RELEASE_RUN == 'false'
       run: mike deploy --push --remote origin --branch gh-pages --update-aliases --config-file mkdocs.yml latest ${{ env.DEFAULT_REPO_BRANCH }}


### PR DESCRIPTION
This PR should close #1038, and also adds a changelog build to all pushes to master, showing unreleased changes.

As this is a "tinkering" PR I will self-merge and check that the docs are built correctly.