### PR TITLE
Prevent errors/retries on read timeouts

### DIFF
--- a/optimade/validator/__init__.py
+++ b/optimade/validator/__init__.py
@@ -2,7 +2,7 @@
 # pylint: disable=import-outside-toplevel
 from optimade import __version__, __api_version__
 from .validator import ImplementationValidator
-from .utils import DEFAULT_CONN_TIMEOUT
+from .utils import DEFAULT_CONN_TIMEOUT, DEFAULT_READ_TIMEOUT
 
 __all__ = ["ImplementationValidator", "validate"]
 
@@ -112,6 +112,13 @@ def validate():  # pragma: no cover
         help=f"Timeout to use for each individual request (DEFAULT: {DEFAULT_CONN_TIMEOUT} s)",
     )
 
+    parser.add_argument(
+        "--read-timeout",
+        type=float,
+        default=DEFAULT_READ_TIMEOUT,
+        help=f"Read timeout to use for each individual request (DEFAULT: {DEFAULT_READ_TIMEOUT} s)",
+    )
+
     args = vars(parser.parse_args())
 
     if os.environ.get("OPTIMADE_VERBOSITY") is not None:
@@ -145,6 +152,7 @@ def validate():  # pragma: no cover
         page_limit=args["page_limit"],
         http_headers=args["headers"],
         timeout=args["timeout"],
+        read_timeout=args["read_timeout"],
     )
 
     try:

--- a/optimade/validator/utils.py
+++ b/optimade/validator/utils.py
@@ -39,7 +39,7 @@ from optimade.models import (
 # Default connection timeout allows for one default-sized TCP retransmission window
 # (see https://docs.python-requests.org/en/latest/user/advanced/#timeouts)
 DEFAULT_CONN_TIMEOUT = 3.05
-DEFAULT_READ_TIMEOUT = 30
+DEFAULT_READ_TIMEOUT = 60
 
 
 class ResponseError(Exception):

--- a/optimade/validator/utils.py
+++ b/optimade/validator/utils.py
@@ -247,6 +247,10 @@ class Client:  # pragma: no cover
             except requests.exceptions.ConnectionError as exc:
                 errors.append(str(exc))
 
+            # Read timeouts should prevent further retries
+            except requests.exceptions.ReadTimeout as exc:
+                raise ResponseError(str(exc)) from None
+
             except requests.exceptions.MissingSchema:
                 sys.exit(
                     f"Unable to make request on {self.last_request}, did you mean http://{self.last_request}?"

--- a/optimade/validator/utils.py
+++ b/optimade/validator/utils.py
@@ -249,7 +249,7 @@ class Client:  # pragma: no cover
 
             # Read timeouts should prevent further retries
             except requests.exceptions.ReadTimeout as exc:
-                raise ResponseError(str(exc)) from None
+                raise ResponseError(str(exc)) from exc
 
             except requests.exceptions.MissingSchema:
                 sys.exit(


### PR DESCRIPTION
The last PR (#1051) introduced explicit read timeouts and reduced the default value to 30 seconds. After some testing with the dashboard, 30 seconds is quite a harsh timeout for some implementations/requests, so this is now increased to 2 minutes by default. Also, as `requests.exceptions.ReadTimeout` does not subclass `requests.exceptions.ConnectionError`, these requests were failing with "internal" validator errors, rather than being handled as errors related to the implementation.

This PR fixes that error handling, and additionally prevents read timeouts from triggering retries. A CLI arg was also added for `--read-timeout` for easier testing.