### PR TITLE
Remove problematic `MissingExpectedField` warning when creating models

### DIFF
--- a/tests/models/test_structures.py
+++ b/tests/models/test_structures.py
@@ -4,8 +4,7 @@ import itertools
 
 from pydantic import ValidationError
 
-from optimade.models.structures import StructureResource, CORRELATED_STRUCTURE_FIELDS
-from optimade.server.warnings import MissingExpectedField
+from optimade.models.structures import StructureResource
 
 
 MAPPER = "StructureMapper"
@@ -21,7 +20,6 @@ def test_good_structures(mapper):
         StructureResource(**mapper(MAPPER).map_back(structure))
 
 
-@pytest.mark.filterwarnings("ignore", category=MissingExpectedField)
 def test_good_structure_with_missing_data(mapper, good_structure):
     """Check deserialization of well-formed structure used
     as example data with all combinations of null values
@@ -200,21 +198,3 @@ def test_structure_fatal_deformities(good_structure, deformity):
     good_structure["attributes"].update(deformity)
     with pytest.raises(ValidationError, match=rf".*{re.escape(message)}.*"):
         StructureResource(**good_structure)
-
-
-minor_deformities = (
-    {f: None} for f in set(f for _ in CORRELATED_STRUCTURE_FIELDS for f in _)
-)
-
-
-@pytest.mark.parametrize("deformity", minor_deformities)
-def test_structure_minor_deformities(good_structure, deformity):
-    """Make specific checks upon performing single minor invalidations
-    of the data of a good structure that should emit warnings.
-    """
-    if deformity is None:
-        StructureResource(**good_structure)
-    else:
-        good_structure["attributes"].update(deformity)
-        with pytest.warns(MissingExpectedField):
-            StructureResource(**good_structure)


### PR DESCRIPTION
This warning is annoying and perhaps not that useful anymore. It could be replaced by a similar check at the level of the adapters.