### PR TITLE
Jinja2 version workaround

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,7 +208,6 @@ jobs:
     - name: Install adapter conversion dependencies
       run: |
         pip install -r requirements-client.txt
-        pip install -r requirements.txt
         # AiiDA-specific
         reentry scan
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,8 @@ jobs:
       run: |
         pip install -r requirements-client.txt
         # AiiDA-specific
-        reentry scan
+        # reentry scan
+        pip install --r requirements.txt
 
     - name: Setup up environment for AiiDA
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,9 +208,9 @@ jobs:
     - name: Install adapter conversion dependencies
       run: |
         pip install -r requirements-client.txt
-        # AiiDA-specific
-        # reentry scan
         pip install -r requirements.txt
+        # AiiDA-specific
+        reentry scan
 
     - name: Setup up environment for AiiDA
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,7 +210,7 @@ jobs:
         pip install -r requirements-client.txt
         # AiiDA-specific
         # reentry scan
-        pip install --r requirements.txt
+        pip install -r requirements.txt
 
     - name: Setup up environment for AiiDA
       env:

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,4 +1,4 @@
-markupsafe==2.0.1
+markupsafe==2.0.1 # Can be removed once aiida supports Jinja2>=3, see pallets/markupsafe#284
 mike==1.1.2
 mkdocs==1.2.3
 mkdocs-awesome-pages-plugin==2.6.1

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,3 +1,4 @@
+markupsafe==2.0.1
 mike==1.1.2
 mkdocs==1.2.3
 mkdocs-awesome-pages-plugin==2.6.1


### PR DESCRIPTION
Fixes #1079 

This PR implements a workaround for a Jinja2 issue, where installing Jinja2<3 is an issue.

AiiDA requires Jinja2<3, so after installing AiiDA, the base requirements are re-installed. This is just a workaround. The issue lies with AiiDA's requirements.