### PR TITLE
Syntactic tweaks to models and schemas for compatibility with `fastapi>0.66`

### DIFF
--- a/openapi/index_openapi.json
+++ b/openapi/index_openapi.json
@@ -419,7 +419,7 @@
             "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "type": "string",
             "description": "A string containing the full version number of the API served at that versioned base URL.\nThe version number string MUST NOT be prefixed by, e.g., 'v'.\nExamples: `1.0.0`, `1.0.0-rc.2`.",
-            "examples": [
+            "example": [
               "0.10.1",
               "1.0.0-rc.2",
               "1.2.3-rc.5+develop"
@@ -857,7 +857,7 @@
             "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "type": "string",
             "description": "Presently used full version of the OPTIMADE API.\nThe version number string MUST NOT be prefixed by, e.g., \"v\".\nExamples: `1.0.0`, `1.0.0-rc.2`.",
-            "examples": [
+            "example": [
               "0.10.1",
               "1.0.0-rc.2",
               "1.2.3-rc.5+develop"
@@ -1650,7 +1650,7 @@
             "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "type": "string",
             "description": "Presently used full version of the OPTIMADE API.\nThe version number string MUST NOT be prefixed by, e.g., \"v\".\nExamples: `1.0.0`, `1.0.0-rc.2`.",
-            "examples": [
+            "example": [
               "0.10.1",
               "1.0.0-rc.2",
               "1.2.3-rc.5+develop"

--- a/openapi/index_openapi.json
+++ b/openapi/index_openapi.json
@@ -418,7 +418,12 @@
             "title": "Version",
             "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "type": "string",
-            "description": "A string containing the full version number of the API served at that versioned base URL.\nThe version number string MUST NOT be prefixed by, e.g., 'v'.\nExamples: `1.0.0`, `1.0.0-rc.2`."
+            "description": "A string containing the full version number of the API served at that versioned base URL.\nThe version number string MUST NOT be prefixed by, e.g., 'v'.\nExamples: `1.0.0`, `1.0.0-rc.2`.",
+            "examples": [
+              "0.10.1",
+              "1.0.0-rc.2",
+              "1.2.3-rc.5+develop"
+            ]
           }
         },
         "description": "A JSON object containing information about an available API version"
@@ -505,12 +510,16 @@
           "id": {
             "title": "Id",
             "type": "string",
-            "description": "An entry's ID as defined in section Definition of Terms.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n\n- **Examples**:\n    - `\"db/1234567\"`\n    - `\"cod/2000000\"`\n    - `\"cod/2000000@1234567\"`\n    - `\"nomad/L1234567890\"`\n    - `\"42\"`"
+            "description": "An entry's ID as defined in section Definition of Terms.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n\n- **Examples**:\n    - `\"db/1234567\"`\n    - `\"cod/2000000\"`\n    - `\"cod/2000000@1234567\"`\n    - `\"nomad/L1234567890\"`\n    - `\"42\"`",
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "must"
           },
           "type": {
             "title": "Type",
             "type": "string",
-            "description": "The name of the type of an entry.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n    - MUST be an existing entry type.\n    - The entry of type `<type>` and ID `<id>` MUST be returned in response to a request for `/<type>/<id>` under the versioned base URL.\n\n- **Example**: `\"structures\"`"
+            "description": "The name of the type of an entry.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n    - MUST be an existing entry type.\n    - The entry of type `<type>` and ID `<id>` MUST be returned in response to a request for `/<type>/<id>` under the versioned base URL.\n\n- **Example**: `\"structures\"`",
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "must"
           },
           "links": {
             "title": "Links",
@@ -561,13 +570,17 @@
           "immutable_id": {
             "title": "Immutable Id",
             "type": "string",
-            "description": "The entry's immutable ID (e.g., an UUID). This is important for databases having preferred IDs that point to \"the latest version\" of a record, but still offer access to older variants. This ID maps to the version-specific record, in case it changes in the future.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n\n- **Examples**:\n    - `\"8bd3e750-b477-41a0-9b11-3a799f21b44f\"`\n    - `\"fjeiwoj,54;@=%<>#32\"` (Strings that are not URL-safe are allowed.)"
+            "description": "The entry's immutable ID (e.g., an UUID). This is important for databases having preferred IDs that point to \"the latest version\" of a record, but still offer access to older variants. This ID maps to the version-specific record, in case it changes in the future.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n\n- **Examples**:\n    - `\"8bd3e750-b477-41a0-9b11-3a799f21b44f\"`\n    - `\"fjeiwoj,54;@=%<>#32\"` (Strings that are not URL-safe are allowed.)",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "must"
           },
           "last_modified": {
             "title": "Last Modified",
             "type": "string",
             "description": "Date and time representing when the entry was last modified.\n\n- **Type**: timestamp.\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response unless the query parameter `response_fields` is present and does not include this property.\n\n- **Example**:\n    - As part of JSON response format: `\"2007-04-05T14:30:20Z\"` (i.e., encoded as an [RFC 3339 Internet Date/Time Format](https://tools.ietf.org/html/rfc3339#section-5.6) string.)",
-            "format": "date-time"
+            "format": "date-time",
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "must"
           }
         },
         "description": "Contains key-value pairs representing the entry's properties."
@@ -639,9 +652,9 @@
             "title": "About",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -760,9 +773,9 @@
             "title": "Homepage",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -775,9 +788,9 @@
             "title": "Source Url",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -799,9 +812,9 @@
             "title": "Issue Tracker",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -843,7 +856,12 @@
             "title": "Api Version",
             "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "type": "string",
-            "description": "Presently used full version of the OPTIMADE API.\nThe version number string MUST NOT be prefixed by, e.g., \"v\".\nExamples: `1.0.0`, `1.0.0-rc.2`."
+            "description": "Presently used full version of the OPTIMADE API.\nThe version number string MUST NOT be prefixed by, e.g., \"v\".\nExamples: `1.0.0`, `1.0.0-rc.2`.",
+            "examples": [
+              "0.10.1",
+              "1.0.0-rc.2",
+              "1.2.3-rc.5+develop"
+            ]
           },
           "available_api_versions": {
             "title": "Available Api Versions",
@@ -1101,7 +1119,9 @@
           "id": {
             "title": "Id",
             "type": "string",
-            "description": "An entry's ID as defined in section Definition of Terms.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n\n- **Examples**:\n    - `\"db/1234567\"`\n    - `\"cod/2000000\"`\n    - `\"cod/2000000@1234567\"`\n    - `\"nomad/L1234567890\"`\n    - `\"42\"`"
+            "description": "An entry's ID as defined in section Definition of Terms.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n\n- **Examples**:\n    - `\"db/1234567\"`\n    - `\"cod/2000000\"`\n    - `\"cod/2000000@1234567\"`\n    - `\"nomad/L1234567890\"`\n    - `\"42\"`",
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "must"
           },
           "type": {
             "title": "Type",
@@ -1174,9 +1194,9 @@
             "title": "Base Url",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -1189,9 +1209,9 @@
             "title": "Homepage",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -1408,9 +1428,9 @@
             "title": "Homepage",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -1493,9 +1513,9 @@
             "title": "Self",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -1508,9 +1528,9 @@
             "title": "Related",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -1593,9 +1613,9 @@
             "title": "Self",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -1629,7 +1649,12 @@
             "title": "Api Version",
             "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "type": "string",
-            "description": "Presently used full version of the OPTIMADE API.\nThe version number string MUST NOT be prefixed by, e.g., \"v\".\nExamples: `1.0.0`, `1.0.0-rc.2`."
+            "description": "Presently used full version of the OPTIMADE API.\nThe version number string MUST NOT be prefixed by, e.g., \"v\".\nExamples: `1.0.0`, `1.0.0-rc.2`.",
+            "examples": [
+              "0.10.1",
+              "1.0.0-rc.2",
+              "1.2.3-rc.5+develop"
+            ]
           },
           "more_data_available": {
             "title": "More Data Available",
@@ -1640,9 +1665,9 @@
             "title": "Schema",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -1772,9 +1797,9 @@
             "title": "Self",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -1787,9 +1812,9 @@
             "title": "Related",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -1802,9 +1827,9 @@
             "title": "First",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -1817,9 +1842,9 @@
             "title": "Last",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -1832,9 +1857,9 @@
             "title": "Prev",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -1847,9 +1872,9 @@
             "title": "Next",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {

--- a/openapi/index_openapi.json
+++ b/openapi/index_openapi.json
@@ -886,7 +886,8 @@
           "is_index": {
             "title": "Is Index",
             "type": "boolean",
-            "description": "This must be `true` since this is an index meta-database (see section Index Meta-Database)."
+            "description": "This must be `true` since this is an index meta-database (see section Index Meta-Database).",
+            "default": true
           }
         },
         "description": "Attributes for Base URL Info endpoint for an Index Meta-Database"
@@ -904,12 +905,14 @@
           "id": {
             "title": "Id",
             "pattern": "^/$",
-            "type": "string"
+            "type": "string",
+            "default": "/"
           },
           "type": {
             "title": "Type",
             "pattern": "^info$",
-            "type": "string"
+            "type": "string",
+            "default": "info"
           },
           "links": {
             "title": "Links",
@@ -1104,7 +1107,8 @@
             "title": "Type",
             "pattern": "^links$",
             "type": "string",
-            "description": "These objects are described in detail in the section Links Endpoint"
+            "description": "These objects are described in detail in the section Links Endpoint",
+            "default": "links"
           },
           "links": {
             "title": "Links",
@@ -1475,7 +1479,8 @@
           "type": {
             "title": "Type",
             "pattern": "^links$",
-            "type": "string"
+            "type": "string",
+            "default": "links"
           }
         },
         "description": "A related Links resource object"
@@ -1915,7 +1920,8 @@
             "title": "Type",
             "pattern": "^warning$",
             "type": "string",
-            "description": "Warnings must be of type \"warning\""
+            "description": "Warnings must be of type \"warning\"",
+            "default": "warning"
           }
         },
         "description": "OPTIMADE-specific warning class based on OPTIMADE-specific JSON API Error.\n\nFrom the specification:\n\nA warning resource object is defined similarly to a JSON API error object, but MUST also include the field type, which MUST have the value \"warning\".\nThe field detail MUST be present and SHOULD contain a non-critical message, e.g., reporting unrecognized search attributes or deprecated features.\n\nNote: Must be named \"Warnings\", since \"Warning\" is a built-in Python class."

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -1358,7 +1358,9 @@
                 "type": "integer"
               }
             },
-            "description": "Index of the sites (0-based) that belong to each group for each assembly.\n\n- **Examples**:\n    - `[[1], [2]]`: two groups, one with the second site, one with the third.\n    - `[[1,2], [3]]`: one group with the second and third site, one with the fourth."
+            "description": "Index of the sites (0-based) that belong to each group for each assembly.\n\n- **Examples**:\n    - `[[1], [2]]`: two groups, one with the second site, one with the third.\n    - `[[1,2], [3]]`: one group with the second and third site, one with the fourth.",
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "optional"
           },
           "group_probabilities": {
             "title": "Group Probabilities",
@@ -1366,7 +1368,9 @@
             "items": {
               "type": "number"
             },
-            "description": "Statistical probability of each group. It MUST have the same length as `sites_in_groups`.\nIt SHOULD sum to one.\nSee below for examples of how to specify the probability of the occurrence of a vacancy.\nThe possible reasons for the values not to sum to one are the same as already specified above for the `concentration` of each `species`."
+            "description": "Statistical probability of each group. It MUST have the same length as `sites_in_groups`.\nIt SHOULD sum to one.\nSee below for examples of how to specify the probability of the occurrence of a vacancy.\nThe possible reasons for the values not to sum to one are the same as already specified above for the `concentration` of each `species`.",
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "optional"
           }
         },
         "description": "A description of groups of sites that are statistically correlated.\n\n- **Examples** (for each entry of the assemblies list):\n    - `{\"sites_in_groups\": [[0], [1]], \"group_probabilities: [0.3, 0.7]}`: the first site and the second site never occur at the same time in the unit cell.\n      Statistically, 30 % of the times the first site is present, while 70 % of the times the second site is present.\n    - `{\"sites_in_groups\": [[1,2], [3]], \"group_probabilities: [0.3, 0.7]}`: the second and third site are either present together or not present; they form the first group of atoms for this assembly.\n      The second group is formed by the fourth site. Sites of the first group (the second and the third) are never present at the same time as the fourth site.\n      30 % of times sites 1 and 2 are present (and site 3 is absent); 70 % of times site 3 is present (and sites 1 and 2 are absent)."
@@ -1398,7 +1402,12 @@
             "title": "Version",
             "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "type": "string",
-            "description": "A string containing the full version number of the API served at that versioned base URL.\nThe version number string MUST NOT be prefixed by, e.g., 'v'.\nExamples: `1.0.0`, `1.0.0-rc.2`."
+            "description": "A string containing the full version number of the API served at that versioned base URL.\nThe version number string MUST NOT be prefixed by, e.g., 'v'.\nExamples: `1.0.0`, `1.0.0-rc.2`.",
+            "examples": [
+              "0.10.1",
+              "1.0.0-rc.2",
+              "1.2.3-rc.5+develop"
+            ]
           }
         },
         "description": "A JSON object containing information about an available API version"
@@ -1417,7 +1426,12 @@
             "title": "Api Version",
             "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "type": "string",
-            "description": "Presently used full version of the OPTIMADE API.\nThe version number string MUST NOT be prefixed by, e.g., \"v\".\nExamples: `1.0.0`, `1.0.0-rc.2`."
+            "description": "Presently used full version of the OPTIMADE API.\nThe version number string MUST NOT be prefixed by, e.g., \"v\".\nExamples: `1.0.0`, `1.0.0-rc.2`.",
+            "examples": [
+              "0.10.1",
+              "1.0.0-rc.2",
+              "1.2.3-rc.5+develop"
+            ]
           },
           "available_api_versions": {
             "title": "Available Api Versions",
@@ -1758,12 +1772,16 @@
           "id": {
             "title": "Id",
             "type": "string",
-            "description": "An entry's ID as defined in section Definition of Terms.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n\n- **Examples**:\n    - `\"db/1234567\"`\n    - `\"cod/2000000\"`\n    - `\"cod/2000000@1234567\"`\n    - `\"nomad/L1234567890\"`\n    - `\"42\"`"
+            "description": "An entry's ID as defined in section Definition of Terms.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n\n- **Examples**:\n    - `\"db/1234567\"`\n    - `\"cod/2000000\"`\n    - `\"cod/2000000@1234567\"`\n    - `\"nomad/L1234567890\"`\n    - `\"42\"`",
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "must"
           },
           "type": {
             "title": "Type",
             "type": "string",
-            "description": "The name of the type of an entry.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n    - MUST be an existing entry type.\n    - The entry of type `<type>` and ID `<id>` MUST be returned in response to a request for `/<type>/<id>` under the versioned base URL.\n\n- **Example**: `\"structures\"`"
+            "description": "The name of the type of an entry.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n    - MUST be an existing entry type.\n    - The entry of type `<type>` and ID `<id>` MUST be returned in response to a request for `/<type>/<id>` under the versioned base URL.\n\n- **Example**: `\"structures\"`",
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "must"
           },
           "links": {
             "title": "Links",
@@ -1814,13 +1832,17 @@
           "immutable_id": {
             "title": "Immutable Id",
             "type": "string",
-            "description": "The entry's immutable ID (e.g., an UUID). This is important for databases having preferred IDs that point to \"the latest version\" of a record, but still offer access to older variants. This ID maps to the version-specific record, in case it changes in the future.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n\n- **Examples**:\n    - `\"8bd3e750-b477-41a0-9b11-3a799f21b44f\"`\n    - `\"fjeiwoj,54;@=%<>#32\"` (Strings that are not URL-safe are allowed.)"
+            "description": "The entry's immutable ID (e.g., an UUID). This is important for databases having preferred IDs that point to \"the latest version\" of a record, but still offer access to older variants. This ID maps to the version-specific record, in case it changes in the future.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n\n- **Examples**:\n    - `\"8bd3e750-b477-41a0-9b11-3a799f21b44f\"`\n    - `\"fjeiwoj,54;@=%<>#32\"` (Strings that are not URL-safe are allowed.)",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "must"
           },
           "last_modified": {
             "title": "Last Modified",
             "type": "string",
             "description": "Date and time representing when the entry was last modified.\n\n- **Type**: timestamp.\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response unless the query parameter `response_fields` is present and does not include this property.\n\n- **Example**:\n    - As part of JSON response format: `\"2007-04-05T14:30:20Z\"` (i.e., encoded as an [RFC 3339 Internet Date/Time Format](https://tools.ietf.org/html/rfc3339#section-5.6) string.)",
-            "format": "date-time"
+            "format": "date-time",
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "must"
           }
         },
         "description": "Contains key-value pairs representing the entry's properties."
@@ -1892,9 +1914,9 @@
             "title": "About",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -2013,9 +2035,9 @@
             "title": "Homepage",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -2028,9 +2050,9 @@
             "title": "Source Url",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -2052,9 +2074,9 @@
             "title": "Issue Tracker",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -2218,7 +2240,9 @@
           "id": {
             "title": "Id",
             "type": "string",
-            "description": "An entry's ID as defined in section Definition of Terms.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n\n- **Examples**:\n    - `\"db/1234567\"`\n    - `\"cod/2000000\"`\n    - `\"cod/2000000@1234567\"`\n    - `\"nomad/L1234567890\"`\n    - `\"42\"`"
+            "description": "An entry's ID as defined in section Definition of Terms.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n\n- **Examples**:\n    - `\"db/1234567\"`\n    - `\"cod/2000000\"`\n    - `\"cod/2000000@1234567\"`\n    - `\"nomad/L1234567890\"`\n    - `\"42\"`",
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "must"
           },
           "type": {
             "title": "Type",
@@ -2291,9 +2315,9 @@
             "title": "Base Url",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -2306,9 +2330,9 @@
             "title": "Homepage",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -2515,17 +2539,23 @@
           "name": {
             "title": "Name",
             "type": "string",
-            "description": "Full name of the person, REQUIRED."
+            "description": "Full name of the person, REQUIRED.",
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "optional"
           },
           "firstname": {
             "title": "Firstname",
             "type": "string",
-            "description": "First name of the person."
+            "description": "First name of the person.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "lastname": {
             "title": "Lastname",
             "type": "string",
-            "description": "Last name of the person."
+            "description": "Last name of the person.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           }
         },
         "description": "A person, i.e., an author, editor or other."
@@ -2559,9 +2589,9 @@
             "title": "Homepage",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -2626,14 +2656,18 @@
           "id": {
             "title": "Id",
             "type": "string",
-            "description": "An entry's ID as defined in section Definition of Terms.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n\n- **Examples**:\n    - `\"db/1234567\"`\n    - `\"cod/2000000\"`\n    - `\"cod/2000000@1234567\"`\n    - `\"nomad/L1234567890\"`\n    - `\"42\"`"
+            "description": "An entry's ID as defined in section Definition of Terms.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n\n- **Examples**:\n    - `\"db/1234567\"`\n    - `\"cod/2000000\"`\n    - `\"cod/2000000@1234567\"`\n    - `\"nomad/L1234567890\"`\n    - `\"42\"`",
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "must"
           },
           "type": {
             "title": "Type",
             "pattern": "^references$",
             "type": "string",
             "description": "The name of the type of an entry.\n- **Type**: string.\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n    - MUST be an existing entry type.\n    - The entry of type <type> and ID <id> MUST be returned in response to a request for `/<type>/<id>` under the versioned base URL.\n- **Example**: `\"structures\"`",
-            "default": "references"
+            "default": "references",
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "must"
           },
           "links": {
             "title": "Links",
@@ -2678,13 +2712,17 @@
           "immutable_id": {
             "title": "Immutable Id",
             "type": "string",
-            "description": "The entry's immutable ID (e.g., an UUID). This is important for databases having preferred IDs that point to \"the latest version\" of a record, but still offer access to older variants. This ID maps to the version-specific record, in case it changes in the future.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n\n- **Examples**:\n    - `\"8bd3e750-b477-41a0-9b11-3a799f21b44f\"`\n    - `\"fjeiwoj,54;@=%<>#32\"` (Strings that are not URL-safe are allowed.)"
+            "description": "The entry's immutable ID (e.g., an UUID). This is important for databases having preferred IDs that point to \"the latest version\" of a record, but still offer access to older variants. This ID maps to the version-specific record, in case it changes in the future.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n\n- **Examples**:\n    - `\"8bd3e750-b477-41a0-9b11-3a799f21b44f\"`\n    - `\"fjeiwoj,54;@=%<>#32\"` (Strings that are not URL-safe are allowed.)",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "must"
           },
           "last_modified": {
             "title": "Last Modified",
             "type": "string",
             "description": "Date and time representing when the entry was last modified.\n\n- **Type**: timestamp.\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response unless the query parameter `response_fields` is present and does not include this property.\n\n- **Example**:\n    - As part of JSON response format: `\"2007-04-05T14:30:20Z\"` (i.e., encoded as an [RFC 3339 Internet Date/Time Format](https://tools.ietf.org/html/rfc3339#section-5.6) string.)",
-            "format": "date-time"
+            "format": "date-time",
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "must"
           },
           "authors": {
             "title": "Authors",
@@ -2692,7 +2730,9 @@
             "items": {
               "$ref": "#/components/schemas/Person"
             },
-            "description": "List of person objects containing the authors of the reference."
+            "description": "List of person objects containing the authors of the reference.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "editors": {
             "title": "Editors",
@@ -2700,12 +2740,16 @@
             "items": {
               "$ref": "#/components/schemas/Person"
             },
-            "description": "List of person objects containing the editors of the reference."
+            "description": "List of person objects containing the editors of the reference.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "doi": {
             "title": "Doi",
             "type": "string",
-            "description": "The digital object identifier of the reference."
+            "description": "The digital object identifier of the reference.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "url": {
             "title": "Url",
@@ -2713,117 +2757,163 @@
             "minLength": 1,
             "type": "string",
             "description": "The URL of the reference.",
-            "format": "uri"
+            "format": "uri",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "address": {
             "title": "Address",
             "type": "string",
-            "description": "Meaning of property matches the BiBTeX specification."
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "annote": {
             "title": "Annote",
             "type": "string",
-            "description": "Meaning of property matches the BiBTeX specification."
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "booktitle": {
             "title": "Booktitle",
             "type": "string",
-            "description": "Meaning of property matches the BiBTeX specification."
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "chapter": {
             "title": "Chapter",
             "type": "string",
-            "description": "Meaning of property matches the BiBTeX specification."
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "crossref": {
             "title": "Crossref",
             "type": "string",
-            "description": "Meaning of property matches the BiBTeX specification."
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "edition": {
             "title": "Edition",
             "type": "string",
-            "description": "Meaning of property matches the BiBTeX specification."
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "howpublished": {
             "title": "Howpublished",
             "type": "string",
-            "description": "Meaning of property matches the BiBTeX specification."
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "institution": {
             "title": "Institution",
             "type": "string",
-            "description": "Meaning of property matches the BiBTeX specification."
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "journal": {
             "title": "Journal",
             "type": "string",
-            "description": "Meaning of property matches the BiBTeX specification."
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "key": {
             "title": "Key",
             "type": "string",
-            "description": "Meaning of property matches the BiBTeX specification."
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "month": {
             "title": "Month",
             "type": "string",
-            "description": "Meaning of property matches the BiBTeX specification."
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "note": {
             "title": "Note",
             "type": "string",
-            "description": "Meaning of property matches the BiBTeX specification."
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "number": {
             "title": "Number",
             "type": "string",
-            "description": "Meaning of property matches the BiBTeX specification."
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "organization": {
             "title": "Organization",
             "type": "string",
-            "description": "Meaning of property matches the BiBTeX specification."
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "pages": {
             "title": "Pages",
             "type": "string",
-            "description": "Meaning of property matches the BiBTeX specification."
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "publisher": {
             "title": "Publisher",
             "type": "string",
-            "description": "Meaning of property matches the BiBTeX specification."
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "school": {
             "title": "School",
             "type": "string",
-            "description": "Meaning of property matches the BiBTeX specification."
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "series": {
             "title": "Series",
             "type": "string",
-            "description": "Meaning of property matches the BiBTeX specification."
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "title": {
             "title": "Title",
             "type": "string",
-            "description": "Meaning of property matches the BiBTeX specification."
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "bib_type": {
             "title": "Bib Type",
             "type": "string",
-            "description": "Type of the reference, corresponding to the **type** property in the BiBTeX specification."
+            "description": "Type of the reference, corresponding to the **type** property in the BiBTeX specification.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "volume": {
             "title": "Volume",
             "type": "string",
-            "description": "Meaning of property matches the BiBTeX specification."
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "year": {
             "title": "Year",
             "type": "string",
-            "description": "Meaning of property matches the BiBTeX specification."
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           }
         },
         "description": "Model that stores the attributes of a reference.\n\nMany properties match the meaning described in the\n[BibTeX specification](http://bibtexml.sourceforge.net/btxdoc.pdf)."
@@ -2997,9 +3087,9 @@
             "title": "Self",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -3012,9 +3102,9 @@
             "title": "Related",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -3097,9 +3187,9 @@
             "title": "Self",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -3133,7 +3223,12 @@
             "title": "Api Version",
             "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "type": "string",
-            "description": "Presently used full version of the OPTIMADE API.\nThe version number string MUST NOT be prefixed by, e.g., \"v\".\nExamples: `1.0.0`, `1.0.0-rc.2`."
+            "description": "Presently used full version of the OPTIMADE API.\nThe version number string MUST NOT be prefixed by, e.g., \"v\".\nExamples: `1.0.0`, `1.0.0-rc.2`.",
+            "examples": [
+              "0.10.1",
+              "1.0.0-rc.2",
+              "1.2.3-rc.5+develop"
+            ]
           },
           "more_data_available": {
             "title": "More Data Available",
@@ -3144,9 +3239,9 @@
             "title": "Schema",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -3239,7 +3334,9 @@
           "name": {
             "title": "Name",
             "type": "string",
-            "description": "Gives the name of the species; the **name** value MUST be unique in the `species` list."
+            "description": "Gives the name of the species; the **name** value MUST be unique in the `species` list.",
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "optional"
           },
           "chemical_symbols": {
             "title": "Chemical Symbols",
@@ -3247,7 +3344,9 @@
             "items": {
               "type": "string"
             },
-            "description": "MUST be a list of strings of all chemical elements composing this species. Each item of the list MUST be one of the following:\n\n- a valid chemical-element symbol, or\n- the special value `\"X\"` to represent a non-chemical element, or\n- the special value `\"vacancy\"` to represent that this site has a non-zero probability of having a vacancy (the respective probability is indicated in the `concentration` list, see below).\n\nIf any one entry in the `species` list has a `chemical_symbols` list that is longer than 1 element, the correct flag MUST be set in the list `structure_features`."
+            "description": "MUST be a list of strings of all chemical elements composing this species. Each item of the list MUST be one of the following:\n\n- a valid chemical-element symbol, or\n- the special value `\"X\"` to represent a non-chemical element, or\n- the special value `\"vacancy\"` to represent that this site has a non-zero probability of having a vacancy (the respective probability is indicated in the `concentration` list, see below).\n\nIf any one entry in the `species` list has a `chemical_symbols` list that is longer than 1 element, the correct flag MUST be set in the list `structure_features`.",
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "optional"
           },
           "concentration": {
             "title": "Concentration",
@@ -3255,7 +3354,9 @@
             "items": {
               "type": "number"
             },
-            "description": "MUST be a list of floats, with same length as `chemical_symbols`. The numbers represent the relative concentration of the corresponding chemical symbol in this species. The numbers SHOULD sum to one. Cases in which the numbers do not sum to one typically fall only in the following two categories:\n\n- Numerical errors when representing float numbers in fixed precision, e.g. for two chemical symbols with concentrations `1/3` and `2/3`, the concentration might look something like `[0.33333333333, 0.66666666666]`. If the client is aware that the sum is not one because of numerical precision, it can renormalize the values so that the sum is exactly one.\n- Experimental errors in the data present in the database. In this case, it is the responsibility of the client to decide how to process the data.\n\nNote that concentrations are uncorrelated between different site (even of the same species)."
+            "description": "MUST be a list of floats, with same length as `chemical_symbols`. The numbers represent the relative concentration of the corresponding chemical symbol in this species. The numbers SHOULD sum to one. Cases in which the numbers do not sum to one typically fall only in the following two categories:\n\n- Numerical errors when representing float numbers in fixed precision, e.g. for two chemical symbols with concentrations `1/3` and `2/3`, the concentration might look something like `[0.33333333333, 0.66666666666]`. If the client is aware that the sum is not one because of numerical precision, it can renormalize the values so that the sum is exactly one.\n- Experimental errors in the data present in the database. In this case, it is the responsibility of the client to decide how to process the data.\n\nNote that concentrations are uncorrelated between different site (even of the same species).",
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "optional"
           },
           "mass": {
             "title": "Mass",
@@ -3263,12 +3364,17 @@
             "items": {
               "type": "number"
             },
-            "description": "If present MUST be a list of floats expressed in a.m.u.\nElements denoting vacancies MUST have masses equal to 0."
+            "description": "If present MUST be a list of floats expressed in a.m.u.\nElements denoting vacancies MUST have masses equal to 0.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional",
+            "x-optimade-unit": "a.m.u."
           },
           "original_name": {
             "title": "Original Name",
             "type": "string",
-            "description": "Can be any valid Unicode string, and SHOULD contain (if specified) the name of the species that is used internally in the source database.\n\nNote: With regards to \"source database\", we refer to the immediate source being queried via the OPTIMADE API implementation."
+            "description": "Can be any valid Unicode string, and SHOULD contain (if specified) the name of the species that is used internally in the source database.\n\nNote: With regards to \"source database\", we refer to the immediate source being queried via the OPTIMADE API implementation.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "attached": {
             "title": "Attached",
@@ -3276,7 +3382,9 @@
             "items": {
               "type": "string"
             },
-            "description": "If provided MUST be a list of length 1 or more of strings of chemical symbols for the elements attached to this site, or \"X\" for a non-chemical element."
+            "description": "If provided MUST be a list of length 1 or more of strings of chemical symbols for the elements attached to this site, or \"X\" for a non-chemical element.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "nattached": {
             "title": "Nattached",
@@ -3284,7 +3392,9 @@
             "items": {
               "type": "integer"
             },
-            "description": "If provided MUST be a list of length 1 or more of integers indicating the number of attached atoms of the kind specified in the value of the :field:`attached` key."
+            "description": "If provided MUST be a list of length 1 or more of integers indicating the number of attached atoms of the kind specified in the value of the :field:`attached` key.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           }
         },
         "description": "A list describing the species of the sites of this structure.\n\nSpecies can represent pure chemical elements, virtual-crystal atoms representing a\nstatistical occupation of a given site by multiple chemical elements, and/or a\nlocation to which there are attached atoms, i.e., atoms whose precise location are\nunknown beyond that they are attached to that position (frequently used to indicate\nhydrogen atoms attached to another element, e.g., a carbon with three attached\nhydrogens might represent a methyl group, -CH3).\n\n- **Examples**:\n    - `[ {\"name\": \"Ti\", \"chemical_symbols\": [\"Ti\"], \"concentration\": [1.0]} ]`: any site with this species is occupied by a Ti atom.\n    - `[ {\"name\": \"Ti\", \"chemical_symbols\": [\"Ti\", \"vacancy\"], \"concentration\": [0.9, 0.1]} ]`: any site with this species is occupied by a Ti atom with 90 % probability, and has a vacancy with 10 % probability.\n    - `[ {\"name\": \"BaCa\", \"chemical_symbols\": [\"vacancy\", \"Ba\", \"Ca\"], \"concentration\": [0.05, 0.45, 0.5], \"mass\": [0.0, 137.327, 40.078]} ]`: any site with this species is occupied by a Ba atom with 45 % probability, a Ca atom with 50 % probability, and by a vacancy with 5 % probability. The mass of this site is (on average) 88.5 a.m.u.\n    - `[ {\"name\": \"C12\", \"chemical_symbols\": [\"C\"], \"concentration\": [1.0], \"mass\": [12.0]} ]`: any site with this species is occupied by a carbon isotope with mass 12.\n    - `[ {\"name\": \"C13\", \"chemical_symbols\": [\"C\"], \"concentration\": [1.0], \"mass\": [13.0]} ]`: any site with this species is occupied by a carbon isotope with mass 13.\n    - `[ {\"name\": \"CH3\", \"chemical_symbols\": [\"C\"], \"concentration\": [1.0], \"attached\": [\"H\"], \"nattached\": [3]} ]`: any site with this species is occupied by a methyl group, -CH3, which is represented without specifying precise positions of the hydrogen atoms."
@@ -3352,14 +3462,18 @@
           "id": {
             "title": "Id",
             "type": "string",
-            "description": "An entry's ID as defined in section Definition of Terms.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n\n- **Examples**:\n    - `\"db/1234567\"`\n    - `\"cod/2000000\"`\n    - `\"cod/2000000@1234567\"`\n    - `\"nomad/L1234567890\"`\n    - `\"42\"`"
+            "description": "An entry's ID as defined in section Definition of Terms.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n\n- **Examples**:\n    - `\"db/1234567\"`\n    - `\"cod/2000000\"`\n    - `\"cod/2000000@1234567\"`\n    - `\"nomad/L1234567890\"`\n    - `\"42\"`",
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "must"
           },
           "type": {
             "title": "Type",
             "pattern": "^structures$",
             "type": "string",
             "description": "The name of the type of an entry.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n    - MUST be an existing entry type.\n    - The entry of type `<type>` and ID `<id>` MUST be returned in response to a request for `/<type>/<id>` under the versioned base URL.\n\n- **Examples**:\n    - `\"structures\"`",
-            "default": "structures"
+            "default": "structures",
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "must"
           },
           "links": {
             "title": "Links",
@@ -3418,14 +3532,18 @@
           "immutable_id": {
             "title": "Immutable Id",
             "type": "string",
-            "description": "The entry's immutable ID (e.g., an UUID). This is important for databases having preferred IDs that point to \"the latest version\" of a record, but still offer access to older variants. This ID maps to the version-specific record, in case it changes in the future.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n\n- **Examples**:\n    - `\"8bd3e750-b477-41a0-9b11-3a799f21b44f\"`\n    - `\"fjeiwoj,54;@=%<>#32\"` (Strings that are not URL-safe are allowed.)"
+            "description": "The entry's immutable ID (e.g., an UUID). This is important for databases having preferred IDs that point to \"the latest version\" of a record, but still offer access to older variants. This ID maps to the version-specific record, in case it changes in the future.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n\n- **Examples**:\n    - `\"8bd3e750-b477-41a0-9b11-3a799f21b44f\"`\n    - `\"fjeiwoj,54;@=%<>#32\"` (Strings that are not URL-safe are allowed.)",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "must"
           },
           "last_modified": {
             "title": "Last Modified",
             "type": "string",
             "description": "Date and time representing when the entry was last modified.\n\n- **Type**: timestamp.\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response unless the query parameter `response_fields` is present and does not include this property.\n\n- **Example**:\n    - As part of JSON response format: `\"2007-04-05T14:30:20Z\"` (i.e., encoded as an [RFC 3339 Internet Date/Time Format](https://tools.ietf.org/html/rfc3339#section-5.6) string.)",
             "format": "date-time",
-            "nullable": true
+            "nullable": true,
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "must"
           },
           "elements": {
             "title": "Elements",
@@ -3434,13 +3552,17 @@
               "type": "string"
             },
             "description": "The chemical symbols of the different elements present in the structure.\n\n- **Type**: list of strings.\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - The strings are the chemical symbols, i.e., either a single uppercase letter or an uppercase letter followed by a number of lowercase letters.\n    - The order MUST be alphabetical.\n    - MUST refer to the same elements in the same order, and therefore be of the same length, as `elements_ratios`, if the latter is provided.\n    - Note: This property SHOULD NOT contain the string \"X\" to indicate non-chemical elements or \"vacancy\" to indicate vacancies (in contrast to the field `chemical_symbols` for the `species` property).\n\n- **Examples**:\n    - `[\"Si\"]`\n    - `[\"Al\",\"O\",\"Si\"]`\n\n- **Query examples**:\n    - A filter that matches all records of structures that contain Si, Al **and** O, and possibly other elements: `elements HAS ALL \"Si\", \"Al\", \"O\"`.\n    - To match structures with exactly these three elements, use `elements HAS ALL \"Si\", \"Al\", \"O\" AND elements LENGTH 3`.\n    - Note: length queries on this property can be equivalently formulated by filtering on the `nelements`_ property directly.",
-            "nullable": true
+            "nullable": true,
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "must"
           },
           "nelements": {
             "title": "Nelements",
             "type": "integer",
             "description": "Number of different elements in the structure as an integer.\n\n- **Type**: integer\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - MUST be equal to the lengths of the list properties `elements` and `elements_ratios`, if they are provided.\n\n- **Examples**:\n    - `3`\n\n- **Querying**:\n    - Note: queries on this property can equivalently be formulated using `elements LENGTH`.\n    - A filter that matches structures that have exactly 4 elements: `nelements=4`.\n    - A filter that matches structures that have between 2 and 7 elements: `nelements>=2 AND nelements<=7`.",
-            "nullable": true
+            "nullable": true,
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "must"
           },
           "elements_ratios": {
             "title": "Elements Ratios",
@@ -3449,33 +3571,43 @@
               "type": "number"
             },
             "description": "Relative proportions of different elements in the structure.\n\n- **Type**: list of floats\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - Composed by the proportions of elements in the structure as a list of floating point numbers.\n    - The sum of the numbers MUST be 1.0 (within floating point accuracy)\n    - MUST refer to the same elements in the same order, and therefore be of the same length, as `elements`, if the latter is provided.\n\n- **Examples**:\n    - `[1.0]`\n    - `[0.3333333333333333, 0.2222222222222222, 0.4444444444444444]`\n\n- **Query examples**:\n    - Note: Useful filters can be formulated using the set operator syntax for correlated values.\n      However, since the values are floating point values, the use of equality comparisons is generally inadvisable.\n    - OPTIONAL: a filter that matches structures where approximately 1/3 of the atoms in the structure are the element Al is: `elements:elements_ratios HAS ALL \"Al\":>0.3333, \"Al\":<0.3334`.",
-            "nullable": true
+            "nullable": true,
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "must"
           },
           "chemical_formula_descriptive": {
             "title": "Chemical Formula Descriptive",
             "type": "string",
             "description": "The chemical formula for a structure as a string in a form chosen by the API implementation.\n\n- **Type**: string\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - The chemical formula is given as a string consisting of properly capitalized element symbols followed by integers or decimal numbers, balanced parentheses, square, and curly brackets `(`,`)`, `[`,`]`, `{`, `}`, commas, the `+`, `-`, `:` and `=` symbols. The parentheses are allowed to be followed by a number. Spaces are allowed anywhere except within chemical symbols. The order of elements and any groupings indicated by parentheses or brackets are chosen freely by the API implementation.\n    - The string SHOULD be arithmetically consistent with the element ratios in the `chemical_formula_reduced` property.\n    - It is RECOMMENDED, but not mandatory, that symbols, parentheses and brackets, if used, are used with the meanings prescribed by [IUPAC's Nomenclature of Organic Chemistry](https://www.qmul.ac.uk/sbcs/iupac/bibliog/blue.html).\n\n- **Examples**:\n    - `\"(H2O)2 Na\"`\n    - `\"NaCl\"`\n    - `\"CaCO3\"`\n    - `\"CCaO3\"`\n    - `\"(CH3)3N+ - [CH2]2-OH = Me3N+ - CH2 - CH2OH\"`\n\n- **Query examples**:\n    - Note: the free-form nature of this property is likely to make queries on it across different databases inconsistent.\n    - A filter that matches an exactly given formula: `chemical_formula_descriptive=\"(H2O)2 Na\"`.\n    - A filter that does a partial match: `chemical_formula_descriptive CONTAINS \"H2O\"`.",
-            "nullable": true
+            "nullable": true,
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "must"
           },
           "chemical_formula_reduced": {
             "title": "Chemical Formula Reduced",
             "pattern": "^([A-Z][a-z]?([2-9]|[1-9]\\d+)?)+$",
             "type": "string",
             "description": "The reduced chemical formula for a structure as a string with element symbols and integer chemical proportion numbers.\nThe proportion number MUST be omitted if it is 1.\n\n- **Type**: string\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property.\n      However, support for filters using partial string matching with this property is OPTIONAL (i.e., BEGINS WITH, ENDS WITH, and CONTAINS).\n      Intricate queries on formula components are instead suggested to be formulated using set-type filter operators on the multi valued `elements` and `elements_ratios` properties.\n    - Element symbols MUST have proper capitalization (e.g., `\"Si\"`, not `\"SI\"` for \"silicon\").\n    - Elements MUST be placed in alphabetical order, followed by their integer chemical proportion number.\n    - For structures with no partial occupation, the chemical proportion numbers are the smallest integers for which the chemical proportion is exactly correct.\n    - For structures with partial occupation, the chemical proportion numbers are integers that within reasonable approximation indicate the correct chemical proportions. The precise details of how to perform the rounding is chosen by the API implementation.\n    - No spaces or separators are allowed.\n\n- **Examples**:\n    - `\"H2NaO\"`\n    - `\"ClNa\"`\n    - `\"CCaO3\"`\n\n- **Query examples**:\n    - A filter that matches an exactly given formula is `chemical_formula_reduced=\"H2NaO\"`.",
-            "nullable": true
+            "nullable": true,
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "must"
           },
           "chemical_formula_hill": {
             "title": "Chemical Formula Hill",
             "pattern": "^([A-Z][a-z]?([2-9]|[1-9]\\d+)?)+$",
             "type": "string",
-            "description": "The chemical formula for a structure in [Hill form](https://dx.doi.org/10.1021/ja02046a005) with element symbols followed by integer chemical proportion numbers. The proportion number MUST be omitted if it is 1.\n\n- **Type**: string\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n    - **Query**: Support for queries on this property is OPTIONAL.\n      If supported, only a subset of the filter features MAY be supported.\n    - The overall scale factor of the chemical proportions is chosen such that the resulting values are integers that indicate the most chemically relevant unit of which the system is composed.\n      For example, if the structure is a repeating unit cell with four hydrogens and four oxygens that represents two hydroperoxide molecules, `chemical_formula_hill` is `\"H2O2\"` (i.e., not `\"HO\"`, nor `\"H4O4\"`).\n    - If the chemical insight needed to ascribe a Hill formula to the system is not present, the property MUST be handled as unset.\n    - Element symbols MUST have proper capitalization (e.g., `\"Si\"`, not `\"SI\"` for \"silicon\").\n    - Elements MUST be placed in [Hill order](https://dx.doi.org/10.1021/ja02046a005), followed by their integer chemical proportion number.\n      Hill order means: if carbon is present, it is placed first, and if also present, hydrogen is placed second.\n      After that, all other elements are ordered alphabetically.\n      If carbon is not present, all elements are ordered alphabetically.\n    - If the system has sites with partial occupation and the total occupations of each element do not all sum up to integers, then the Hill formula SHOULD be handled as unset.\n    - No spaces or separators are allowed.\n\n- **Examples**:\n    - `\"H2O2\"`\n\n- **Query examples**:\n    - A filter that matches an exactly given formula is `chemical_formula_hill=\"H2O2\"`."
+            "description": "The chemical formula for a structure in [Hill form](https://dx.doi.org/10.1021/ja02046a005) with element symbols followed by integer chemical proportion numbers. The proportion number MUST be omitted if it is 1.\n\n- **Type**: string\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n    - **Query**: Support for queries on this property is OPTIONAL.\n      If supported, only a subset of the filter features MAY be supported.\n    - The overall scale factor of the chemical proportions is chosen such that the resulting values are integers that indicate the most chemically relevant unit of which the system is composed.\n      For example, if the structure is a repeating unit cell with four hydrogens and four oxygens that represents two hydroperoxide molecules, `chemical_formula_hill` is `\"H2O2\"` (i.e., not `\"HO\"`, nor `\"H4O4\"`).\n    - If the chemical insight needed to ascribe a Hill formula to the system is not present, the property MUST be handled as unset.\n    - Element symbols MUST have proper capitalization (e.g., `\"Si\"`, not `\"SI\"` for \"silicon\").\n    - Elements MUST be placed in [Hill order](https://dx.doi.org/10.1021/ja02046a005), followed by their integer chemical proportion number.\n      Hill order means: if carbon is present, it is placed first, and if also present, hydrogen is placed second.\n      After that, all other elements are ordered alphabetically.\n      If carbon is not present, all elements are ordered alphabetically.\n    - If the system has sites with partial occupation and the total occupations of each element do not all sum up to integers, then the Hill formula SHOULD be handled as unset.\n    - No spaces or separators are allowed.\n\n- **Examples**:\n    - `\"H2O2\"`\n\n- **Query examples**:\n    - A filter that matches an exactly given formula is `chemical_formula_hill=\"H2O2\"`.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "chemical_formula_anonymous": {
             "title": "Chemical Formula Anonymous",
             "pattern": "^([A-Z][a-z]?([2-9]|[1-9]\\d+)?)+$",
             "type": "string",
             "description": "The anonymous formula is the `chemical_formula_reduced`, but where the elements are instead first ordered by their chemical proportion number, and then, in order left to right, replaced by anonymous symbols A, B, C, ..., Z, Aa, Ba, ..., Za, Ab, Bb, ... and so on.\n\n- **Type**: string\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property.\n      However, support for filters using partial string matching with this property is OPTIONAL (i.e., BEGINS WITH, ENDS WITH, and CONTAINS).\n\n- **Examples**:\n    - `\"A2B\"`\n    - `\"A42B42C16D12E10F9G5\"`\n\n- **Querying**:\n    - A filter that matches an exactly given formula is `chemical_formula_anonymous=\"A2B\"`.",
-            "nullable": true
+            "nullable": true,
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "must"
           },
           "dimension_types": {
             "title": "Dimension Types",
@@ -3486,13 +3618,17 @@
               "$ref": "#/components/schemas/Periodicity"
             },
             "description": "List of three integers.\nFor each of the three directions indicated by the three lattice vectors (see property `lattice_vectors`), this list indicates if the direction is periodic (value `1`) or non-periodic (value `0`).\nNote: the elements in this list each refer to the direction of the corresponding entry in `lattice_vectors` and *not* the Cartesian x, y, z directions.\n\n- **Type**: list of integers.\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: Support for queries on this property is OPTIONAL.\n    - MUST be a list of length 3.\n    - Each integer element MUST assume only the value 0 or 1.\n\n- **Examples**:\n    - For a molecule: `[0, 0, 0]`\n    - For a wire along the direction specified by the third lattice vector: `[0, 0, 1]`\n    - For a 2D surface/slab, periodic on the plane defined by the first and third lattice vectors: `[1, 0, 1]`\n    - For a bulk 3D system: `[1, 1, 1]`",
-            "nullable": true
+            "nullable": true,
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "optional"
           },
           "nperiodic_dimensions": {
             "title": "Nperiodic Dimensions",
             "type": "integer",
             "description": "An integer specifying the number of periodic dimensions in the structure, equivalent to the number of non-zero entries in `dimension_types`.\n\n- **Type**: integer\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - The integer value MUST be between 0 and 3 inclusive and MUST be equal to the sum of the items in the `dimension_types` property.\n    - This property only reflects the treatment of the lattice vectors provided for the structure, and not any physical interpretation of the dimensionality of its contents.\n\n- **Examples**:\n    - `2` should be indicated in cases where `dimension_types` is any of `[1, 1, 0]`, `[1, 0, 1]`, `[0, 1, 1]`.\n\n- **Query examples**:\n    - Match only structures with exactly 3 periodic dimensions: `nperiodic_dimensions=3`\n    - Match all structures with 2 or fewer periodic dimensions: `nperiodic_dimensions<=2`",
-            "nullable": true
+            "nullable": true,
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "must"
           },
           "lattice_vectors": {
             "title": "Lattice Vectors",
@@ -3500,35 +3636,43 @@
             "minItems": 3,
             "type": "array",
             "items": {
+              "maxItems": 3,
+              "minItems": 3,
               "type": "array",
               "items": {
                 "type": "number"
-              },
-              "minItems": 3,
-              "maxItems": 3
+              }
             },
             "description": "The three lattice vectors in Cartesian coordinates, in \u00e5ngstr\u00f6m (\u00c5).\n\n- **Type**: list of list of floats or unknown values.\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: Support for queries on this property is OPTIONAL.\n      If supported, filters MAY support only a subset of comparison operators.\n    - MUST be a list of three vectors *a*, *b*, and *c*, where each of the vectors MUST BE a list of the vector's coordinates along the x, y, and z Cartesian coordinates.\n      (Therefore, the first index runs over the three lattice vectors and the second index runs over the x, y, z Cartesian coordinates).\n    - For databases that do not define an absolute Cartesian system (e.g., only defining the length and angles between vectors), the first lattice vector SHOULD be set along *x* and the second on the *xy*-plane.\n    - MUST always contain three vectors of three coordinates each, independently of the elements of property `dimension_types`.\n      The vectors SHOULD by convention be chosen so the determinant of the `lattice_vectors` matrix is different from zero.\n      The vectors in the non-periodic directions have no significance beyond fulfilling these requirements.\n    - The coordinates of the lattice vectors of non-periodic dimensions (i.e., those dimensions for which `dimension_types` is `0`) MAY be given as a list of all `null` values.\n        If a lattice vector contains the value `null`, all coordinates of that lattice vector MUST be `null`.\n\n- **Examples**:\n    - `[[4.0,0.0,0.0],[0.0,4.0,0.0],[0.0,1.0,4.0]]` represents a cell, where the first vector is `(4, 0, 0)`, i.e., a vector aligned along the `x` axis of length 4 \u00c5; the second vector is `(0, 4, 0)`; and the third vector is `(0, 1, 4)`.",
-            "nullable": true
+            "nullable": true,
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "optional",
+            "x-optimade-unit": "\u00c5"
           },
           "cartesian_site_positions": {
             "title": "Cartesian Site Positions",
             "type": "array",
             "items": {
+              "maxItems": 3,
+              "minItems": 3,
               "type": "array",
               "items": {
                 "type": "number"
-              },
-              "minItems": 3,
-              "maxItems": 3
+              }
             },
             "description": "Cartesian positions of each site in the structure.\nA site is usually used to describe positions of atoms; what atoms can be encountered at a given site is conveyed by the `species_at_sites` property, and the species themselves are described in the `species` property.\n\n- **Type**: list of list of floats\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: Support for queries on this property is OPTIONAL.\n      If supported, filters MAY support only a subset of comparison operators.\n    - It MUST be a list of length equal to the number of sites in the structure, where every element is a list of the three Cartesian coordinates of a site expressed as float values in the unit angstrom (\u00c5).\n    - An entry MAY have multiple sites at the same Cartesian position (for a relevant use of this, see e.g., the property `assemblies`).\n\n- **Examples**:\n    - `[[0,0,0],[0,0,2]]` indicates a structure with two sites, one sitting at the origin and one along the (positive) *z*-axis, 2 \u00c5 away from the origin.",
-            "nullable": true
+            "nullable": true,
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "optional",
+            "x-optimade-unit": "\u00c5"
           },
           "nsites": {
             "title": "Nsites",
             "type": "integer",
             "description": "An integer specifying the length of the `cartesian_site_positions` property.\n\n- **Type**: integer\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n\n- **Examples**:\n    - `42`\n\n- **Query examples**:\n    - Match only structures with exactly 4 sites: `nsites=4`\n    - Match structures that have between 2 and 7 sites: `nsites>=2 AND nsites<=7`",
-            "nullable": true
+            "nullable": true,
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "must"
           },
           "species": {
             "title": "Species",
@@ -3537,7 +3681,9 @@
               "$ref": "#/components/schemas/Species"
             },
             "description": "A list describing the species of the sites of this structure.\nSpecies can represent pure chemical elements, virtual-crystal atoms representing a statistical occupation of a given site by multiple chemical elements, and/or a location to which there are attached atoms, i.e., atoms whose precise location are unknown beyond that they are attached to that position (frequently used to indicate hydrogen atoms attached to another element, e.g., a carbon with three attached hydrogens might represent a methyl group, -CH3).\n\n- **Type**: list of dictionary with keys:\n    - `name`: string (REQUIRED)\n    - `chemical_symbols`: list of strings (REQUIRED)\n    - `concentration`: list of float (REQUIRED)\n    - `attached`: list of strings (REQUIRED)\n    - `nattached`: list of integers (OPTIONAL)\n    - `mass`: list of floats (OPTIONAL)\n    - `original_name`: string (OPTIONAL).\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: Support for queries on this property is OPTIONAL.\n        If supported, filters MAY support only a subset of comparison operators.\n    - Each list member MUST be a dictionary with the following keys:\n        - **name**: REQUIRED; gives the name of the species; the **name** value MUST be unique in the `species` list;\n        - **chemical_symbols**: REQUIRED; MUST be a list of strings of all chemical elements composing this species.\n          Each item of the list MUST be one of the following:\n            - a valid chemical-element symbol, or\n            - the special value `\"X\"` to represent a non-chemical element, or\n            - the special value `\"vacancy\"` to represent that this site has a non-zero probability of having a vacancy (the respective probability is indicated in the `concentration` list, see below).\n\n          If any one entry in the `species` list has a `chemical_symbols` list that is longer than 1 element, the correct flag MUST be set in the list `structure_features`.\n\n        - **concentration**: REQUIRED; MUST be a list of floats, with same length as `chemical_symbols`.\n          The numbers represent the relative concentration of the corresponding chemical symbol in this species.\n          The numbers SHOULD sum to one. Cases in which the numbers do not sum to one typically fall only in the following two categories:\n\n            - Numerical errors when representing float numbers in fixed precision, e.g. for two chemical symbols with concentrations `1/3` and `2/3`, the concentration might look something like `[0.33333333333, 0.66666666666]`. If the client is aware that the sum is not one because of numerical precision, it can renormalize the values so that the sum is exactly one.\n            - Experimental errors in the data present in the database. In this case, it is the responsibility of the client to decide how to process the data.\n\n            Note that concentrations are uncorrelated between different sites (even of the same species).\n\n        - **attached**: OPTIONAL; if provided MUST be a list of length 1 or more of strings of chemical symbols for the elements attached to this site, or \"X\" for a non-chemical element.\n\n        - **nattached**: OPTIONAL; if provided MUST be a list of length 1 or more of integers indicating the number of attached atoms of the kind specified in the value of the `attached` key.\n\n          The implementation MUST include either both or none of the `attached` and `nattached` keys, and if they are provided, they MUST be of the same length.\n          Furthermore, if they are provided, the `structure_features` property MUST include the string `site_attachments`.\n\n        - **mass**: OPTIONAL. If present MUST be a list of floats, with the same length as `chemical_symbols`, providing element masses expressed in a.m.u.\n          Elements denoting vacancies MUST have masses equal to 0.\n\n        - **original_name**: OPTIONAL. Can be any valid Unicode string, and SHOULD contain (if specified) the name of the species that is used internally in the source database.\n\n          Note: With regards to \"source database\", we refer to the immediate source being queried via the OPTIMADE API implementation.\n\n          The main use of this field is for source databases that use species names, containing characters that are not allowed (see description of the list property `species_at_sites`).\n\n    - For systems that have only species formed by a single chemical symbol, and that have at most one species per chemical symbol, SHOULD use the chemical symbol as species name (e.g., `\"Ti\"` for titanium, `\"O\"` for oxygen, etc.)\n      However, note that this is OPTIONAL, and client implementations MUST NOT assume that the key corresponds to a chemical symbol, nor assume that if the species name is a valid chemical symbol, that it represents a species with that chemical symbol.\n      This means that a species `{\"name\": \"C\", \"chemical_symbols\": [\"Ti\"], \"concentration\": [1.0]}` is valid and represents a titanium species (and *not* a carbon species).\n    - It is NOT RECOMMENDED that a structure includes species that do not have at least one corresponding site.\n\n- **Examples**:\n    - `[ {\"name\": \"Ti\", \"chemical_symbols\": [\"Ti\"], \"concentration\": [1.0]} ]`: any site with this species is occupied by a Ti atom.\n    - `[ {\"name\": \"Ti\", \"chemical_symbols\": [\"Ti\", \"vacancy\"], \"concentration\": [0.9, 0.1]} ]`: any site with this species is occupied by a Ti atom with 90 % probability, and has a vacancy with 10 % probability.\n    - `[ {\"name\": \"BaCa\", \"chemical_symbols\": [\"vacancy\", \"Ba\", \"Ca\"], \"concentration\": [0.05, 0.45, 0.5], \"mass\": [0.0, 137.327, 40.078]} ]`: any site with this species is occupied by a Ba atom with 45 % probability, a Ca atom with 50 % probability, and by a vacancy with 5 % probability. The mass of this site is (on average) 88.5 a.m.u.\n    - `[ {\"name\": \"C12\", \"chemical_symbols\": [\"C\"], \"concentration\": [1.0], \"mass\": [12.0]} ]`: any site with this species is occupied by a carbon isotope with mass 12.\n    - `[ {\"name\": \"C13\", \"chemical_symbols\": [\"C\"], \"concentration\": [1.0], \"mass\": [13.0]} ]`: any site with this species is occupied by a carbon isotope with mass 13.\n    - `[ {\"name\": \"CH3\", \"chemical_symbols\": [\"C\"], \"concentration\": [1.0], \"attached\": [\"H\"], \"nattached\": [3]} ]`: any site with this species is occupied by a methyl group, -CH3, which is represented without specifying precise positions of the hydrogen atoms.",
-            "nullable": true
+            "nullable": true,
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "optional"
           },
           "species_at_sites": {
             "title": "Species At Sites",
@@ -3546,7 +3692,9 @@
               "type": "string"
             },
             "description": "Name of the species at each site (where values for sites are specified with the same order of the property `cartesian_site_positions`).\nThe properties of the species are found in the property `species`.\n\n- **Type**: list of strings.\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: Support for queries on this property is OPTIONAL.\n      If supported, filters MAY support only a subset of comparison operators.\n    - MUST have length equal to the number of sites in the structure (first dimension of the list property `cartesian_site_positions`).\n    - Each species name mentioned in the `species_at_sites` list MUST be described in the list property `species` (i.e. for each value in the `species_at_sites` list there MUST exist exactly one dictionary in the `species` list with the `name` attribute equal to the corresponding `species_at_sites` value).\n    - Each site MUST be associated only to a single species.\n      **Note**: However, species can represent mixtures of atoms, and multiple species MAY be defined for the same chemical element.\n      This latter case is useful when different atoms of the same type need to be grouped or distinguished, for instance in simulation codes to assign different initial spin states.\n\n- **Examples**:\n    - `[\"Ti\",\"O2\"]` indicates that the first site is hosting a species labeled `\"Ti\"` and the second a species labeled `\"O2\"`.\n    - `[\"Ac\", \"Ac\", \"Ag\", \"Ir\"]` indicating the first two sites contains the `\"Ac\"` species, while the third and fourth sites contain the `\"Ag\"` and `\"Ir\"` species, respectively.",
-            "nullable": true
+            "nullable": true,
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "optional"
           },
           "assemblies": {
             "title": "Assemblies",
@@ -3554,7 +3702,9 @@
             "items": {
               "$ref": "#/components/schemas/Assembly"
             },
-            "description": "A description of groups of sites that are statistically correlated.\n\n- **Type**: list of dictionary with keys:\n    - `sites_in_groups`: list of list of integers (REQUIRED)\n    - `group_probabilities`: list of floats (REQUIRED)\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n    - **Query**: Support for queries on this property is OPTIONAL.\n        If supported, filters MAY support only a subset of comparison operators.\n    - The property SHOULD be `null` for entries that have no partial occupancies.\n    - If present, the correct flag MUST be set in the list `structure_features`.\n    - Client implementations MUST check its presence (as its presence changes the interpretation of the structure).\n    - If present, it MUST be a list of dictionaries, each of which represents an assembly and MUST have the following two keys:\n        - **sites_in_groups**: Index of the sites (0-based) that belong to each group for each assembly.\n\n            Example: `[[1], [2]]`: two groups, one with the second site, one with the third.\n            Example: `[[1,2], [3]]`: one group with the second and third site, one with the fourth.\n\n        - **group_probabilities**: Statistical probability of each group. It MUST have the same length as `sites_in_groups`.\n            It SHOULD sum to one.\n            See below for examples of how to specify the probability of the occurrence of a vacancy.\n            The possible reasons for the values not to sum to one are the same as already specified above for the `concentration` of each `species`.\n\n    - If a site is not present in any group, it means that it is present with 100 % probability (as if no assembly was specified).\n    - A site MUST NOT appear in more than one group.\n\n- **Examples** (for each entry of the assemblies list):\n    - `{\"sites_in_groups\": [[0], [1]], \"group_probabilities: [0.3, 0.7]}`: the first site and the second site never occur at the same time in the unit cell.\n        Statistically, 30 % of the times the first site is present, while 70 % of the times the second site is present.\n    - `{\"sites_in_groups\": [[1,2], [3]], \"group_probabilities: [0.3, 0.7]}`: the second and third site are either present together or not present; they form the first group of atoms for this assembly.\n        The second group is formed by the fourth site.\n        Sites of the first group (the second and the third) are never present at the same time as the fourth site.\n        30 % of times sites 1 and 2 are present (and site 3 is absent); 70 % of times site 3 is present (and sites 1 and 2 are absent).\n\n- **Notes**:\n    - Assemblies are essential to represent, for instance, the situation where an atom can statistically occupy two different positions (sites).\n\n    - By defining groups, it is possible to represent, e.g., the case where a functional molecule (and not just one atom) is either present or absent (or the case where it it is present in two conformations)\n\n    - Considerations on virtual alloys and on vacancies: In the special case of a virtual alloy, these specifications allow two different, equivalent ways of specifying them.\n        For instance, for a site at the origin with 30 % probability of being occupied by Si, 50 % probability of being occupied by Ge, and 20 % of being a vacancy, the following two representations are possible:\n\n        - Using a single species:\n            ```json\n            {\n              \"cartesian_site_positions\": [[0,0,0]],\n              \"species_at_sites\": [\"SiGe-vac\"],\n              \"species\": [\n              {\n                \"name\": \"SiGe-vac\",\n                \"chemical_symbols\": [\"Si\", \"Ge\", \"vacancy\"],\n                \"concentration\": [0.3, 0.5, 0.2]\n              }\n              ]\n              // ...\n            }\n            ```\n\n        - Using multiple species and the assemblies:\n            ```json\n            {\n              \"cartesian_site_positions\": [ [0,0,0], [0,0,0], [0,0,0] ],\n              \"species_at_sites\": [\"Si\", \"Ge\", \"vac\"],\n              \"species\": [\n                { \"name\": \"Si\", \"chemical_symbols\": [\"Si\"], \"concentration\": [1.0] },\n                { \"name\": \"Ge\", \"chemical_symbols\": [\"Ge\"], \"concentration\": [1.0] },\n                { \"name\": \"vac\", \"chemical_symbols\": [\"vacancy\"], \"concentration\": [1.0] }\n              ],\n              \"assemblies\": [\n                {\n              \"sites_in_groups\": [ [0], [1], [2] ],\n              \"group_probabilities\": [0.3, 0.5, 0.2]\n                }\n              ]\n              // ...\n            }\n            ```\n\n    - It is up to the database provider to decide which representation to use, typically depending on the internal format in which the structure is stored.\n        However, given a structure identified by a unique ID, the API implementation MUST always provide the same representation for it.\n\n    - The probabilities of occurrence of different assemblies are uncorrelated.\n        So, for instance in the following case with two assemblies:\n        ```json\n        {\n          \"assemblies\": [\n            {\n              \"sites_in_groups\": [ [0], [1] ],\n              \"group_probabilities\": [0.2, 0.8],\n            },\n            {\n              \"sites_in_groups\": [ [2], [3] ],\n              \"group_probabilities\": [0.3, 0.7]\n            }\n          ]\n        }\n        ```\n\n        Site 0 is present with a probability of 20 % and site 1 with a probability of 80 %. These two sites are correlated (either site 0 or 1 is present). Similarly, site 2 is present with a probability of 30 % and site 3 with a probability of 70 %.\n        These two sites are correlated (either site 2 or 3 is present).\n        However, the presence or absence of sites 0 and 1 is not correlated with the presence or absence of sites 2 and 3 (in the specific example, the pair of sites (0, 2) can occur with 0.2*0.3 = 6 % probability; the pair (0, 3) with 0.2*0.7 = 14 % probability; the pair (1, 2) with 0.8*0.3 = 24 % probability; and the pair (1, 3) with 0.8*0.7 = 56 % probability)."
+            "description": "A description of groups of sites that are statistically correlated.\n\n- **Type**: list of dictionary with keys:\n    - `sites_in_groups`: list of list of integers (REQUIRED)\n    - `group_probabilities`: list of floats (REQUIRED)\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n    - **Query**: Support for queries on this property is OPTIONAL.\n        If supported, filters MAY support only a subset of comparison operators.\n    - The property SHOULD be `null` for entries that have no partial occupancies.\n    - If present, the correct flag MUST be set in the list `structure_features`.\n    - Client implementations MUST check its presence (as its presence changes the interpretation of the structure).\n    - If present, it MUST be a list of dictionaries, each of which represents an assembly and MUST have the following two keys:\n        - **sites_in_groups**: Index of the sites (0-based) that belong to each group for each assembly.\n\n            Example: `[[1], [2]]`: two groups, one with the second site, one with the third.\n            Example: `[[1,2], [3]]`: one group with the second and third site, one with the fourth.\n\n        - **group_probabilities**: Statistical probability of each group. It MUST have the same length as `sites_in_groups`.\n            It SHOULD sum to one.\n            See below for examples of how to specify the probability of the occurrence of a vacancy.\n            The possible reasons for the values not to sum to one are the same as already specified above for the `concentration` of each `species`.\n\n    - If a site is not present in any group, it means that it is present with 100 % probability (as if no assembly was specified).\n    - A site MUST NOT appear in more than one group.\n\n- **Examples** (for each entry of the assemblies list):\n    - `{\"sites_in_groups\": [[0], [1]], \"group_probabilities: [0.3, 0.7]}`: the first site and the second site never occur at the same time in the unit cell.\n        Statistically, 30 % of the times the first site is present, while 70 % of the times the second site is present.\n    - `{\"sites_in_groups\": [[1,2], [3]], \"group_probabilities: [0.3, 0.7]}`: the second and third site are either present together or not present; they form the first group of atoms for this assembly.\n        The second group is formed by the fourth site.\n        Sites of the first group (the second and the third) are never present at the same time as the fourth site.\n        30 % of times sites 1 and 2 are present (and site 3 is absent); 70 % of times site 3 is present (and sites 1 and 2 are absent).\n\n- **Notes**:\n    - Assemblies are essential to represent, for instance, the situation where an atom can statistically occupy two different positions (sites).\n\n    - By defining groups, it is possible to represent, e.g., the case where a functional molecule (and not just one atom) is either present or absent (or the case where it it is present in two conformations)\n\n    - Considerations on virtual alloys and on vacancies: In the special case of a virtual alloy, these specifications allow two different, equivalent ways of specifying them.\n        For instance, for a site at the origin with 30 % probability of being occupied by Si, 50 % probability of being occupied by Ge, and 20 % of being a vacancy, the following two representations are possible:\n\n        - Using a single species:\n            ```json\n            {\n              \"cartesian_site_positions\": [[0,0,0]],\n              \"species_at_sites\": [\"SiGe-vac\"],\n              \"species\": [\n              {\n                \"name\": \"SiGe-vac\",\n                \"chemical_symbols\": [\"Si\", \"Ge\", \"vacancy\"],\n                \"concentration\": [0.3, 0.5, 0.2]\n              }\n              ]\n              // ...\n            }\n            ```\n\n        - Using multiple species and the assemblies:\n            ```json\n            {\n              \"cartesian_site_positions\": [ [0,0,0], [0,0,0], [0,0,0] ],\n              \"species_at_sites\": [\"Si\", \"Ge\", \"vac\"],\n              \"species\": [\n                { \"name\": \"Si\", \"chemical_symbols\": [\"Si\"], \"concentration\": [1.0] },\n                { \"name\": \"Ge\", \"chemical_symbols\": [\"Ge\"], \"concentration\": [1.0] },\n                { \"name\": \"vac\", \"chemical_symbols\": [\"vacancy\"], \"concentration\": [1.0] }\n              ],\n              \"assemblies\": [\n                {\n              \"sites_in_groups\": [ [0], [1], [2] ],\n              \"group_probabilities\": [0.3, 0.5, 0.2]\n                }\n              ]\n              // ...\n            }\n            ```\n\n    - It is up to the database provider to decide which representation to use, typically depending on the internal format in which the structure is stored.\n        However, given a structure identified by a unique ID, the API implementation MUST always provide the same representation for it.\n\n    - The probabilities of occurrence of different assemblies are uncorrelated.\n        So, for instance in the following case with two assemblies:\n        ```json\n        {\n          \"assemblies\": [\n            {\n              \"sites_in_groups\": [ [0], [1] ],\n              \"group_probabilities\": [0.2, 0.8],\n            },\n            {\n              \"sites_in_groups\": [ [2], [3] ],\n              \"group_probabilities\": [0.3, 0.7]\n            }\n          ]\n        }\n        ```\n\n        Site 0 is present with a probability of 20 % and site 1 with a probability of 80 %. These two sites are correlated (either site 0 or 1 is present). Similarly, site 2 is present with a probability of 30 % and site 3 with a probability of 70 %.\n        These two sites are correlated (either site 2 or 3 is present).\n        However, the presence or absence of sites 0 and 1 is not correlated with the presence or absence of sites 2 and 3 (in the specific example, the pair of sites (0, 2) can occur with 0.2*0.3 = 6 % probability; the pair (0, 3) with 0.2*0.7 = 14 % probability; the pair (1, 2) with 0.8*0.3 = 24 % probability; and the pair (1, 3) with 0.8*0.7 = 56 % probability).",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "structure_features": {
             "title": "Structure Features",
@@ -3562,7 +3712,9 @@
             "items": {
               "$ref": "#/components/schemas/StructureFeatures"
             },
-            "description": "A list of strings that flag which special features are used by the structure.\n\n- **Type**: list of strings\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property.\n    Filters on the list MUST support all mandatory HAS-type queries.\n    Filter operators for comparisons on the string components MUST support equality, support for other comparison operators are OPTIONAL.\n    - MUST be an empty list if no special features are used.\n    - MUST be sorted alphabetically.\n    - If a special feature listed below is used, the list MUST contain the corresponding string.\n    - If a special feature listed below is not used, the list MUST NOT contain the corresponding string.\n    - **List of strings used to indicate special structure features**:\n        - `disorder`: this flag MUST be present if any one entry in the `species` list has a `chemical_symbols` list that is longer than 1 element.\n        - `implicit_atoms`: this flag MUST be present if the structure contains atoms that are not assigned to sites via the property `species_at_sites` (e.g., because their positions are unknown).\n           When this flag is present, the properties related to the chemical formula will likely not match the type and count of atoms represented by the `species_at_sites`, `species` and `assemblies` properties.\n        - `site_attachments`: this flag MUST be present if any one entry in the `species` list includes `attached` and `nattached`.\n        - `assemblies`: this flag MUST be present if the property `assemblies` is present.\n\n- **Examples**: A structure having implicit atoms and using assemblies: `[\"assemblies\", \"implicit_atoms\"]`"
+            "description": "A list of strings that flag which special features are used by the structure.\n\n- **Type**: list of strings\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property.\n    Filters on the list MUST support all mandatory HAS-type queries.\n    Filter operators for comparisons on the string components MUST support equality, support for other comparison operators are OPTIONAL.\n    - MUST be an empty list if no special features are used.\n    - MUST be sorted alphabetically.\n    - If a special feature listed below is used, the list MUST contain the corresponding string.\n    - If a special feature listed below is not used, the list MUST NOT contain the corresponding string.\n    - **List of strings used to indicate special structure features**:\n        - `disorder`: this flag MUST be present if any one entry in the `species` list has a `chemical_symbols` list that is longer than 1 element.\n        - `implicit_atoms`: this flag MUST be present if the structure contains atoms that are not assigned to sites via the property `species_at_sites` (e.g., because their positions are unknown).\n           When this flag is present, the properties related to the chemical formula will likely not match the type and count of atoms represented by the `species_at_sites`, `species` and `assemblies` properties.\n        - `site_attachments`: this flag MUST be present if any one entry in the `species` list includes `attached` and `nattached`.\n        - `assemblies`: this flag MUST be present if the property `assemblies` is present.\n\n- **Examples**: A structure having implicit atoms and using assemblies: `[\"assemblies\", \"implicit_atoms\"]`",
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "must"
           }
         },
         "description": "This class contains the Field for the attributes used to represent a structure, e.g. unit cell, atoms, positions."
@@ -3736,9 +3888,9 @@
             "title": "Self",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -3751,9 +3903,9 @@
             "title": "Related",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -3766,9 +3918,9 @@
             "title": "First",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -3781,9 +3933,9 @@
             "title": "Last",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -3796,9 +3948,9 @@
             "title": "Prev",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -3811,9 +3963,9 @@
             "title": "Next",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -1403,7 +1403,7 @@
             "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "type": "string",
             "description": "A string containing the full version number of the API served at that versioned base URL.\nThe version number string MUST NOT be prefixed by, e.g., 'v'.\nExamples: `1.0.0`, `1.0.0-rc.2`.",
-            "examples": [
+            "example": [
               "0.10.1",
               "1.0.0-rc.2",
               "1.2.3-rc.5+develop"
@@ -1427,7 +1427,7 @@
             "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "type": "string",
             "description": "Presently used full version of the OPTIMADE API.\nThe version number string MUST NOT be prefixed by, e.g., \"v\".\nExamples: `1.0.0`, `1.0.0-rc.2`.",
-            "examples": [
+            "example": [
               "0.10.1",
               "1.0.0-rc.2",
               "1.2.3-rc.5+develop"
@@ -3224,7 +3224,7 @@
             "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "type": "string",
             "description": "Presently used full version of the OPTIMADE API.\nThe version number string MUST NOT be prefixed by, e.g., \"v\".\nExamples: `1.0.0`, `1.0.0-rc.2`.",
-            "examples": [
+            "example": [
               "0.10.1",
               "1.0.0-rc.2",
               "1.2.3-rc.5+develop"

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -1478,12 +1478,14 @@
           "id": {
             "title": "Id",
             "pattern": "^/$",
-            "type": "string"
+            "type": "string",
+            "default": "/"
           },
           "type": {
             "title": "Type",
             "pattern": "^info$",
-            "type": "string"
+            "type": "string",
+            "default": "info"
           },
           "links": {
             "title": "Links",
@@ -2222,7 +2224,8 @@
             "title": "Type",
             "pattern": "^links$",
             "type": "string",
-            "description": "These objects are described in detail in the section Links Endpoint"
+            "description": "These objects are described in detail in the section Links Endpoint",
+            "default": "links"
           },
           "links": {
             "title": "Links",
@@ -2629,7 +2632,8 @@
             "title": "Type",
             "pattern": "^references$",
             "type": "string",
-            "description": "The name of the type of an entry.\n- **Type**: string.\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n    - MUST be an existing entry type.\n    - The entry of type <type> and ID <id> MUST be returned in response to a request for `/<type>/<id>` under the versioned base URL.\n- **Example**: `\"structures\"`"
+            "description": "The name of the type of an entry.\n- **Type**: string.\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n    - MUST be an existing entry type.\n    - The entry of type <type> and ID <id> MUST be returned in response to a request for `/<type>/<id>` under the versioned base URL.\n- **Example**: `\"structures\"`",
+            "default": "references"
           },
           "links": {
             "title": "Links",
@@ -3354,7 +3358,8 @@
             "title": "Type",
             "pattern": "^structures$",
             "type": "string",
-            "description": "The name of the type of an entry.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n    - MUST be an existing entry type.\n    - The entry of type `<type>` and ID `<id>` MUST be returned in response to a request for `/<type>/<id>` under the versioned base URL.\n\n- **Examples**:\n    - `\"structures\"`"
+            "description": "The name of the type of an entry.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n    - MUST be an existing entry type.\n    - The entry of type `<type>` and ID `<id>` MUST be returned in response to a request for `/<type>/<id>` under the versioned base URL.\n\n- **Examples**:\n    - `\"structures\"`",
+            "default": "structures"
           },
           "links": {
             "title": "Links",
@@ -3879,7 +3884,8 @@
             "title": "Type",
             "pattern": "^warning$",
             "type": "string",
-            "description": "Warnings must be of type \"warning\""
+            "description": "Warnings must be of type \"warning\"",
+            "default": "warning"
           }
         },
         "description": "OPTIMADE-specific warning class based on OPTIMADE-specific JSON API Error.\n\nFrom the specification:\n\nA warning resource object is defined similarly to a JSON API error object, but MUST also include the field type, which MUST have the value \"warning\".\nThe field detail MUST be present and SHOULD contain a non-critical message, e.g., reporting unrecognized search attributes or deprecated features.\n\nNote: Must be named \"Warnings\", since \"Warning\" is a built-in Python class."

--- a/optimade/models/baseinfo.py
+++ b/optimade/models/baseinfo.py
@@ -100,6 +100,6 @@ Examples: `1.0.0`, `1.0.0-rc.2`.""",
 
 
 class BaseInfoResource(Resource):
-    id: str = Field("/", const="/", pattern="^/$")
-    type: str = Field("info", const="info", pattern="^info$")
+    id: str = Field("/", regex="^/$")
+    type: str = Field("info", regex="^info$")
     attributes: BaseInfoAttributes = Field(...)

--- a/optimade/models/entries.py
+++ b/optimade/models/entries.py
@@ -1,7 +1,7 @@
 # pylint: disable=line-too-long,no-self-argument
 from datetime import datetime
 from typing import Optional, Dict, List
-from pydantic import BaseModel, Field, validator  # pylint: disable=no-name-in-module
+from pydantic import BaseModel, validator  # pylint: disable=no-name-in-module
 
 from optimade.models.jsonapi import Relationships, Attributes, Resource
 from optimade.models.optimade_json import Relationship, DataType
@@ -124,7 +124,7 @@ class EntryResource(Resource):
         queryable=SupportLevel.MUST,
     )
 
-    type: str = Field(
+    type: str = OptimadeField(
         description="""The name of the type of an entry.
 
 - **Type**: string.

--- a/optimade/models/index_metadb.py
+++ b/optimade/models/index_metadb.py
@@ -28,7 +28,6 @@ class IndexInfoAttributes(BaseInfoAttributes):
 
     is_index: bool = StrictField(
         True,
-        const=True,
         description="This must be `true` since this is an index meta-database (see section Index Meta-Database).",
     )
 
@@ -36,7 +35,7 @@ class IndexInfoAttributes(BaseInfoAttributes):
 class RelatedLinksResource(BaseResource):
     """A related Links resource object"""
 
-    type: str = Field("links", const="links", regex="^links$")
+    type: str = Field("links", regex="^links$")
 
 
 class IndexRelationship(BaseModel):

--- a/optimade/models/links.py
+++ b/optimade/models/links.py
@@ -91,9 +91,8 @@ class LinksResource(EntryResource):
 
     type: str = StrictField(
         "links",
-        const="links",
         description="These objects are described in detail in the section Links Endpoint",
-        pattern="^links$",
+        regex="^links$",
     )
 
     attributes: LinksResourceAttributes = StrictField(

--- a/optimade/models/optimade_json.py
+++ b/optimade/models/optimade_json.py
@@ -146,9 +146,8 @@ class Warnings(OptimadeError):
 
     type: str = StrictField(
         "warning",
-        const="warning",
         description='Warnings must be of type "warning"',
-        pattern="^warning$",
+        regex="^warning$",
     )
 
     @root_validator(pre=True)

--- a/optimade/models/references.py
+++ b/optimade/models/references.py
@@ -250,7 +250,6 @@ class ReferenceResource(EntryResource):
 
     type: str = OptimadeField(
         "references",
-        const="references",
         description="""The name of the type of an entry.
 - **Type**: string.
 - **Requirements/Conventions**:
@@ -260,7 +259,7 @@ class ReferenceResource(EntryResource):
     - MUST be an existing entry type.
     - The entry of type <type> and ID <id> MUST be returned in response to a request for `/<type>/<id>` under the versioned base URL.
 - **Example**: `"structures"`""",
-        pattern="^references$",
+        regex="^references$",
         support=SupportLevel.MUST,
         queryable=SupportLevel.MUST,
     )

--- a/optimade/models/structures.py
+++ b/optimade/models/structures.py
@@ -1106,7 +1106,6 @@ class StructureResource(EntryResource):
 
     type: str = StrictField(
         "structures",
-        const="structures",
         description="""The name of the type of an entry.
 
 - **Type**: string.
@@ -1120,7 +1119,7 @@ class StructureResource(EntryResource):
 
 - **Examples**:
     - `"structures"`""",
-        pattern="^structures$",
+        regex="^structures$",
         support=SupportLevel.MUST,
         queryable=SupportLevel.MUST,
     )

--- a/optimade/models/structures.py
+++ b/optimade/models/structures.py
@@ -814,7 +814,8 @@ The properties of the species are found in the property `species`.
             nullable_props = (
                 prop
                 for prop in schema["required"]
-                if schema["properties"][prop].get("support") == SupportLevel.SHOULD
+                if schema["properties"][prop].get("x-optimade-support")
+                == SupportLevel.SHOULD
             )
             for prop in nullable_props:
                 schema["properties"][prop]["nullable"] = True

--- a/optimade/models/utils.py
+++ b/optimade/models/utils.py
@@ -164,7 +164,7 @@ class SemanticVersion(str):
     def __modify_schema__(cls, field_schema):
         field_schema.update(
             pattern=cls.regex.pattern,
-            examples=["0.10.1", "1.0.0-rc.2", "1.2.3-rc.5+develop"],
+            example=["0.10.1", "1.0.0-rc.2", "1.2.3-rc.5+develop"],
         )
 
     @classmethod

--- a/optimade/server/mappers/entries.py
+++ b/optimade/server/mappers/entries.py
@@ -159,7 +159,7 @@ class BaseResourceMapper:
             cls.ENTRY_RESOURCE_CLASS.schema()
             .get("properties", {})
             .get("type", {})
-            .get("const", "")
+            .get("default", "")
         )
 
     @classmethod

--- a/optimade/server/routers/index_info.py
+++ b/optimade/server/routers/index_info.py
@@ -27,8 +27,8 @@ def get_info(request: Request) -> IndexInfoResponse:
     return IndexInfoResponse(
         meta=meta_values(request.url, 1, 1, more_data_available=False),
         data=IndexInfoResource(
-            id=IndexInfoResource.schema()["properties"]["id"]["const"],
-            type=IndexInfoResource.schema()["properties"]["type"]["const"],
+            id=IndexInfoResource.schema()["properties"]["id"]["default"],
+            type=IndexInfoResource.schema()["properties"]["type"]["default"],
             attributes=IndexInfoAttributes(
                 api_version=f"{__api_version__}",
                 available_api_versions=[
@@ -46,7 +46,7 @@ def get_info(request: Request) -> IndexInfoResponse:
                 "default": IndexRelationship(
                     data={
                         "type": RelatedLinksResource.schema()["properties"]["type"][
-                            "const"
+                            "default"
                         ],
                         "id": CONFIG.default_db,
                     }

--- a/optimade/server/routers/info.py
+++ b/optimade/server/routers/info.py
@@ -27,8 +27,8 @@ def get_info(request: Request) -> InfoResponse:
     return InfoResponse(
         meta=meta_values(request.url, 1, 1, more_data_available=False),
         data=BaseInfoResource(
-            id=BaseInfoResource.schema()["properties"]["id"]["const"],
-            type=BaseInfoResource.schema()["properties"]["type"]["const"],
+            id=BaseInfoResource.schema()["properties"]["id"]["default"],
+            type=BaseInfoResource.schema()["properties"]["type"]["default"],
             attributes=BaseInfoAttributes(
                 api_version=__api_version__,
                 available_api_versions=[

--- a/optimade/server/schemas.py
+++ b/optimade/server/schemas.py
@@ -58,11 +58,17 @@ def retrieve_queryable_properties(
             else:
                 properties[name] = {"description": value.get("description", "")}
                 # Update schema with extension keys provided they are not None
-                for key in [_ for _ in ("unit", "queryable", "support") if _ in value]:
-                    properties[name][key] = value[key]
+                for key in (
+                    "x-optimade-unit",
+                    "x-optimade-queryable",
+                    "x-optimade-support",
+                    "x-optimade-unit",
+                ):
+                    if value.get(key) is not None:
+                        properties[name][key.replace("x-optimade-", "")] = value[key]
                 # All properties are sortable with the MongoDB backend.
                 # While the result for sorting lists may not be as expected, they are still sorted.
-                properties[name]["sortable"] = value.get("sortable", True)
+                properties[name]["sortable"] = value.get("x-optimade-sortable", True)
                 # Try to get OpenAPI-specific "format" if possible, else get "type"; a mandatory OpenAPI key.
                 properties[name]["type"] = DataType.from_json_type(
                     value.get("format", value.get("type"))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 elasticsearch-dsl==6.4.0
 email_validator==1.2.1
-fastapi==0.65.2
+fastapi==0.78.0
 lark-parser==0.12.0
 mongomock==4.0.0
 pydantic==1.9.0

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ setup(
     python_requires=">=3.7,<3.11",
     install_requires=[
         "lark-parser~=0.12",
-        "fastapi~=0.65.2",
+        "fastapi~=0.65",
         "pydantic~=1.9",
         "email_validator~=1.2",
         "requests~=2.27",


### PR DESCRIPTION
This PR makes 2 main changes to ensure FastAPI compatibility going forward (see #887).

The issue is essentially that FastAPI broke OpenAPI specs generated from pydantic by adding `extra = 'allow'` to its base OpenAPI schema class (see https://github.com/tiangolo/fastapi/issues/3745). For example, if you used `Field(const=True)` in pydantic, the `const` key would be added to the eventual OpenAPI schema, yet `const` does not exist as an OpenAPI field. The same then happened for our custom schema injections of `support`, `queryable` and `unit`.

This PR adds the following workarounds:

- Replace all uses of `const` and `pattern` with just the pydantic `regex` (which checks the value with the regex and also injects `pattern` into the schema). ~`typing.Literal`, replacing constant values in the OpenAPI schema with single-valued enums. The other option here would be to remove the `const` check and replace `pattern` with `regex` so that pydantic applies the regex during validation.~
- Add wrappers to the underlying pydantic fields that prefix our custom injected fields, so that `support` becomes e.g. `x-optimade-support`. These need to be retained in the JSONSchema so that they can be used to set the OpenAPI nullable flag.
- Finally this PR fixes an issue where one field was not wrapped in `OptimadeField` already.