### PR TITLE
Cancel CI PR jobs that are in progress with new changes, add skip_changelog label to overrides

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -40,7 +40,7 @@ jobs:
       with:
         token: ${{ secrets.RELEASE_PAT_CASPER }}
         release_branch: ${{ env.PUBLISH_UPDATE_BRANCH }}
-        exclude_labels: "duplicate,question,invalid,wontfix,dependency_updates"
+        exclude_labels: "duplicate,question,invalid,wontfix,dependency_updates,skip_changelog"
 
     - name: Update API Reference docs and version - Commit changes and update tag
       run: .github/utils/update_docs.sh
@@ -65,7 +65,7 @@ jobs:
         release_branch: ${{ env.PUBLISH_UPDATE_BRANCH }}
         since_tag: "${{ env.PREVIOUS_VERSION }}"
         output: "release_changelog.md"
-        exclude_labels: "duplicate,question,invalid,wontfix,dependency_updates"
+        exclude_labels: "duplicate,question,invalid,wontfix,dependency_updates,skip_changelog"
 
     - name: Append changelog to release body
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,13 @@ on:
     - master
     - 'push-action/**'
 
-jobs:
+# Cancel running workflows when additional changes are pushed
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-a-fallback-value
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
+jobs:
   lint:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci_cd_updated_master.yml
+++ b/.github/workflows/ci_cd_updated_master.yml
@@ -72,7 +72,7 @@ jobs:
       with:
         token: ${{ secrets.RELEASE_PAT_CASPER }}
         release_branch: ${{ env.PUBLISH_UPDATE_BRANCH }}
-        exclude_labels: "duplicate,question,invalid,wontfix,dependency_updates"
+        exclude_labels: "duplicate,question,invalid,wontfix,dependency_updates,skip_changelog"
         future_release: "Unreleased changes"
 
     - name: Deploy documentation


### PR DESCRIPTION
As above. This PR will cancel workflows from running when new changes are pushed to a PR.