### PR TITLE
Use bot account PAT for releases

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Update changelog
       uses: CharMixer/auto-changelog-action@v1
       with:
-        token: ${{ secrets.RELEASE_PAT_CASPER }}
+        token: ${{ secrets.RELEASE_PAT_BOT }}
         release_branch: ${{ env.PUBLISH_UPDATE_BRANCH }}
         exclude_labels: "duplicate,question,invalid,wontfix,dependency_updates,skip_changelog"
 
@@ -48,7 +48,7 @@ jobs:
     - name: Update '${{ env.PUBLISH_UPDATE_BRANCH }}'
       uses: CasperWA/push-protected@v2
       with:
-        token: ${{ secrets.RELEASE_PAT_CASPER }}
+        token: ${{ secrets.RELEASE_PAT_BOT }}
         branch: ${{ env.PUBLISH_UPDATE_BRANCH }}
         unprotect_reviews: true
         sleep: 15
@@ -61,7 +61,7 @@ jobs:
     - name: Create release-specific changelog
       uses: CharMixer/auto-changelog-action@v1
       with:
-        token: ${{ secrets.RELEASE_PAT_CASPER }}
+        token: ${{ secrets.RELEASE_PAT_BOT }}
         release_branch: ${{ env.PUBLISH_UPDATE_BRANCH }}
         since_tag: "${{ env.PREVIOUS_VERSION }}"
         output: "release_changelog.md"
@@ -73,7 +73,7 @@ jobs:
         cat release_changelog.md >> release_body.md
         gh api /repos/${{ github.repository }}/releases/${{ github.event.release.id }} -X PATCH -F body='@release_body.md'
       env:
-        GITHUB_TOKEN: ${{ secrets.RELEASE_PAT_CASPER }}
+        GITHUB_TOKEN: ${{ secrets.RELEASE_PAT_BOT }}
 
     - name: Build source distribution
       run: python -m build

--- a/.github/workflows/ci_automerge_dependabot.yml
+++ b/.github/workflows/ci_automerge_dependabot.yml
@@ -24,4 +24,4 @@ jobs:
         PR_ID="$(gh api graphql -F owner='{owner}' -F name='{repo}' -f query='query($owner: String!, $name: String!) {repository(owner: $owner, name: $name) {pullRequest(number: ${{ github.event.pull_request.number }}) {id}}}' --jq '.data.repository.pullRequest.id')"
         gh api graphql -f pr_id="$PR_ID" -f query='mutation($pr_id: ID!) {enablePullRequestAutoMerge(input:{mergeMethod:SQUASH,pullRequestId:$pr_id }) {pullRequest {number}}}'
       env:
-        GITHUB_TOKEN: ${{ secrets.RELEASE_PAT_CASPER }}
+        GITHUB_TOKEN: ${{ secrets.RELEASE_PAT_BOT }}

--- a/.github/workflows/ci_cd_updated_master.yml
+++ b/.github/workflows/ci_cd_updated_master.yml
@@ -70,7 +70,7 @@ jobs:
     - name: Update changelog with unreleased changes
       uses: CharMixer/auto-changelog-action@v1
       with:
-        token: ${{ secrets.RELEASE_PAT_CASPER }}
+        token: ${{ secrets.RELEASE_PAT_BOT }}
         release_branch: ${{ env.PUBLISH_UPDATE_BRANCH }}
         exclude_labels: "duplicate,question,invalid,wontfix,dependency_updates,skip_changelog"
         future_release: "Unreleased changes"
@@ -123,7 +123,7 @@ jobs:
     - name: Push to '${{ env.DEPENDABOT_BRANCH }}'
       uses: CasperWA/push-protected@v2
       with:
-        token: ${{ secrets.RELEASE_PAT_CASPER }}
+        token: ${{ secrets.RELEASE_PAT_BOT }}
         branch: ${{ env.DEPENDABOT_BRANCH }}
         sleep: 15
         force: ${{ env.FORCE_PUSH }}

--- a/.github/workflows/ci_dependabot.yml
+++ b/.github/workflows/ci_dependabot.yml
@@ -81,7 +81,7 @@ jobs:
       id: cpr
       uses: peter-evans/create-pull-request@v3
       with:
-        token: ${{ secrets.RELEASE_PAT_CASPER }}
+        token: ${{ secrets.RELEASE_PAT_BOT }}
         commit-message: New @dependabot-fueled updates
         committer: "${{ env.GIT_USER_NAME }} <${{ env.GIT_USER_EMAIL }}>"
         author: "${{ env.GIT_USER_NAME }} <${{ env.GIT_USER_EMAIL }}>"


### PR DESCRIPTION
I just made @bot-optimade for the status page etc. and it probably makes sense to use it here too. It has the dev@optimade.org email address so will take ownership of the commits previously attributed to "OPTIMADE Developers".

I have added the bot's PAT to the organization secrets so that we can replace @CasperWA's credentials. 