### PR TITLE
Add `http_client_deps` to `dev_deps` in setup.py 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ dev_deps = (
     + docs_deps
     + testing_deps
     + client_deps
+    + http_client_deps
 )
 all_deps = (
     dev_deps


### PR DESCRIPTION
In the instructions for the installation of the development version of the optimade-python-tools we ask the user to run py.test to check if the installation was successful.
The requirements for the http client are however missing from the dev_deps, which causes py.test to fail.
Therefore I have added the the http_client_deps to the  dev_deps