### PR TITLE
Set future-release label for changelog

### DIFF
--- a/.github/workflows/ci_cd_updated_master.yml
+++ b/.github/workflows/ci_cd_updated_master.yml
@@ -73,6 +73,7 @@ jobs:
         token: ${{ secrets.RELEASE_PAT_CASPER }}
         release_branch: ${{ env.PUBLISH_UPDATE_BRANCH }}
         exclude_labels: "duplicate,question,invalid,wontfix,dependency_updates"
+        future_release: "Unreleased changes"
 
     - name: Deploy documentation
       if: env.RELEASE_RUN == 'false'


### PR DESCRIPTION
Final change to the changelog. This adds unreleased changes to the changelog deployed with mike.

I think this makes sense as the docs deployed under `latest` will include changes that are currently not mentioned in the changelog there. @CasperWA may have opinions before this is merged though.

NB/ as this PR is also tagged with `dependency_updates`, there will be no change to the "latest" changelog until we add something else to master.