### PR TITLE
Allow specification of provider field descriptions/units etc. in config file

### DIFF
--- a/optimade/server/config.py
+++ b/optimade/server/config.py
@@ -2,7 +2,7 @@
 from enum import Enum
 from pathlib import Path
 import warnings
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 try:
     from typing import Literal
@@ -224,7 +224,8 @@ class ServerConfig(BaseSettings):
         description="General information about the provider of this OPTIMADE implementation",
     )
     provider_fields: Dict[
-        Literal["links", "references", "structures"], List[str]
+        Literal["links", "references", "structures"],
+        List[Union[str, Dict[Literal["name", "type", "unit", "description"], str]]],
     ] = Field(
         {},
         description=(

--- a/optimade/server/entry_collections/entry_collections.py
+++ b/optimade/server/entry_collections/entry_collections.py
@@ -83,7 +83,10 @@ class EntryCollection(ABC):
         self.transformer = transformer
 
         self.provider_prefix = CONFIG.provider.prefix
-        self.provider_fields = CONFIG.provider_fields.get(resource_mapper.ENDPOINT, [])
+        self.provider_fields = [
+            field if isinstance(field, str) else field["name"]
+            for field in CONFIG.provider_fields.get(resource_mapper.ENDPOINT, [])
+        ]
 
         self._all_fields: Set[str] = None
 

--- a/optimade/server/mappers/entries.py
+++ b/optimade/server/mappers/entries.py
@@ -92,6 +92,12 @@ class BaseResourceMapper:
             tuple(
                 (f"_{CONFIG.provider.prefix}_{field}", field)
                 for field in CONFIG.provider_fields.get(cls.ENDPOINT, [])
+                if isinstance(field, str)
+            )
+            + tuple(
+                (f"_{CONFIG.provider.prefix}_{field['name']}", field["name"])
+                for field in CONFIG.provider_fields.get(cls.ENDPOINT, [])
+                if isinstance(field, dict)
             )
             + tuple(
                 (f"_{CONFIG.provider.prefix}_{field}", field)
@@ -126,6 +132,12 @@ class BaseResourceMapper:
             .union(
                 cls.get_optimade_field(field)
                 for field in CONFIG.provider_fields.get(cls.ENDPOINT, ())
+                if isinstance(field, str)
+            )
+            .union(
+                cls.get_optimade_field(field["name"])
+                for field in CONFIG.provider_fields.get(cls.ENDPOINT, ())
+                if isinstance(field, dict)
             )
             .union(set(cls.get_optimade_field(field) for field in cls.PROVIDER_FIELDS))
         )

--- a/optimade/server/routers/info.py
+++ b/optimade/server/routers/info.py
@@ -65,7 +65,9 @@ def get_entry_info(request: Request, entry: str) -> EntryInfoResponse:
 
     schema = ENTRY_INFO_SCHEMAS[entry]()
     queryable_properties = {"id", "type", "attributes"}
-    properties = retrieve_queryable_properties(schema, queryable_properties)
+    properties = retrieve_queryable_properties(
+        schema, queryable_properties, entry_type=entry
+    )
 
     output_fields_by_format = {"json": list(properties.keys())}
 

--- a/optimade_config.json
+++ b/optimade_config.json
@@ -18,7 +18,7 @@
     "provider_fields": {
         "structures": [
             "band_gap",
-            "chemsys"
+            {"name": "chemsys", "type": "string", "description": "A string representing the chemical system in an ordered fashion"}
         ]
     },
     "aliases": {

--- a/tests/server/routers/test_info.py
+++ b/tests/server/routers/test_info.py
@@ -1,5 +1,3 @@
-import pytest
-
 from optimade.models import InfoResponse, EntryInfoResponse, IndexInfoResponse, DataType
 
 from ..utils import RegularEndpointTests, IndexEndpointTests
@@ -90,12 +88,10 @@ class TestInfoStructuresEndpoint(RegularEndpointTests):
             else:
                 assert "unit" not in info_keys, f"Field: {field}"
 
-    @pytest.mark.skip("Unskip when PR #277 has been merged.")
     def test_provider_fields(self):
         """Check the presence of provider-specific fields"""
-        from optimade.server.config import CONFIG
 
-        provider_fields = CONFIG.provider_fields.get("structures", [])
+        provider_fields = ["chemsys"]
 
         if not provider_fields:
             import warnings
@@ -104,7 +100,7 @@ class TestInfoStructuresEndpoint(RegularEndpointTests):
             return
 
         for field in provider_fields:
-            updated_field_name = f"_{CONFIG.provider.prefix}_{field}"
+            updated_field_name = f"_exmpl_{field}"
             assert updated_field_name in self.json_response.get("data", {}).get(
                 "properties", {}
             )

--- a/tests/server/test_schemas.py
+++ b/tests/server/test_schemas.py
@@ -30,3 +30,23 @@ def test_schemas():
         # Check that all expected keys are present for OPTIMADE fields
         for key in ("type", "sortable", "queryable", "description"):
             assert all(key in properties[field] for field in properties)
+
+
+def test_provider_field_schemas():
+    """Tests that the default configured provider fields that have descriptions
+    are dereferenced appropriately.
+
+    """
+    entry = "structures"
+    test_field = "chemsys"
+    schema = ENTRY_INFO_SCHEMAS[entry]()
+    top_level_props = ("id", "type", "attributes")
+    properties = retrieve_queryable_properties(schema, top_level_props, entry)
+    name = f"_exmpl_{test_field}"
+
+    assert name in properties
+    assert properties[name] == {
+        "type": "string",
+        "description": "A string representing the chemical system in an ordered fashion",
+        "sortable": True,
+    }

--- a/tests/test_config.json
+++ b/tests/test_config.json
@@ -18,7 +18,7 @@
     "provider_fields": {
         "structures": [
             "band_gap",
-            "chemsys"
+            {"name": "chemsys", "type": "string", "description": "A string representing the chemical system in an ordered fashion"}
         ]
     },
     "aliases": {


### PR DESCRIPTION
Closes #1095.

This PR also enables some old tests for provider fields that we had disabled.