### PR TITLE
Make structure adapters infer `species` from `species_at_sites` when missing

### DIFF
--- a/optimade/adapters/structures/aiida.py
+++ b/optimade/adapters/structures/aiida.py
@@ -8,11 +8,13 @@ For more information on the AiiDA code see [their website](http://www.aiida.net)
 This conversion function relies on the [`aiida-core`](https://github.com/aiidateam/aiida-core) package.
 """
 from warnings import warn
+from typing import List, Optional
 
 from optimade.models import StructureResource as OptimadeStructure
+from optimade.models import Species as OptimadeStructureSpecies
 
 from optimade.adapters.warnings import AdapterPackageNotFound, ConversionWarning
-from optimade.adapters.structures.utils import pad_cell
+from optimade.adapters.structures.utils import pad_cell, species_from_species_at_sites
 
 try:
     from aiida.orm.nodes.data.structure import StructureData, Kind, Site
@@ -46,8 +48,13 @@ def get_aiida_structure_data(optimade_structure: OptimadeStructure) -> Structure
     lattice_vectors, adjust_cell = pad_cell(attributes.lattice_vectors)
     structure = StructureData(cell=lattice_vectors)
 
+    # If species not provided, infer data from species_at_sites
+    species: Optional[List[OptimadeStructureSpecies]] = attributes.species
+    if not species:
+        species = species_from_species_at_sites(attributes.species_at_sites)
+
     # Add Kinds
-    for kind in attributes.species:
+    for kind in species:
         symbols = []
         concentration = []
         mass = 0.0

--- a/optimade/adapters/structures/utils.py
+++ b/optimade/adapters/structures/utils.py
@@ -6,6 +6,7 @@ Most of these functions rely on the [NumPy](https://numpy.org/) library.
 from typing import List, Tuple, Iterable
 
 from optimade.models.structures import Vector3D
+from optimade.models.structures import Species as OptimadeStructureSpecies
 
 try:
     import numpy as np
@@ -315,3 +316,28 @@ def pad_cell(
         outer=tuple,
         inner=tuple,
     )
+
+
+def species_from_species_at_sites(
+    species_at_sites: List[str],
+) -> List[OptimadeStructureSpecies]:
+    """When a list of species dictionaries is not provided, this function
+    can be used to infer the species from the provided species_at_sites.
+
+    In this use case, species_at_sites is assumed to provide a list of
+    element symbols, and refers to situations with no mixed occupancy, i.e.,
+    the constructed species list will contain all unique species with
+    concentration equal to 1 and the species_at_site tag will be used as
+    the chemical symbol.
+
+    Parameters:
+        species_at_sites: The list found under the species_at_sites field.
+
+    Returns:
+        An OPTIMADE species list.
+
+    """
+    return [
+        OptimadeStructureSpecies(name=_, concentration=[1.0], chemical_symbols=[_])
+        for _ in set(species_at_sites)
+    ]

--- a/tests/adapters/structures/conftest.py
+++ b/tests/adapters/structures/conftest.py
@@ -49,3 +49,9 @@ def null_lattice_vector_structure(raw_structure) -> Structure:
     raw_structure["attributes"]["dimension_types"][0] = 0
     raw_structure["attributes"]["nperiodic_dimensions"] = 2
     return Structure(raw_structure)
+
+
+@pytest.fixture
+def null_species_structure(raw_structure) -> Structure:
+    raw_structure["attributes"]["species"] = None
+    return Structure(raw_structure)

--- a/tests/adapters/structures/test_aiida.py
+++ b/tests/adapters/structures/test_aiida.py
@@ -82,3 +82,8 @@ def test_special_species(SPECIAL_SPECIES_STRUCTURES):
                 )
         else:
             assert aiida_structure.kinds[0].mass == 1.0
+
+
+def test_null_species(null_species_structure):
+    """Make sure null species are handled"""
+    assert isinstance(get_aiida_structure_data(null_species_structure), StructureData)

--- a/tests/adapters/structures/test_ase.py
+++ b/tests/adapters/structures/test_ase.py
@@ -40,3 +40,8 @@ def test_special_species(SPECIAL_SPECIES_STRUCTURES):
             r"(ASE cannot handle structures with unknown \('X'\) chemical symbols)",
         ):
             get_ase_atoms(structure)
+
+
+def test_null_species(null_species_structure):
+    """Make sure null species are handled"""
+    assert isinstance(get_ase_atoms(null_species_structure), Atoms)

--- a/tests/adapters/structures/test_pymatgen.py
+++ b/tests/adapters/structures/test_pymatgen.py
@@ -49,3 +49,8 @@ def test_special_species(SPECIAL_SPECIES_STRUCTURES):
     for special_structure in SPECIAL_SPECIES_STRUCTURES:
         structure = Structure(special_structure)
         assert isinstance(get_pymatgen(structure), PymatgenStructure)
+
+
+def test_null_species(null_species_structure):
+    """Make sure null species are handled"""
+    assert isinstance(get_pymatgen(null_species_structure), PymatgenStructure)

--- a/tests/adapters/structures/test_utils.py
+++ b/tests/adapters/structures/test_utils.py
@@ -16,6 +16,7 @@ from optimade.adapters.structures.utils import (
     fractional_coordinates,
     pad_cell,
     scaled_cell,
+    species_from_species_at_sites,
 )
 
 
@@ -115,3 +116,47 @@ def test_scaled_cell_consistency(structure):
     volume_from_scale = 1 / numpy.linalg.det(scale)
 
     assert volume_from_scale == pytest.approx(volume_from_cellpar)
+
+
+def test_species_from_species_at_sites(structure):
+    """Test that species can be inferred from species_at_sites"""
+    species_at_sites = ["Si"]
+    assert [d.dict() for d in species_from_species_at_sites(species_at_sites)] == [
+        {
+            "name": "Si",
+            "concentration": [1.0],
+            "chemical_symbols": ["Si"],
+            "attached": None,
+            "mass": None,
+            "original_name": None,
+            "nattached": None,
+        },
+    ]
+
+    species_at_sites = ["Si", "Si", "O", "O", "O", "O"]
+    assert sorted(
+        [d.dict() for d in species_from_species_at_sites(species_at_sites)],
+        key=lambda _: _["name"],
+    ) == sorted(
+        [
+            {
+                "name": "O",
+                "concentration": [1.0],
+                "chemical_symbols": ["O"],
+                "attached": None,
+                "mass": None,
+                "original_name": None,
+                "nattached": None,
+            },
+            {
+                "name": "Si",
+                "concentration": [1.0],
+                "chemical_symbols": ["Si"],
+                "attached": None,
+                "mass": None,
+                "original_name": None,
+                "nattached": None,
+            },
+        ],
+        key=lambda _: _["name"],
+    )


### PR DESCRIPTION
I keep running into this issue where implementations do not return `species` by default, because their species dictionaries are extremely simple (i.e., single chemical symbol per species, no disorder, and the name follows the element symbol).

This PR allows the ASE, AiiDA and pymatgen structure adapters to infer this simple structure from just `species_at_sites` when `species` is missing/None.