### PR TITLE
Harden validator for partially implemented APIs

### DIFF
--- a/optimade/validator/__init__.py
+++ b/optimade/validator/__init__.py
@@ -1,5 +1,6 @@
 """ This module contains the ImplementationValidator class and corresponding command line tools. """
 # pylint: disable=import-outside-toplevel
+import warnings
 from optimade import __version__, __api_version__
 from .validator import ImplementationValidator
 from .utils import DEFAULT_CONN_TIMEOUT, DEFAULT_READ_TIMEOUT
@@ -89,7 +90,7 @@ def validate():  # pragma: no cover
     parser.add_argument(
         "--page_limit",
         type=int,
-        default=5,
+        default=None,
         help="Alter the requested page limit for some tests.",
     )
 
@@ -140,6 +141,11 @@ def validate():  # pragma: no cover
     if args["as_type"] is not None and args["as_type"] not in valid_types:
         sys.exit(f"{args['as_type']} is not a valid type, must be one of {valid_types}")
 
+    if args["page_limit"] is not None:
+        warnings.warn(
+            "The `--page_limit` flag is now deprecated and will not be used by the validator."
+        )
+
     validator = ImplementationValidator(
         base_url=args["base_url"],
         verbosity=args["verbosity"],
@@ -149,7 +155,6 @@ def validate():  # pragma: no cover
         run_optional_tests=not args["skip_optional"],
         fail_fast=args["fail_fast"],
         minimal=args["minimal"],
-        page_limit=args["page_limit"],
         http_headers=args["headers"],
         timeout=args["timeout"],
         read_timeout=args["read_timeout"],

--- a/optimade/validator/validator.py
+++ b/optimade/validator/validator.py
@@ -557,7 +557,7 @@ class ImplementationValidator:
         test_query = f"{endp}?response_fields={','.join(subset_fields)}&page_limit=1"
         response, _ = self._get_endpoint(test_query, multistage=True)
 
-        if response and len(response.json()["data"]) == 1:
+        if response and len(response.json()["data"]) >= 0:
             doc = response.json()["data"][0]
             expected_fields = set(subset_fields)
             expected_fields -= CONF.top_level_non_attribute_fields

--- a/optimade/validator/validator.py
+++ b/optimade/validator/validator.py
@@ -380,6 +380,7 @@ class ImplementationValidator:
         prop_list = list(_impl_properties.keys())
 
         self._check_response_fields(endp, prop_list)
+
         chosen_entry, _ = self._get_archetypal_entry(endp, prop_list)
 
         if not chosen_entry:
@@ -524,19 +525,16 @@ class ImplementationValidator:
             if data_returned < 1:
                 return (
                     None,
-                    "Endpoint {endp!r} returned no entries, cannot get archetypal entry.",
+                    "Endpoint {endp!r} returned no entries, cannot get archetypal entry or test filtering.",
                 )
 
-            response, message = self._get_endpoint(
-                f"{endp}?page_offset={random.randint(0, data_returned-1)}&response_fields={','.join(properties)}",
-                multistage=True,
+            archetypal_entry = response.json()["data"][
+                random.randint(0, data_returned - 1)
+            ]
+            return (
+                archetypal_entry,
+                f"set archetypal entry for {endp} with ID {archetypal_entry['id']}.",
             )
-            if response:
-                archetypal_entry = response.json()["data"][0]
-                return (
-                    archetypal_entry,
-                    f"set archetypal entry for {endp} with ID {archetypal_entry['id']}.",
-                )
 
         raise ResponseError(f"Failed to get archetypal entry. Details: {message}")
 


### PR DESCRIPTION
Closes #1180 by hardening some of the validator testing, namely:

1. Prevent skipping `response_field` tests if `page_limit` has no effect
2. Use a weirder default value for `page_limit` (4 instead of 5) so that tests cannot accidentally pass.
3. Do not rely on `page_offset` being implemented when choosing the archetypal entry for filtering
4. Prevent optional filter tests from ending tests early when non-optional sections should fail 
5. Assume that inclusive tests contain the archetypal result on the first page (i.e. do not allow sorting to change between queries). This was allowing completely missing filtering to pass all tests, as the results may have been on future pages