### PR TITLE
Append python version deprecation warning filter.

### DIFF
--- a/optimade/__init__.py
+++ b/optimade/__init__.py
@@ -10,7 +10,7 @@ if sys.version_info.minor == 7:
         action="once",
         message=r"v0\.17 of the `optimade` package.*",
         category=DeprecationWarning,
-        append=False,
+        append=True,
     )
     warnings.warn(
         "v0.17 of the `optimade` package will be the last to support Python 3.7. "


### PR DESCRIPTION
It would be nice to give package users a change to actually disable the warning. When you do not append your own filter right before issuing the warning, there is no chance. You are just overwriting any existing filter. If you would append the filter, a previous installed filter with a higher priority (e.g. ignore), would have an effect. 

Not sure if I fully understand filter warnings; I hope, I understood the append flag correctly. It works for me, if it is set to True.