### PR TITLE
Adjusted check_response so it can also handle single entries.

### DIFF
--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -117,8 +117,10 @@ def check_response(get_good_response):
         server: Union[str, OptimadeTestClient] = "regular",
     ):
         response = get_good_response(request, server)
-
-        response_ids = [struct["id"] for struct in response["data"]]
+        if type(response["data"]) == dict:
+            response_ids = [response["data"]["id"]]
+        else:
+            response_ids = [struct["id"] for struct in response["data"]]
 
         if expected_return is None:
             expected_return = len(expected_ids)

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -117,7 +117,7 @@ def check_response(get_good_response):
         server: Union[str, OptimadeTestClient] = "regular",
     ):
         response = get_good_response(request, server)
-        if type(response["data"]) == dict:
+        if isinstance(response["data"], dict):
             response_ids = [response["data"]["id"]]
         else:
             response_ids = [struct["id"] for struct in response["data"]]

--- a/tests/server/routers/test_structures.py
+++ b/tests/server/routers/test_structures.py
@@ -69,6 +69,15 @@ class TestSingleStructureEndpoint(RegularEndpointTests):
         assert "_exmpl_chemsys" in self.json_response["data"]["attributes"]
 
 
+def TestCheckResponseSingleStructure(check_response):
+    """Tests whether check_response also handles single endpoint queries correctly."""
+
+    test_id = "mpf_1"
+    expected_ids = ["mpf_1"]
+    request = f"/structures/{test_id}?response_fields=chemical_formula_reduced"
+    check_response(request, expected_ids=expected_ids)
+
+
 class TestMissingSingleStructureEndpoint(RegularEndpointTests):
     """Tests for /structures/<entry_id> for unknown <entry_id>"""
 

--- a/tests/server/routers/test_structures.py
+++ b/tests/server/routers/test_structures.py
@@ -69,7 +69,7 @@ class TestSingleStructureEndpoint(RegularEndpointTests):
         assert "_exmpl_chemsys" in self.json_response["data"]["attributes"]
 
 
-def TestCheckResponseSingleStructure(check_response):
+def test_check_response_single_structure(check_response):
     """Tests whether check_response also handles single endpoint queries correctly."""
 
     test_id = "mpf_1"


### PR DESCRIPTION
In #1125 I noticed that the `check_response` function did not work for single entry endpoints.
This code should fix that issue.

closes #1125