### PR TITLE
Added option to validate incoming URL query parameters

### DIFF
--- a/optimade/server/config.py
+++ b/optimade/server/config.py
@@ -267,6 +267,10 @@ class ServerConfig(BaseSettings):
         Path("/var/log/optimade/"),
         description="Folder in which log files will be saved.",
     )
+    check_parameters: Optional[bool] = Field(
+        True,
+        description="If True, the code will check whether the query parameters given in the URL string are correct.",
+    )
 
     @validator("implementation", pre=True)
     def set_implementation_version(cls, v):

--- a/optimade/server/config.py
+++ b/optimade/server/config.py
@@ -269,7 +269,7 @@ class ServerConfig(BaseSettings):
     )
     validate_query_parameters: Optional[bool] = Field(
         True,
-        description="If True, the code will check whether the query parameters given in the URL string are correct.",
+        description="If True, the server will check whether the query parameters given in the request are correct.",
     )
 
     @validator("implementation", pre=True)

--- a/optimade/server/config.py
+++ b/optimade/server/config.py
@@ -267,7 +267,7 @@ class ServerConfig(BaseSettings):
         Path("/var/log/optimade/"),
         description="Folder in which log files will be saved.",
     )
-    check_parameters: Optional[bool] = Field(
+    validate_query_parameters: Optional[bool] = Field(
         True,
         description="If True, the code will check whether the query parameters given in the URL string are correct.",
     )

--- a/optimade/server/query_params.py
+++ b/optimade/server/query_params.py
@@ -10,7 +10,9 @@ from optimade.server.warnings import UnknownProviderQueryParameter
 
 class BaseQueryParams:
     def check_params(self, query_params):
-        """This method check whether there are no misspelled query parameters in the request."""
+        """This method check whether all the query_parameters that are specified in the URL string occur in the relevant QueryParams class.
+        If a query parameter is found that is not defined QueryParams class and it does not have a known prefix of an appropriate error or warning will be given.
+        """
         if CONFIG.check_parameters:
             errors = []
             warnings = []

--- a/optimade/server/query_params.py
+++ b/optimade/server/query_params.py
@@ -1,4 +1,4 @@
-from fastapi import Query, Request
+from fastapi import Query
 from pydantic import EmailStr  # pylint: disable=no-name-in-module
 
 from optimade.server.config import CONFIG
@@ -9,12 +9,12 @@ from optimade.server.warnings import UnknownProviderQueryParameter
 
 
 class BaseQueryParams:
-    def check_params(self, request: Request):
+    def check_params(self, query_params):
         """This method check whether there are no misspelled query parameters in the request."""
         if CONFIG.check_parameters:
             errors = []
             warnings = []
-            for param in request.query_params.keys():
+            for param in query_params.keys():
                 if not hasattr(self, param):
                     split_param = param.split("_")
                     if param.startswith("_") and len(split_param) > 2:

--- a/optimade/server/query_params.py
+++ b/optimade/server/query_params.py
@@ -11,16 +11,16 @@ from abc import ABC
 
 class BaseQueryParams(ABC):
     def check_params(self, query_params: Iterable[str]) -> None:
-        """This method checks whether all the query parameters that are specified 
+        """This method checks whether all the query parameters that are specified
         in the URL string are implemented in the relevant `*QueryParams` class.
-        
-        If a query parameter is found that is not defined in the relevant `*QueryParams` class, 
-        and it does not have a known provider prefix, an appropriate error (`BadRequest`) 
+
+        If a query parameter is found that is not defined in the relevant `*QueryParams` class,
+        and it does not have a known provider prefix, an appropriate error (`BadRequest`)
         or warning (`UnknownProviderQueryParameter`) will be emitted.
 
         Arguments:
             query_params: An iterable of the request's string query parameters.
-            
+
         Raises:
             `BadRequest`: if the query parameter was not found in the relevant class, or if it
                 does not have a valid prefix.

--- a/optimade/server/query_params.py
+++ b/optimade/server/query_params.py
@@ -10,12 +10,20 @@ from abc import ABC
 
 
 class BaseQueryParams(ABC):
-    def check_params(self, query_params: Iterable[str]):
-        """This method checks whether all the query_parameters that are specified in the URL string occur in the relevant QueryParams class.
-        If a query parameter is found that is not defined in the QueryParams class and it does not have a known prefix, an appropriate error or warning will be given.
+    def check_params(self, query_params: Iterable[str]) -> None:
+        """This method checks whether all the query parameters that are specified 
+        in the URL string are implemented in the relevant `*QueryParams` class.
+        
+        If a query parameter is found that is not defined in the relevant `*QueryParams` class, 
+        and it does not have a known provider prefix, an appropriate error (`BadRequest`) 
+        or warning (`UnknownProviderQueryParameter`) will be emitted.
 
-        args:
-            query_params: An iterable object that returns the query parameters, as strings, for which it should be checked that they are in the relevant QueryParams class.
+        Arguments:
+            query_params: An iterable of the request's string query parameters.
+            
+        Raises:
+            `BadRequest`: if the query parameter was not found in the relevant class, or if it
+                does not have a valid prefix.
 
         """
         if not getattr(CONFIG, "validate_query_parameters", False):

--- a/optimade/server/query_params.py
+++ b/optimade/server/query_params.py
@@ -18,7 +18,7 @@ class BaseQueryParams(ABC):
             query_params: An iterable object that returns the query parameters, as strings, for which it should be checked that they are in the relevant QueryParams class.
 
         """
-        if not CONFIG.validate_query_parameters:
+        if not getattr(CONFIG, "validate_query_parameters", False):
             return
         errors = []
         warnings = []

--- a/optimade/server/query_params.py
+++ b/optimade/server/query_params.py
@@ -1,6 +1,6 @@
 from fastapi import Query
 from pydantic import EmailStr  # pylint: disable=no-name-in-module
-
+from typing import Iterable
 from optimade.server.config import CONFIG
 from warnings import warn
 from optimade.server.mappers import BaseResourceMapper
@@ -9,14 +9,18 @@ from optimade.server.warnings import UnknownProviderQueryParameter
 
 
 class BaseQueryParams:
-    def check_params(self, query_params):
+    def check_params(self, query_params: Iterable[str]):
         """This method check whether all the query_parameters that are specified in the URL string occur in the relevant QueryParams class.
         If a query parameter is found that is not defined QueryParams class and it does not have a known prefix of an appropriate error or warning will be given.
+
+        args:
+            query_params: An iterable object that returns the query parameters, as strings, for which it should be checked that they are in the relevant QueryParams class.
+
         """
         if CONFIG.check_parameters:
             errors = []
             warnings = []
-            for param in query_params.keys():
+            for param in query_params:
                 if not hasattr(self, param):
                     split_param = param.split("_")
                     if param.startswith("_") and len(split_param) > 2:

--- a/optimade/server/query_params.py
+++ b/optimade/server/query_params.py
@@ -17,7 +17,8 @@ class BaseQueryParams:
             query_params: An iterable object that returns the query parameters, as strings, for which it should be checked that they are in the relevant QueryParams class.
 
         """
-        if CONFIG.check_parameters:
+        if not CONFIG.validate_query_parameters:
+            return
             errors = []
             warnings = []
             for param in query_params:

--- a/optimade/server/routers/utils.py
+++ b/optimade/server/routers/utils.py
@@ -23,7 +23,6 @@ from optimade.server.exceptions import BadRequest, InternalServerError
 from optimade.server.query_params import EntryListingQueryParams, SingleEntryQueryParams
 from optimade.utils import mongo_id_for_database, get_providers, PROVIDER_LIST_URLS
 
-
 __all__ = (
     "BASE_URL_PREFIXES",
     "meta_values",

--- a/optimade/server/routers/utils.py
+++ b/optimade/server/routers/utils.py
@@ -288,6 +288,7 @@ def get_single_entry(
 ) -> EntryResponseOne:
     from optimade.server.routers import ENTRY_COLLECTIONS
 
+    check_params(request, params)
     params.filter = f'id="{entry_id}"'
     (
         results,
@@ -343,5 +344,5 @@ def check_params(
                     )
             else:
                 raise BadRequest(
-                    detail=f"The query parameter '{param}' is not known by this server."
+                    detail=f"The query parameter '{param}' is not known by this entry point."
                 )

--- a/optimade/server/routers/utils.py
+++ b/optimade/server/routers/utils.py
@@ -1,5 +1,6 @@
 # pylint: disable=import-outside-toplevel,too-many-locals
 import re
+from warnings import warn
 import urllib.parse
 from datetime import datetime
 from typing import Any, Dict, List, Set, Union
@@ -22,6 +23,8 @@ from optimade.server.entry_collections import EntryCollection
 from optimade.server.exceptions import BadRequest, InternalServerError
 from optimade.server.query_params import EntryListingQueryParams, SingleEntryQueryParams
 from optimade.utils import mongo_id_for_database, get_providers, PROVIDER_LIST_URLS
+from optimade.server.mappers import BaseResourceMapper
+from optimade.server.warnings import UnknownProviderQueryParameter
 
 __all__ = (
     "BASE_URL_PREFIXES",
@@ -235,6 +238,7 @@ def get_entries(
     """Generalized /{entry} endpoint getter"""
     from optimade.server.routers import ENTRY_COLLECTIONS
 
+    check_params(request, params)
     (
         results,
         data_returned,
@@ -319,3 +323,25 @@ def get_single_entry(
         ),
         included=included,
     )
+
+
+def check_params(
+    request: Request, params: Union[EntryListingQueryParams, SingleEntryQueryParams]
+):
+    for param in request.query_params.keys():
+        if not hasattr(params, param):
+            split_param = param.split("_")
+            if param.startswith("_") and len(split_param) > 2:
+                if split_param[1] not in BaseResourceMapper.KNOWN_PROVIDER_PREFIXES:
+                    warn(
+                        f"The Query parameter '{param}' has an unknown provider prefix: '{split_param[1]}'. This query parameter has been ignored.",
+                        UnknownProviderQueryParameter,
+                    )
+                elif split_param[1] in BaseResourceMapper.SUPPORTED_PREFIXES:
+                    raise BadRequest(
+                        detail=f"The query parameter '{param}' has a prefix that is supported by this server, yet the parameter is not known."
+                    )
+            else:
+                raise BadRequest(
+                    detail=f"The query parameter '{param}' is not known by this server."
+                )

--- a/optimade/server/routers/utils.py
+++ b/optimade/server/routers/utils.py
@@ -236,7 +236,7 @@ def get_entries(
     """Generalized /{entry} endpoint getter"""
     from optimade.server.routers import ENTRY_COLLECTIONS
 
-    params.check_params(request)
+    params.check_params(request.query_params)
     (
         results,
         data_returned,
@@ -286,7 +286,7 @@ def get_single_entry(
 ) -> EntryResponseOne:
     from optimade.server.routers import ENTRY_COLLECTIONS
 
-    params.check_params(request)
+    params.check_params(request.query_params)
     params.filter = f'id="{entry_id}"'
     (
         results,

--- a/optimade/server/warnings.py
+++ b/optimade/server/warnings.py
@@ -59,7 +59,7 @@ class UnknownProviderProperty(OptimadeWarning):
 
 
 class UnknownProviderQueryParameter(OptimadeWarning):
-    """A provider-specific query parameter has been requested in the query who's prefix is not
+    """A provider-specific query parameter has been requested in the query with a prefix not
     recognised by this implementation.
 
     """

--- a/optimade/server/warnings.py
+++ b/optimade/server/warnings.py
@@ -56,3 +56,10 @@ class UnknownProviderProperty(OptimadeWarning):
     recognised by this implementation.
 
     """
+
+
+class UnknownProviderQueryParameter(OptimadeWarning):
+    """A provider-specific query parameter has been requested in the query who's prefix is not
+    recognised by this implementation.
+
+    """

--- a/optimade/server/warnings.py
+++ b/optimade/server/warnings.py
@@ -8,10 +8,7 @@ class OptimadeWarning(Warning):
         self.title = title if title else self.__class__.__name__
 
     def __repr__(self) -> str:
-        attrs = {
-            "detail": self.detail,
-            "title": self.title,
-        }
+        attrs = {"detail": self.detail, "title": self.title}
         return "<{:s}({:s})>".format(
             self.__class__.__name__,
             " ".join(

--- a/tests/server/query_params/test_filter.py
+++ b/tests/server/query_params/test_filter.py
@@ -605,7 +605,7 @@ def test_wrong_query_param(check_error_response):
         request,
         expected_status=400,
         expected_title="Bad Request",
-        expected_detail="The query parameter '_exmpl_filter' has a prefix that is supported by this server, yet the parameter is not known.",
+        expected_detail="The query parameter(s) '['_exmpl_filter']' are not recognised by this endpoint.",
     )
 
     request = "/structures?filer=nelements=2"
@@ -613,7 +613,7 @@ def test_wrong_query_param(check_error_response):
         request,
         expected_status=400,
         expected_title="Bad Request",
-        expected_detail="The query parameter 'filer' is not known by this entry point.",
+        expected_detail="The query parameter(s) '['filer']' are not recognised by this endpoint.",
     )
 
     request = "/structures/mpf_3819?filter=nelements=2"
@@ -621,7 +621,7 @@ def test_wrong_query_param(check_error_response):
         request,
         expected_status=400,
         expected_title="Bad Request",
-        expected_detail="The query parameter 'filter' is not known by this entry point.",
+        expected_detail="The query parameter(s) '['filter']' are not recognised by this endpoint.",
     )
 
 
@@ -637,7 +637,7 @@ def test_handling_prefixed_query_param(check_response):
     expected_warnings = [
         {
             "title": "UnknownProviderQueryParameter",
-            "detail": "The Query parameter '_unknown_filter' has an unknown provider prefix: 'unknown'. This query parameter has been ignored.",
+            "detail": "The query parameter(s) '['_unknown_filter']' are unrecognised and have been ignored.",
         }
     ]
     check_response(

--- a/tests/server/query_params/test_filter.py
+++ b/tests/server/query_params/test_filter.py
@@ -599,7 +599,7 @@ def test_filter_on_unknown_fields(check_response, check_error_response):
     check_response(request, expected_ids=expected_ids)
 
 
-def test_misspelled_query_param(check_error_response):
+def test_wrong_query_param(check_error_response):
     request = "/structures?_exmpl_filter=nelements=2"
     check_error_response(
         request,
@@ -613,7 +613,15 @@ def test_misspelled_query_param(check_error_response):
         request,
         expected_status=400,
         expected_title="Bad Request",
-        expected_detail="The query parameter 'filer' is not known by this server.",
+        expected_detail="The query parameter 'filer' is not known by this entry point.",
+    )
+
+    request = "/structures/mpf_3819?filter=nelements=2"
+    check_error_response(
+        request,
+        expected_status=400,
+        expected_title="Bad Request",
+        expected_detail="The query parameter 'filter' is not known by this entry point.",
     )
 
 


### PR DESCRIPTION
After the discussion in #1120 I have made this function that checks whether the query parameters are known to the server or have a known prefix. If not, an appropriate error/warning is given.
I now perform this check fairly early in the process, If you want I could extract the query parameters at a later stage from the URL string. Although this would be a bit of double work as fastAPI has already done this for us. 