### PR TITLE
Optimisation: do not re-access mapper properties inside the request loop

### DIFF
--- a/optimade/server/entry_collections/entry_collections.py
+++ b/optimade/server/entry_collections/entry_collections.py
@@ -160,12 +160,13 @@ class EntryCollection(ABC):
 
         bad_optimade_fields = set()
         bad_provider_fields = set()
+        supported_prefixes = self.resource_mapper.SUPPORTED_PREFIXES
+        all_attributes = self.resource_mapper.ALL_ATTRIBUTES
         for field in include_fields:
-            if field not in self.resource_mapper.ALL_ATTRIBUTES:
+            if field not in all_attributes:
                 if field.startswith("_"):
                     if any(
-                        field.startswith(f"_{prefix}_")
-                        for prefix in self.resource_mapper.SUPPORTED_PREFIXES
+                        field.startswith(f"_{prefix}_") for prefix in supported_prefixes
                     ):
                         bad_provider_fields.add(field)
                 else:


### PR DESCRIPTION
Closes #1219 by accessing the config variables outside of the response field loop.