### PR TITLE
Use `build` package to build distributions

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -76,7 +76,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.RELEASE_PAT_CASPER }}
 
     - name: Build source distribution
-      run: python ./setup.py sdist
+      run: python -m build
 
     - name: Publish package to PyPI
       uses: pypa/gh-action-pypi-publish@master

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,5 +2,4 @@ recursive-include optimade/server/ *.json
 recursive-include optimade/server/data/ *
 recursive-include optimade/server/routers/static/ *
 recursive-include optimade/grammar/ *.lark
-recursive-include optimade/validator/data/ *.txt
 include LICENSE

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+build==0.7.0
 codecov==2.1.12
 invoke==1.6.0
 jsondiff==1.3.0

--- a/setup.py
+++ b/setup.py
@@ -43,10 +43,11 @@ docs_deps = [
     "mkdocstrings~=0.17.0",
 ]
 testing_deps = [
-    "pytest~=6.2",
-    "pytest-cov~=3.0",
+    "build~=0.7.0",
     "codecov~=2.1",
     "jsondiff~=1.3",
+    "pytest~=6.2",
+    "pytest-cov~=3.0",
 ] + server_deps
 dev_deps = (
     ["pylint~=2.12", "pre-commit~=2.16", "invoke~=1.6"]


### PR DESCRIPTION
Fixes #1061 

Use `python -m build` instead of `python setup.py sdist` for building the distribution.
Also use this in the tests - simultaneously fixing an issue experienced with `python setup.py sdist`.

Remove unnecessary statement in MANIFEST to include `txt`-files from `optimade/validator/data/`.