### PR TITLE
Change default mike docs version to stable

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,7 +14,6 @@ theme:
   logo: images/optimade_logo_180x180.svg
   favicon: images/favicon.png
   language: en
-  custom_dir: override
 
 repo_name: optimade-python-tools
 repo_url: https://github.com/Materials-Consortia/optimade-python-tools

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,7 @@ theme:
   logo: images/optimade_logo_180x180.svg
   favicon: images/favicon.png
   language: en
+  custom_dir: override
 
 repo_name: optimade-python-tools
 repo_url: https://github.com/Materials-Consortia/optimade-python-tools
@@ -25,7 +26,7 @@ extra:
       link: https://github.com/Materials-Consortia
   version:
     provider: mike
-    default: latest
+    default: stable
 
 extra_css:
   - css/reference.css


### PR DESCRIPTION
This PR simply changes the default version of our documentation to "stable" (i.e. the last release) rather than "latest". I think this is better for new users (some of whom we might expect in the coming days).

I'm not entirely sure if the config change is enough to trigger the change, so I will just merge this myself to test it.