### PR TITLE
Add support for number-based pagination 

### DIFF
--- a/openapi/index_openapi.json
+++ b/openapi/index_openapi.json
@@ -199,9 +199,10 @@
             "required": false,
             "schema": {
               "title": "Page Number",
-              "minimum": 0.0,
+              "minimum": 1.0,
               "type": "integer",
-              "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`."
+              "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`.",
+              "default": 0
             },
             "name": "page_number",
             "in": "query"

--- a/openapi/index_openapi.json
+++ b/openapi/index_openapi.json
@@ -201,8 +201,7 @@
               "title": "Page Number",
               "minimum": 0.0,
               "type": "integer",
-              "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`.",
-              "default": 0
+              "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`."
             },
             "name": "page_number",
             "in": "query"

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -303,8 +303,7 @@
               "title": "Page Number",
               "minimum": 0.0,
               "type": "integer",
-              "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`.",
-              "default": 0
+              "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`."
             },
             "name": "page_number",
             "in": "query"
@@ -562,8 +561,7 @@
               "title": "Page Number",
               "minimum": 0.0,
               "type": "integer",
-              "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`.",
-              "default": 0
+              "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`."
             },
             "name": "page_number",
             "in": "query"
@@ -986,8 +984,7 @@
               "title": "Page Number",
               "minimum": 0.0,
               "type": "integer",
-              "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`.",
-              "default": 0
+              "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`."
             },
             "name": "page_number",
             "in": "query"

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -301,9 +301,10 @@
             "required": false,
             "schema": {
               "title": "Page Number",
-              "minimum": 0.0,
+              "minimum": 1.0,
               "type": "integer",
-              "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`."
+              "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`.",
+              "default": 0
             },
             "name": "page_number",
             "in": "query"
@@ -559,9 +560,10 @@
             "required": false,
             "schema": {
               "title": "Page Number",
-              "minimum": 0.0,
+              "minimum": 1.0,
               "type": "integer",
-              "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`."
+              "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`.",
+              "default": 0
             },
             "name": "page_number",
             "in": "query"
@@ -982,9 +984,10 @@
             "required": false,
             "schema": {
               "title": "Page Number",
-              "minimum": 0.0,
+              "minimum": 1.0,
               "type": "integer",
-              "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`."
+              "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`.",
+              "default": 0
             },
             "name": "page_number",
             "in": "query"

--- a/optimade/server/entry_collections/entry_collections.py
+++ b/optimade/server/entry_collections/entry_collections.py
@@ -11,7 +11,11 @@ from optimade.server.config import CONFIG, SupportedBackend
 from optimade.server.exceptions import BadRequest, Forbidden, NotFound
 from optimade.server.mappers import BaseResourceMapper
 from optimade.server.query_params import EntryListingQueryParams, SingleEntryQueryParams
-from optimade.server.warnings import FieldValueNotRecognized, UnknownProviderProperty
+from optimade.server.warnings import (
+    FieldValueNotRecognized,
+    UnknownProviderProperty,
+    QueryParamNotUsed,
+)
 
 
 def create_collection(
@@ -335,8 +339,10 @@ class EntryCollection(ABC):
         if getattr(params, "page_offset", False):
             if getattr(params, "page_number", False):
                 warnings.warn(
-                    "Only one of the query parameters 'page_number' and 'page_offset' should be set - 'page_number' will be ignored."
+                    message="Only one of the query parameters 'page_number' and 'page_offset' should be set - 'page_number' will be ignored.",
+                    category=QueryParamNotUsed,
                 )
+
             cursor_kwargs["skip"] = params.page_offset
         elif getattr(params, "page_number", False):
             if isinstance(params.page_number, int):

--- a/optimade/server/entry_collections/entry_collections.py
+++ b/optimade/server/entry_collections/entry_collections.py
@@ -331,12 +331,14 @@ class EntryCollection(ABC):
         if getattr(params, "sort", False):
             cursor_kwargs["sort"] = self.parse_sort_params(params.sort)
 
-        # page_offset
+        # page_offset and page_number
         if getattr(params, "page_offset", False):
+            if getattr(params, "page_number", False):
+                raise BadRequest(
+                    "Only one of the query parameters 'page-number' and 'page_offsest' should be set."
+                )
             cursor_kwargs["skip"] = params.page_offset
-
-        # page_number
-        if getattr(params, "page_number", False):
+        elif getattr(params, "page_number", False):
             if isinstance(params.page_number, int):
                 cursor_kwargs["skip"] = (params.page_number - 1) * cursor_kwargs[
                     "limit"

--- a/optimade/server/entry_collections/entry_collections.py
+++ b/optimade/server/entry_collections/entry_collections.py
@@ -335,6 +335,13 @@ class EntryCollection(ABC):
         if getattr(params, "page_offset", False):
             cursor_kwargs["skip"] = params.page_offset
 
+        # page_number
+        if getattr(params, "page_number", False):
+            if isinstance(params.page_number, int):
+                cursor_kwargs["skip"] = (params.page_number - 1) * cursor_kwargs[
+                    "limit"
+                ]
+
         return cursor_kwargs
 
     def parse_sort_params(self, sort_params: str) -> Tuple[Tuple[str, int]]:

--- a/optimade/server/entry_collections/entry_collections.py
+++ b/optimade/server/entry_collections/entry_collections.py
@@ -334,8 +334,8 @@ class EntryCollection(ABC):
         # page_offset and page_number
         if getattr(params, "page_offset", False):
             if getattr(params, "page_number", False):
-                raise BadRequest(
-                    "Only one of the query parameters 'page-number' and 'page_offsest' should be set."
+                warnings.warn(
+                    "Only one of the query parameters 'page_number' and 'page_offset' should be set - 'page_number' will be ignored."
                 )
             cursor_kwargs["skip"] = params.page_offset
         elif getattr(params, "page_number", False):

--- a/optimade/server/query_params.py
+++ b/optimade/server/query_params.py
@@ -172,7 +172,6 @@ class EntryListingQueryParams(BaseQueryParams):
 
     # The reference server implementation only supports offset-based pagination
     unsupported_params: List[str] = [
-        "page_number",
         "page_cursor",
         "page_below",
         "page_above",
@@ -214,7 +213,7 @@ class EntryListingQueryParams(BaseQueryParams):
             ge=0,
         ),
         page_number: int = Query(
-            0,
+            None,
             description="RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`.",
             ge=0,
         ),

--- a/optimade/server/query_params.py
+++ b/optimade/server/query_params.py
@@ -215,7 +215,7 @@ class EntryListingQueryParams(BaseQueryParams):
         page_number: int = Query(
             None,
             description="RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`.",
-            ge=0,
+            ge=1,
         ),
         page_cursor: int = Query(
             0,

--- a/optimade/server/query_params.py
+++ b/optimade/server/query_params.py
@@ -213,7 +213,7 @@ class EntryListingQueryParams(BaseQueryParams):
             ge=0,
         ),
         page_number: int = Query(
-            None,
+            0,
             description="RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`.",
             ge=1,
         ),

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -102,14 +102,26 @@ def get_good_response(client, index_client):
 
 @pytest.fixture
 def check_response(get_good_response):
-    """Fixture to check "good" response"""
+    """Check response matches expectations for a given request.
+
+    Parameters:
+        request: The request to check.
+        expected_ids: A list of IDs, or a single ID to check
+            the response for.
+        page_limit: The number of results expected per page.
+        expected_return: The number of results expected to be returned.
+        expected_as_is: Whether to enforce the order of the IDs.
+        expected_warnings: A list of expected warning messages.
+        server: The type of server to test, or the actual test client class.
+
+    """
     from typing import List
     from optimade.server.config import CONFIG
     from .utils import OptimadeTestClient
 
     def inner(
         request: str,
-        expected_ids: List[str],
+        expected_ids: Union[str, List[str]],
         page_limit: int = CONFIG.page_limit,
         expected_return: int = None,
         expected_as_is: bool = False,
@@ -117,10 +129,11 @@ def check_response(get_good_response):
         server: Union[str, OptimadeTestClient] = "regular",
     ):
         response = get_good_response(request, server)
-        if isinstance(response["data"], dict):
-            response_ids = [response["data"]["id"]]
-        else:
-            response_ids = [struct["id"] for struct in response["data"]]
+        if isinstance(expected_ids, str):
+            expected_ids = [expected_ids]
+            response["data"] = [response["data"]]
+
+        response_ids = [struct["id"] for struct in response["data"]]
 
         if expected_return is not None:
             assert expected_return == response["meta"]["data_returned"]

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -122,18 +122,15 @@ def check_response(get_good_response):
         else:
             response_ids = [struct["id"] for struct in response["data"]]
 
-        if expected_return is None:
-            expected_return = len(expected_ids)
+        if expected_return is not None:
+            assert expected_return == response["meta"]["data_returned"]
 
-        assert response["meta"]["data_returned"] == expected_return
+        assert len(response["data"]) == len(expected_ids)
 
         if not expected_as_is:
             expected_ids = sorted(expected_ids)
 
-        if len(expected_ids) > page_limit:
-            assert expected_ids[:page_limit] == response_ids
-        else:
-            assert expected_ids == response_ids
+        assert expected_ids == response_ids
 
         if expected_warnings:
             assert "warnings" in response["meta"]

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -129,6 +129,7 @@ def check_response(get_good_response):
 
         if not expected_as_is:
             expected_ids = sorted(expected_ids)
+            response_ids = sorted(response_ids)
 
         assert expected_ids == response_ids
 

--- a/tests/server/middleware/test_query_param.py
+++ b/tests/server/middleware/test_query_param.py
@@ -143,3 +143,7 @@ def test_page_number_and_offset(check_response):
 
     request = "/structures?sort=id&page_number=2&page_limit=5"
     check_response(request, expected_ids=expected_ids)
+
+    request = "/structures?sort=last_modified&page_number=2&page_limit=5"
+    expected_ids = ["mpf_30", "mpf_110", "mpf_200", "mpf_220", "mpf_259"]
+    check_response(request, expected_ids=expected_ids)

--- a/tests/server/middleware/test_query_param.py
+++ b/tests/server/middleware/test_query_param.py
@@ -147,3 +147,13 @@ def test_page_number_and_offset(check_response):
     request = "/structures?sort=last_modified&page_number=2&page_limit=5"
     expected_ids = ["mpf_30", "mpf_110", "mpf_200", "mpf_220", "mpf_259"]
     check_response(request, expected_ids=expected_ids)
+
+
+def test_page_number_and_offset_both_set(check_error_response):
+    request = "/structures?sort=last_modified&page_number=2&page_limit=5&page_offset=5"
+    check_error_response(
+        request,
+        expected_status=400,
+        expected_title="Bad Request",
+        expected_detail="Only one of the query parameters 'page-number' and 'page_offsest' should be set.",
+    )

--- a/tests/server/middleware/test_query_param.py
+++ b/tests/server/middleware/test_query_param.py
@@ -107,19 +107,19 @@ def test_handling_prefixed_query_param(check_response):
 
 def test_unsupported_optimade_query_param(check_response):
 
-    request = "/structures?filter=elements LENGTH >= 9&page_number=1"
+    request = "/structures?filter=elements LENGTH >= 9&page_below=1"
     expected_ids = ["mpf_3819"]
     expected_warnings = [
         {
             "title": "QueryParamNotUsed",
-            "detail": "The query parameter(s) '['page_number']' are not supported by this server and have been ignored.",
+            "detail": "The query parameter(s) '['page_below']' are not supported by this server and have been ignored.",
         }
     ]
     check_response(
         request, expected_ids=expected_ids, expected_warnings=expected_warnings
     )
 
-    request = "/structures?filter=elements LENGTH >= 9&page_number=1&_unknown_filter=elements HAS 'Si'"
+    request = "/structures?filter=elements LENGTH >= 9&page_cursor=1&_unknown_filter=elements HAS 'Si'"
     expected_ids = ["mpf_3819"]
     expected_warnings = [
         {
@@ -128,9 +128,18 @@ def test_unsupported_optimade_query_param(check_response):
         },
         {
             "title": "QueryParamNotUsed",
-            "detail": "The query parameter(s) '['page_number']' are not supported by this server and have been ignored.",
+            "detail": "The query parameter(s) '['page_cursor']' are not supported by this server and have been ignored.",
         },
     ]
     check_response(
         request, expected_ids=expected_ids, expected_warnings=expected_warnings
     )
+
+
+def test_page_number_and_offset(check_response):
+    request = "/structures?sort=id&page_offset=5&page_limit=5"
+    expected_ids = ["mpf_23", "mpf_259", "mpf_272", "mpf_276", "mpf_281"]
+    check_response(request, expected_ids=expected_ids)
+
+    request = "/structures?sort=id&page_number=2&page_limit=5"
+    check_response(request, expected_ids=expected_ids)

--- a/tests/server/middleware/test_query_param.py
+++ b/tests/server/middleware/test_query_param.py
@@ -149,11 +149,15 @@ def test_page_number_and_offset(check_response):
     check_response(request, expected_ids=expected_ids)
 
 
-def test_page_number_and_offset_both_set(check_error_response):
+def test_page_number_and_offset_both_set(check_response):
     request = "/structures?sort=last_modified&page_number=2&page_limit=5&page_offset=5"
-    check_error_response(
-        request,
-        expected_status=400,
-        expected_title="Bad Request",
-        expected_detail="Only one of the query parameters 'page-number' and 'page_offsest' should be set.",
+    expected_ids = ["mpf_30", "mpf_110", "mpf_200", "mpf_220", "mpf_259"]
+    expected_warnings = [
+        {
+            "title": "QueryParamNotUsed",
+            "detail": "Only one of the query parameters 'page_number' and 'page_offset' should be set - 'page_number' will be ignored.",
+        }
+    ]
+    check_response(
+        request, expected_ids=expected_ids, expected_warnings=expected_warnings
     )

--- a/tests/server/query_params/test_sort.py
+++ b/tests/server/query_params/test_sort.py
@@ -36,7 +36,7 @@ def test_str_asc(check_response, structures):
     limit = 5
 
     request = f"/structures?sort=id&page_limit={limit}"
-    expected_ids = sorted([doc["task_id"] for doc in structures])
+    expected_ids = sorted([doc["task_id"] for doc in structures])[:limit]
     check_response(
         request,
         expected_ids=expected_ids,
@@ -49,7 +49,7 @@ def test_str_desc(check_response, structures):
     limit = 5
 
     request = f"/structures?sort=-id&page_limit={limit}"
-    expected_ids = sorted([doc["task_id"] for doc in structures], reverse=True)
+    expected_ids = sorted([doc["task_id"] for doc in structures], reverse=True)[:limit]
     check_response(
         request,
         expected_ids=expected_ids,

--- a/tests/server/routers/test_structures.py
+++ b/tests/server/routers/test_structures.py
@@ -73,7 +73,7 @@ def test_check_response_single_structure(check_response):
     """Tests whether check_response also handles single endpoint queries correctly."""
 
     test_id = "mpf_1"
-    expected_ids = ["mpf_1"]
+    expected_ids = "mpf_1"
     request = f"/structures/{test_id}?response_fields=chemical_formula_reduced"
     check_response(request, expected_ids=expected_ids)
 


### PR DESCRIPTION
In this PR I have added support for the `page_number` query parameter, as already mentioned in #1132.
I have also added a test for this.
I had not realized that I also had to add the IDs that are not in the response but do meet the requirements of the filter.
I therefore adjusted the 'check_response' function, so this is no longer necessary. 
This also required changing another test.
Finally, I now also sort the response IDs as the sort in python could be done differently than the sort in the query.  