### PR TITLE
Fix incorrect `meta->data_returned` for paginated results with MongoDB

### DIFF
--- a/optimade/server/entry_collections/mongo.py
+++ b/optimade/server/entry_collections/mongo.py
@@ -123,8 +123,9 @@ class MongoCollection(EntryCollection):
         if not single_entry:
             criteria_nolimit = criteria.copy()
             criteria_nolimit.pop("limit", None)
+            skip = criteria_nolimit.pop("skip", 0)
             data_returned = self.count(**criteria_nolimit)
-            more_data_available = nresults_now < data_returned
+            more_data_available = nresults_now + skip < data_returned
         else:
             # SingleEntryQueryParams, e.g., /structures/{entry_id}
             data_returned = nresults_now

--- a/tests/server/routers/test_structures.py
+++ b/tests/server/routers/test_structures.py
@@ -35,11 +35,13 @@ class TestStructuresEndpoint(RegularEndpointTests):
 
         cursor = json_response["data"].copy()
         assert json_response["meta"]["more_data_available"]
+        assert json_response["meta"]["data_returned"] == total_data
         more_data_available = True
         next_request = json_response["links"]["next"]
 
         while more_data_available:
             next_response = get_good_response(next_request)
+            assert next_response["meta"]["data_returned"] == total_data
             next_request = next_response["links"]["next"]
             cursor.extend(next_response["data"])
             more_data_available = next_response["meta"]["more_data_available"]


### PR DESCRIPTION
Closes #1140.