### PR TITLE
Improve handling of MongoDB ObjectIDs as OPTIMADE `immutable_id`

### DIFF
--- a/optimade/models/entries.py
+++ b/optimade/models/entries.py
@@ -91,6 +91,14 @@ class EntryResourceAttributes(Attributes):
         queryable=SupportLevel.MUST,
     )
 
+    @validator("immutable_id", pre=True)
+    def cast_immutable_id_to_str(cls, value):
+        """Convenience validator for casting `immutable_id` to a string."""
+        if value is not None and not isinstance(value, str):
+            value = str(value)
+
+        return value
+
 
 class EntryResource(Resource):
     """The base model for an entry resource."""

--- a/optimade/server/entry_collections/entry_collections.py
+++ b/optimade/server/entry_collections/entry_collections.py
@@ -272,7 +272,7 @@ class EntryCollection(ABC):
             which will need modification for modified for other backends.
 
         Parameters:
-            params (Union[EntryListingQueryParams, SingleEntryQueryParams]): The initialized query parameter model from the server.
+            params: The initialized query parameter model from the server.
 
         Raises:
             Forbidden: If too large of a page limit is provided.
@@ -318,9 +318,6 @@ class EntryCollection(ABC):
             f"{self.resource_mapper.get_backend_field(f)}": True
             for f in self.all_fields
         }
-
-        if "_id" not in cursor_kwargs["projection"]:
-            cursor_kwargs["projection"]["_id"] = False
 
         if getattr(params, "response_fields", False):
             response_fields = set(params.response_fields.split(","))

--- a/optimade/validator/config.py
+++ b/optimade/validator/config.py
@@ -74,7 +74,7 @@ _INCLUSIVE_OPERATORS = {
     DataType.STRING: inclusive_ops + substring_operators,
     DataType.TIMESTAMP: (
         # N.B. "=" and "<=" are disabled due to issue with microseconds stored in database vs API response (see Materials-Consortia/optimade-python-tools/#606)
-        # ">=" is fine as all microsecond trimming will round times down
+        #      ">=" is fine as all microsecond trimming will round times down
         # "=",
         # "<=",
         ">=",
@@ -101,6 +101,14 @@ _FIELD_SPECIFIC_OVERRIDES = {
     },
     "chemical_formula_reduced": {
         SupportLevel.OPTIONAL: substring_operators,
+    },
+    # Only check immutable_ids can be queried for equality
+    "immutable_id": {
+        SupportLevel.OPTIONAL: [
+            op
+            for op in substring_operators + inclusive_ops + exclusive_ops
+            if op != "="
+        ],
     },
 }
 

--- a/optimade/validator/config.py
+++ b/optimade/validator/config.py
@@ -72,9 +72,9 @@ substring_operators = ("CONTAINS", "STARTS WITH", "STARTS", "ENDS WITH", "ENDS")
 
 _INCLUSIVE_OPERATORS = {
     DataType.STRING: inclusive_ops + substring_operators,
+    # N.B. "=" and "<=" are disabled due to issue with microseconds stored in database vs API response (see Materials-Consortia/optimade-python-tools/#606)
+    # ">=" is fine as all microsecond trimming will round times down
     DataType.TIMESTAMP: (
-        # N.B. "=" and "<=" are disabled due to issue with microseconds stored in database vs API response (see Materials-Consortia/optimade-python-tools/#606)
-        #      ">=" is fine as all microsecond trimming will round times down
         # "=",
         # "<=",
         ">=",

--- a/tests/test_config.json
+++ b/tests/test_config.json
@@ -24,6 +24,7 @@
     "aliases": {
         "structures": {
             "id": "task_id",
+            "immutable_id": "_id",
             "chemical_formula_descriptive": "pretty_formula",
             "chemical_formula_reduced": "pretty_formula",
             "chemical_formula_anonymous": "formula_anonymous"


### PR DESCRIPTION
Currently, we loop over the entire cursor and check whether the `_id` projection was requested, which is very inefficient. This PR makes some fixes around that:

- Use native MongoDB `toString` projection if `_id` is requested (and only do the inefficient loop if using mongomock).
- Tidy up the Mongo-specific param handling into a method
- Loosen the validator to not require comparison operators on the `immutable_id` field (except equality).
- Automatically cast the `immutable_id` field to a string in the models.
- Use the generated MongoDB ObjectID as the `immutable_id` in our test cases.