### PR TITLE
Set Heroku branch in CD

### DIFF
--- a/.github/workflows/ci_cd_updated_master.yml
+++ b/.github/workflows/ci_cd_updated_master.yml
@@ -140,6 +140,7 @@ jobs:
           heroku_api_key: ${{secrets.HEROKU_API_KEY}}
           heroku_app_name: "optimade"
           heroku_email: ${{secrets.HEROKU_EMAIL}}
+          branch: master
       env:
           HD_OPTIMADE_CONFIG_FILE: /app/tests/test_config.json
           HD_OPTIMADE_BASE_URL: https://optimade.herokuapp.com


### PR DESCRIPTION
I think there is an issue that the Heroku branch should be master, whereas on my fork it defaulted to `main`. This PR will be instantly merged to test the deployment from master.