### PR TITLE
Use animated SVG logo for optimade-python-tools landing page

### DIFF
--- a/optimade/server/routers/static/landing_page.html
+++ b/optimade/server/routers/static/landing_page.html
@@ -14,7 +14,7 @@
     </style>
     </head>
     <body>
-        <img id="logo" width="100" src="https://avatars0.githubusercontent.com/u/23107754?s=400&u=e1580af496ac195a3ac4c445a66a5699efb0c3d3"></img>
+        <img id="logo" width="100" src="https://matsci.org/uploads/default/original/2X/b/bd2f59b3bf14fb046b74538750699d7da4c19ac1.svg"></img>
         <h3>This is an <a href="https://www.optimade.org">OPTIMADE</a> base URL which can be queried with an OPTIMADE client.</h3>
         <h3>OPTIMADE version:</h3>
         <h3><span class="version">{{ api_version }}</span></h3>


### PR DESCRIPTION
Use the animated logo of @blokhin on our landing pages (posted at https://matsci.org/t/optimade-animation-live-logo-released-under-cc-by-4-0/43568). I assume matsci.org is sufficiently robust image hosting 🙃 