### PR TITLE
Fix typo in CD release workflow

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -124,7 +124,7 @@ jobs:
     uses: ./.github/workflows/cd_container_image.yml
     with:
       release: true
-      checkout_ref: ${{ env.PUBLISH_UPDATE_BRANCH }}
+      checkout_ref: "${{ env.PUBLISH_UPDATE_BRANCH }}"
     secrets: inherit
     permissions:
       packages: write


### PR DESCRIPTION
I think this is all that was causing the issue... I guess `${{ env.<stuff> }}` needs to be quoted when it is being passed to external actions, but does not need it when it is used directly in GitHub actions keywords (like `with:`). We'll see...