### PR TITLE
Set correct `meta->schema` value automatically

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -80,7 +80,7 @@ jobs:
       run: python -m build
 
     - name: Publish package to PyPI
-      uses: pypa/gh-action-pypi-publish/@release/v1
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.PYPI_PASSWORD }}

--- a/optimade/server/config.py
+++ b/optimade/server/config.py
@@ -255,6 +255,17 @@ class ServerConfig(BaseSettings):
             "MongoDB-based backend."
         ),
     )
+
+    is_index: Optional[bool] = Field(
+        False,
+        description=(
+            "A runtime setting to dynamically switch between index meta-database and "
+            "normal OPTIMADE servers. Used for switching behaviour of e.g., `meta->optimade_schema` "
+            "values in the response. Any provided value may be overridden when used with the reference "
+            "server implementation."
+        ),
+    )
+
     schema_url: Optional[Union[str, AnyHttpUrl]] = Field(
         f"https://schemas.optimade.org/openapi/v{__api_version__}/optimade.json",
         description=(

--- a/optimade/server/main_index.py
+++ b/optimade/server/main_index.py
@@ -133,6 +133,7 @@ def add_optional_versioned_base_urls(app: FastAPI):
 
 @app.on_event("startup")
 async def startup_event():
+    CONFIG.is_index = True
     # Add API endpoints for MANDATORY base URL `/vMAJOR`
     add_major_version_base_url(app)
     # Add API endpoints for OPTIONAL base URLs `/vMAJOR.MINOR` and `/vMAJOR.MINOR.PATCH`

--- a/optimade/server/routers/utils.py
+++ b/optimade/server/routers/utils.py
@@ -2,7 +2,7 @@
 import re
 import urllib.parse
 from datetime import datetime
-from typing import Any, Dict, List, Set, Union
+from typing import Any, Dict, List, Optional, Set, Union
 
 from fastapi import Request
 from fastapi.responses import JSONResponse
@@ -59,7 +59,7 @@ def meta_values(
     data_returned: int,
     data_available: int,
     more_data_available: bool,
-    schema: str,
+    schema: Optional[str] = None,
     **kwargs,
 ) -> ResponseMeta:
     """Helper to initialize the meta values"""
@@ -73,6 +73,9 @@ def meta_values(
         url_path = re.sub(r"/v[0-9]+(\.[0-9]+){,2}/", "/", url.path)
     else:
         url_path = url.path
+
+    if schema is None:
+        schema = CONFIG.schema_url if not CONFIG.is_index else CONFIG.index_schema_url
 
     return ResponseMeta(
         query=ResponseMetaQuery(representation=f"{url_path}?{url.query}"),
@@ -273,7 +276,9 @@ def get_entries(
             data_returned=data_returned,
             data_available=len(collection),
             more_data_available=more_data_available,
-            schema=CONFIG.schema_url,
+            schema=CONFIG.schema_url
+            if not CONFIG.is_index
+            else CONFIG.index_schema_url,
         ),
         included=included,
     )
@@ -321,7 +326,9 @@ def get_single_entry(
             data_returned=data_returned,
             data_available=len(collection),
             more_data_available=more_data_available,
-            schema=CONFIG.schema_url,
+            schema=CONFIG.schema_url
+            if not CONFIG.is_index
+            else CONFIG.index_schema_url,
         ),
         included=included,
     )


### PR DESCRIPTION
This PR adds a config option that tracks whether the reference server is in index or non-index mode, then uses that to correctly set the `meta->schema` value in that server's responses.

This means that a value no longer needs to be provided to the `meta_values` function if not necessary (see https://github.com/aiidateam/aiida-optimade/pull/375).

Also tweaks the OpenAPI schema with a formatting change due to dependency updates.