### PR TITLE
Add mike outdated version banner

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% block outdated %}
+  You are viewing an old or unreleased version.
+  <a href="{{ '../' ~ base_url }}">
+    <strong>Click here to go to latest release.</strong>
+  </a>
+{% endblock %}


### PR DESCRIPTION
Following #1191... this PR extends mkdocs-material with a banner to the latest stable version (see https://squidfunk.github.io/mkdocs-material/setup/setting-up-versioning/?h=outdated#versioning)