### PR TITLE
Add schema parameter when calling meta_values in landing.py

### DIFF
--- a/optimade/server/routers/landing.py
+++ b/optimade/server/routers/landing.py
@@ -26,7 +26,7 @@ def render_landing_page(url: str) -> HTMLResponse:
         web safe before inclusion in the template.
 
     """
-    meta = meta_values(url, 1, 1, more_data_available=False)
+    meta = meta_values(url, 1, 1, more_data_available=False, schema=CONFIG.schema_url)
     major_version = __api_version__.split(".")[0]
     versioned_url = f"{get_base_url(url)}/v{major_version}/"
 


### PR DESCRIPTION
I added a value for the schema parameter, which is passed on to meta_values.
I do not know whether CONFIG.schema_url is an appropriate value for the landing page, but at least the landing page is now loaded correctly. 

Closes #1256