### PR TITLE
Support for Elasticsearch v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,12 +162,13 @@ jobs:
         ports:
         - 5432:5432
       elasticsearch:
-        image: elasticsearch:6.8.23
+        image: elasticsearch:7.17.1
         ports:
           - 9200:9200
           - 9300:9300
         env:
           discovery.type: single-node
+          xpack.security.enabled: 'false'
 
 
     steps:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -101,7 +101,7 @@ These commands should be run from a local optimade-python-tools directory.
 The following command starts a local Elasticsearch v6 instance, runs the test suite, then stops and deletes the containers (required as the tests insert some data):
 
 ```shell
-docker run -d --name elasticsearch_test -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" elasticsearch:6.8.23 \
+docker run -d --name elasticsearch_test -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" -e "xpack.security.enabled=false" elasticsearch:7.17.1 \
 && sleep 10 \
 && OPTIMADE_DATABASE_BACKEND="elastic" py.test; \
 docker container stop elasticsearch_test; docker container rm elasticsearch_test

--- a/optimade/server/entry_collections/elastic_indexes.json
+++ b/optimade/server/entry_collections/elastic_indexes.json
@@ -1,158 +1,157 @@
 {
   "references": {
     "mappings": {
-      "doc": {
-        "properties": {
-          "address": {
-            "type": "keyword"
-          },
-          "annote": {
-            "type": "keyword"
-          },
-          "authors": {
-            "properties": {
-              "name": {
-                "type": "keyword"
-              },
-              "firstname": {
-                "type": "keyword"
-              },
-              "lastname": {
-                "type": "keyword"
-              }
+      "properties": {
+        "address": {
+          "type": "keyword"
+        },
+        "annote": {
+          "type": "keyword"
+        },
+        "authors": {
+          "properties": {
+            "name": {
+              "type": "keyword"
+            },
+            "firstname": {
+              "type": "keyword"
+            },
+            "lastname": {
+              "type": "keyword"
             }
-          },
-          "bib_type": {
-            "type": "keyword"
-          },
-          "booktitle": {
-            "type": "keyword"
-          },
-          "chapter": {
-            "type": "keyword"
-          },
-          "crossref": {
-            "type": "keyword"
-          },
-          "doi": {
-            "type": "keyword"
-          },
-          "edition": {
-            "type": "keyword"
-          },
-          "editors": {
-            "type": "keyword"
-          },
-          "howpublished": {
-            "type": "keyword"
-          },
-          "id": {
-            "type": "keyword"
-          },
-          "immutable_id": {
-            "type": "keyword"
-          },
-          "institution": {
-            "type": "keyword"
-          },
-          "journal": {
-            "type": "keyword"
-          },
-          "key": {
-            "type": "keyword"
-          },
-          "last_modified": {
-            "type": "date"
-          },
-          "links": {
-            "type": "keyword"
-          },
-          "month": {
-            "type": "keyword"
-          },
-          "note": {
-            "type": "keyword"
-          },
-          "number": {
-            "type": "keyword"
-          },
-          "organization": {
-            "type": "keyword"
-          },
-          "pages": {
-            "type": "keyword"
-          },
-          "publisher": {
-            "type": "keyword"
-          },
-          "relationships": {
-            "type": "keyword"
-          },
-          "school": {
-            "type": "keyword"
-          },
-          "series": {
-            "type": "keyword"
-          },
-          "title": {
-            "type": "keyword"
-          },
-          "type": {
-            "type": "keyword"
-          },
-          "url": {
-            "type": "keyword"
-          },
-          "volume": {
-            "type": "keyword"
-          },
-          "year": {
-            "type": "keyword"
           }
+        },
+        "bib_type": {
+          "type": "keyword"
+        },
+        "booktitle": {
+          "type": "keyword"
+        },
+        "chapter": {
+          "type": "keyword"
+        },
+        "crossref": {
+          "type": "keyword"
+        },
+        "doi": {
+          "type": "keyword"
+        },
+        "edition": {
+          "type": "keyword"
+        },
+        "editors": {
+          "type": "keyword"
+        },
+        "howpublished": {
+          "type": "keyword"
+        },
+        "id": {
+          "type": "keyword"
+        },
+        "immutable_id": {
+          "type": "keyword"
+        },
+        "institution": {
+          "type": "keyword"
+        },
+        "journal": {
+          "type": "keyword"
+        },
+        "key": {
+          "type": "keyword"
+        },
+        "last_modified": {
+          "type": "date"
+        },
+        "links": {
+          "type": "keyword"
+        },
+        "month": {
+          "type": "keyword"
+        },
+        "note": {
+          "type": "keyword"
+        },
+        "number": {
+          "type": "keyword"
+        },
+        "organization": {
+          "type": "keyword"
+        },
+        "pages": {
+          "type": "keyword"
+        },
+        "publisher": {
+          "type": "keyword"
+        },
+        "relationships": {
+          "type": "keyword"
+        },
+        "school": {
+          "type": "keyword"
+        },
+        "series": {
+          "type": "keyword"
+        },
+        "title": {
+          "type": "keyword"
+        },
+        "type": {
+          "type": "keyword"
+        },
+        "url": {
+          "type": "keyword"
+        },
+        "volume": {
+          "type": "keyword"
+        },
+        "year": {
+          "type": "keyword"
         }
       }
     }
   },
   "structures": {
     "mappings": {
-      "doc": {
-        "properties": {
-          "chemical_formula_anonymous": {
-            "type": "keyword"
-          },
-          "chemical_formula_descriptive": {
-            "type": "keyword"
-          },
-          "chemical_formula_hill": {
-            "type": "keyword"
-          },
-          "chemical_formula_reduced": {
-            "type": "keyword"
-          },
-          "dimension_types": {
-            "type": "integer"
-          },
-          "elements": {
-            "type": "keyword"
-          },
-          "elements_ratios": {
-            "type": "long"
-          },
-          "id": {
-            "type": "keyword"
-          },
-          "nelements": {
-            "type": "integer"
-          },
-          "nsites": {
-            "type": "integer"
-          },
-          "species_at_sites": {
-            "type": "keyword"
-          },
-          "structure_features": {
-            "type": "keyword"
-          }
+      "properties": {
+        "chemical_formula_anonymous": {
+          "type": "keyword"
+        },
+        "chemical_formula_descriptive": {
+          "type": "keyword"
+        },
+        "chemical_formula_hill": {
+          "type": "keyword"
+        },
+        "chemical_formula_reduced": {
+          "type": "keyword"
+        },
+        "dimension_types": {
+          "type": "integer"
+        },
+        "elements": {
+          "type": "keyword"
+        },
+        "elements_ratios": {
+          "type": "long"
+        },
+        "id": {
+          "type": "keyword"
+        },
+        "nelements": {
+          "type": "integer"
+        },
+        "nsites": {
+          "type": "integer"
+        },
+        "species_at_sites": {
+          "type": "keyword"
+        },
+        "structure_features": {
+          "type": "keyword"
+        },
+        "lattice_vectors": {
+          "type": "float"
         }
       }
     }

--- a/optimade/server/entry_collections/elasticsearch.py
+++ b/optimade/server/entry_collections/elasticsearch.py
@@ -109,7 +109,7 @@ class ElasticCollection(EntryCollection):
 
     def __len__(self):
         """Returns the total number of entries in the collection."""
-        return Search(using=self.client, index=self.name).execute().hits.total
+        return Search(using=self.client, index=self.name).execute().hits.total.value
 
     def insert(self, data: List[EntryResource]) -> None:
         """Add the given entries to the underlying database.
@@ -189,12 +189,13 @@ class ElasticCollection(EntryCollection):
         search = search.sort(*elastic_sort)
 
         search = search[page_offset : page_offset + limit]
+        search = search.extra(track_total_hits=True)
         response = search.execute()
 
         results = [hit.to_dict() for hit in response.hits]
 
         if not single_entry:
-            data_returned = response.hits.total
+            data_returned = response.hits.total.value
             more_data_available = page_offset + limit < data_returned
         else:
             # SingleEntryQueryParams, e.g., /structures/{entry_id}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-elasticsearch-dsl==6.4.0
+elasticsearch-dsl==7.4.0
 email_validator==1.2.1
 fastapi==0.78.0
 lark==0.12.0

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open(module_dir.joinpath("optimade/__init__.py")) as version_file:
 
 # Dependencies
 # Server minded
-elastic_deps = ["elasticsearch-dsl~=6.4,<7.0"]
+elastic_deps = ["elasticsearch-dsl~=7.4,<8.0"]
 mongo_deps = ["pymongo>=3.12.1,<5", "mongomock~=4.0"]
 server_deps = [
     "uvicorn~=0.17",


### PR DESCRIPTION
Elasticsearch 6.8 lost its official support in February 2022. So we should go for Elasticsearch 7, I guess. 

- use 7.x in the ci
- use 7.x in the install docs
- added a fix, because 7.x is capping out the total hits instead of actually trying to compute them by default
- fix the index creation. Before, we were trying to add an explicit mapping. But the mapping json was wrong. Therefore, no mapping had been applied effectively and we were running in a dynamic mapping. However, this dynamic mapping did not work with ES 7 anymore due to slight changes in ES. I fixed the mapping so that the ES indices have an explicit non dynamic mapping now.