### PR TITLE
Validator improvements: use a httpx session/client and a custom `User-Agent`

### DIFF
--- a/optimade/validator/utils.py
+++ b/optimade/validator/utils.py
@@ -28,6 +28,7 @@ except ImportError:
 import httpx
 from pydantic import Field, ValidationError
 
+from optimade import __version__
 from optimade.models.optimade_json import Success
 from optimade.models import (
     ResponseMeta,
@@ -41,6 +42,7 @@ from optimade.models import (
 # (see https://docs.python-requests.org/en/latest/user/advanced/#timeouts)
 DEFAULT_CONN_TIMEOUT = 3.05
 DEFAULT_READ_TIMEOUT = 60
+DEFAULT_USER_AGENT_STRING = f"optimade-python-tools validator/{__version__}"
 
 
 class ResponseError(Exception):
@@ -200,6 +202,8 @@ class Client:  # pragma: no cover
         self.response = None
         self.max_retries = max_retries
         self.headers = headers or {}
+        if "User-Agent" not in self.headers:
+            self.headers["User-Agent"] = DEFAULT_USER_AGENT_STRING
         self.timeout = timeout or DEFAULT_CONN_TIMEOUT
         self.read_timeout = read_timeout or DEFAULT_READ_TIMEOUT
         self.httpx_timeout = httpx.Timeout(self.timeout, read=self.read_timeout)

--- a/optimade/validator/validator.py
+++ b/optimade/validator/validator.py
@@ -266,6 +266,16 @@ class ImplementationValidator:
             RuntimeError: If it was not possible to start the validation process.
 
         """
+        try:
+            self._validate_implementation()
+        finally:
+            try:
+                self.client.close()
+            except Exception:
+                pass
+
+    def _validate_implementation(self):
+        """See [`ImplementationValidator.validate_implementation()`][optimade.validator.ImplementationValidator]."""
         # If a single "as type" has been set, only run that test
         if self.as_type_cls is not None:
             self._log.debug(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 elasticsearch-dsl==6.4.0
 email_validator==1.2.1
 fastapi==0.65.2
+httpx==0.23.0
 lark-parser==0.12.0
 mongomock==4.0.0
 pydantic==1.9.0
 pymongo==4.1.1
 pyyaml==5.4
-requests==2.27.1
 typing-extensions==4.0.0;python_version<'3.8'
 uvicorn==0.17.6

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ setup(
         "fastapi~=0.65.2",
         "pydantic~=1.9",
         "email_validator~=1.2",
-        "requests~=2.27",
+        "httpx~=0.23",
         "typing-extensions~=4.0;python_version<'3.8'",
     ],
     extras_require={


### PR DESCRIPTION
This PR drops the `requests` dependency and replaces it with httpx, which will allow async applications in the future (and is used by the upcoming client).

It also:

1. Uses a `httpx.Client` (equivalent to a `requests.Session`) which seems to speed-up validation by 10-20% for odbx (will observe build time differences for the dashboard).
2. Defines a custom `User-Agent` for the validator that can be used by databases to prioritise/drop requests (closes #1187).