### PR TITLE
Add `lru_cache` to many mapper properties

### DIFF
--- a/optimade/server/mappers/entries.py
+++ b/optimade/server/mappers/entries.py
@@ -1,4 +1,5 @@
 from typing import Tuple, Optional, Type, Set, Dict, Any, Union, List, Iterable
+from functools import lru_cache
 import warnings
 
 from optimade.models.entries import EntryResource
@@ -76,7 +77,8 @@ class BaseResourceMapper:
     ENDPOINT: str
 
     @classmethod
-    def all_aliases(cls) -> Tuple[Tuple[str, str]]:
+    @lru_cache(maxsize=1)
+    def all_aliases(cls) -> Iterable[Tuple[str, str]]:
         """Returns all of the associated aliases for this entry type,
         including those defined by the server config. The first member
         of each tuple is the OPTIMADE-compliant field name, the second
@@ -108,6 +110,7 @@ class BaseResourceMapper:
         )
 
     @classproperty
+    @lru_cache(maxsize=1)
     def SUPPORTED_PREFIXES(cls) -> Set[str]:
         """A set of prefixes handled by this entry type.
 
@@ -150,6 +153,7 @@ class BaseResourceMapper:
         return retrieve_queryable_properties(cls.ENTRY_RESOURCE_CLASS.schema())
 
     @classproperty
+    @lru_cache(maxsize=1)
     def ENDPOINT(cls) -> str:
         """Returns the expected endpoint for this mapper, corresponding
         to the `type` property of the resource class.
@@ -163,7 +167,8 @@ class BaseResourceMapper:
         )
 
     @classmethod
-    def all_length_aliases(cls) -> Tuple[Tuple[str, str]]:
+    @lru_cache(maxsize=1)
+    def all_length_aliases(cls) -> Iterable[Tuple[str, str]]:
         """Returns all of the associated length aliases for this class,
         including those defined by the server config.
 
@@ -178,6 +183,7 @@ class BaseResourceMapper:
         )
 
     @classmethod
+    @lru_cache(maxsize=128)
     def length_alias_for(cls, field: str) -> Optional[str]:
         """Returns the length alias for the particular field,
         or `None` if no such alias is found.
@@ -192,6 +198,7 @@ class BaseResourceMapper:
         return dict(cls.all_length_aliases()).get(field, None)
 
     @classmethod
+    @lru_cache(maxsize=128)
     def get_backend_field(cls, optimade_field: str) -> str:
         """Return the field name configured for the particular
         underlying database for the passed OPTIMADE field name, that would
@@ -226,6 +233,7 @@ class BaseResourceMapper:
         return optimade_field
 
     @classmethod
+    @lru_cache(maxsize=128)
     def alias_for(cls, field: str) -> str:
         """Return aliased field name.
 
@@ -247,6 +255,7 @@ class BaseResourceMapper:
         return cls.get_backend_field(field)
 
     @classmethod
+    @lru_cache(maxsize=128)
     def get_optimade_field(cls, backend_field: str) -> str:
         """Return the corresponding OPTIMADE field name for the underlying database field,
         ready to be used to construct the OPTIMADE-compliant JSON response.
@@ -274,6 +283,7 @@ class BaseResourceMapper:
         )
 
     @classmethod
+    @lru_cache(maxsize=128)
     def alias_of(cls, field: str) -> str:
         """Return de-aliased field name, if it exists,
         otherwise return the input field name.
@@ -296,6 +306,7 @@ class BaseResourceMapper:
         return cls.get_optimade_field(field)
 
     @classmethod
+    @lru_cache(maxsize=1)
     def get_required_fields(cls) -> set:
         """Get REQUIRED response fields.
 


### PR DESCRIPTION
This PR is primarily for optimisation of the mapper by lru caching lots of properties on first run. This is still an unfortunate workaround for our weird class-level storage of these properties, but I think this is a reasonable performance fix that maintains backwards-compat.

Need to run some benchmarks before this gets merged.