### PR TITLE
Fix cases where comparison first and property first queries did not match

### DIFF
--- a/optimade/filtertransformers/mongo.py
+++ b/optimade/filtertransformers/mongo.py
@@ -141,9 +141,9 @@ class MongoTransformer(BaseTransformer):
 
     def constant_first_comparison(self, arg):
         # constant_first_comparison: constant OPERATOR ( non_string_value | not_implemented_string )
-        return {
-            arg[2]: {self.operator_map[self._reversed_operator_map[arg[1]]]: arg[0]}
-        }
+        return self.property_first_comparison(
+            arg[2], {self.operator_map[self._reversed_operator_map[arg[1]]]: arg[0]}
+        )
 
     @v_args(inline=True)
     def value_op_rhs(self, operator, value):

--- a/optimade/server/data/test_references.json
+++ b/optimade/server/data/test_references.json
@@ -58,5 +58,25 @@
     "title": "Dummy reference that should remain orphaned from all structures for testing purposes",
     "journal": "JACS",
     "doi": "10.1038/00000"
+  },
+  {
+    "_id": {
+      "$oid": "98fb441f053b1744107019e3"
+    },
+    "id": "dummy/2022",
+    "last_modified": {
+      "$date": "2022-01-23T14:24:37.332Z"
+    },
+    "authors": [
+      {
+        "name": "A Nother",
+        "firstname": "A",
+        "lastname": "Nother"
+      }
+    ],
+    "year": "2019",
+    "note": "Dummy reference",
+    "title": "Just another title",
+    "journal": "JACS"
   }
 ]

--- a/tests/filtertransformers/test_mongo.py
+++ b/tests/filtertransformers/test_mongo.py
@@ -891,3 +891,5 @@ class TestMongoTransformer:
 
     def test_constant_first_comparisson(self):
         assert self.transform("nelements != 5") == self.transform("5 != nelements")
+        assert self.transform("nelements > 5") == self.transform("5 < nelements")
+        assert self.transform("nelements <= 5") == self.transform("5 >= nelements")

--- a/tests/filtertransformers/test_mongo.py
+++ b/tests/filtertransformers/test_mongo.py
@@ -888,3 +888,6 @@ class TestMongoTransformer:
                 {"number": {"$eq": 0.0}},
             ]
         }
+
+    def test_constant_first_comparisson(self):
+        assert self.transform("nelements != 5") == self.transform("5 != nelements")


### PR DESCRIPTION
Rerouted 'constant_first_comparison' via 'property_first_comparison' in optimade/filtertransformers/mongo.py so  $ne and $size   are handled properly for constant_first_comparisons.

Closes #1133