### PR TITLE
Don't use `env` context for step

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -124,7 +124,7 @@ jobs:
     uses: ./.github/workflows/cd_container_image.yml
     with:
       release: true
-      checkout_ref: "${{ env.PUBLISH_UPDATE_BRANCH }}"
+      checkout_ref: master
     secrets: inherit
     permissions:
       packages: write


### PR DESCRIPTION
Fixes #1176 

Don't use context `env` for publish container image step.