### PR TITLE
Improve error handling for client when updating provider list

### DIFF
--- a/optimade/utils.py
+++ b/optimade/utils.py
@@ -3,8 +3,10 @@ with OPTIMADE providers that can be used in server or client code.
 
 """
 
+import json
 from typing import List, Iterable
 
+from pydantic import ValidationError
 from optimade.models.links import LinksResource
 
 PROVIDER_LIST_URLS = (
@@ -128,7 +130,7 @@ def get_child_database_links(
     links_endp = base_url + "/v1/links"
     try:
         links = requests.get(links_endp, timeout=10)
-    except requests.ConnectionError as exc:
+    except (requests.ConnectionError, requests.Timeout) as exc:
         raise RuntimeError(f"Unable to connect to provider {provider['id']}") from exc
 
     if links.status_code != 200:
@@ -136,7 +138,13 @@ def get_child_database_links(
             f"Invalid response from {links_endp} for provider {provider['id']}: {links.content}."
         )
 
-    links = LinksResponse(**links.json())
+    try:
+        links = LinksResponse(**links.json())
+    except (ValidationError, json.JSONDecodeError) as exc:
+        raise RuntimeError(
+            f"Did not understand response from {provider['id']}: {links.content}"
+        ) from exc
+
     return [
         link
         for link in links.data

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,3 +1,4 @@
+griffe==0.21 # Currently mkdocstrings-python does not pin a griffe version, but it is quite flaky...
 markupsafe==2.0.1 # Can be removed once aiida supports Jinja2>=3, see pallets/markupsafe#284
 mike==1.1.2
 mkdocs==1.3.0


### PR DESCRIPTION
Timeouts/errors were previously not being caught when querying index meta-databases.