### PR TITLE
Remove pinned sub-dep on upf-to-json

### DIFF
--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -4,4 +4,3 @@ jarvis-tools==2022.1.10
 numpy==1.21.5;python_version<'3.8'
 numpy==1.22.0;python_version>='3.8'
 pymatgen==2022.0.16
-upf-to-json==0.9.2 # Can be removed if aiida-core pins to a working version (0.9.4 is broken)

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ server_deps = [
 # Client minded
 aiida_deps = [
     "aiida-core~=1.6,>=1.6.4",
-    "upf-to-json==0.9.2",  # Can be removed if aiida-core pins to a working version
 ]
 ase_deps = ["ase~=3.22"]
 cif_deps = ["numpy~=1.21"]


### PR DESCRIPTION
Closes #1150 (again) by removing the dependency as this was fixed upstream in upf-to-json.