### PR TITLE
Bump elasticsearch version to avoid CVE-2021-44832

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
         ports:
         - 5432:5432
       elasticsearch:
-        image: elasticsearch:6.8.22
+        image: elasticsearch:6.8.23
         ports:
           - 9200:9200
           - 9300:9300

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -96,7 +96,7 @@ These commands should be run from a local optimade-python-tools directory.
 
 The following command starts a local Elasticsearch v6 instance, runs the test suite, then stops and deletes the containers (required as the tests insert some data):
 ```shell
-docker run -d --name elasticsearch_test -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" elasticsearch:6.8.22 \
+docker run -d --name elasticsearch_test -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" elasticsearch:6.8.23 \
 && sleep 10 \
 && OPTIMADE_DATABASE_BACKEND="elastic" py.test; \
 docker container stop elasticsearch_test; docker container rm elasticsearch_test


### PR DESCRIPTION
There is a [security issue with version log4j version 2.17.0](https://github.com/advisories/GHSA-8489-44mv-ggj8) which is included in Elasticsearch 6.8.22. 
Therefore we need to update to Elasticsearch 6.8.23.
This should also fix the [pylint-safety message](https://github.com/Materials-Consortia/optimade-gateway/runs/5032821967?check_suite_focus=true)