### PR TITLE
Pin requirements in CD release workflows

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -33,7 +33,8 @@ jobs:
       run: |
         python -m pip install -U pip
         pip install -U setuptools wheel
-        pip install -U -e .[all]
+        pip install -r requirements.txt -r requirements-dev.txt -r requirements-client.txt -r requirements-http-client.txt -r requirements-docs.txt
+        pip install -e .[all]
 
     - name: Update changelog
       uses: CharMixer/auto-changelog-action@v1
@@ -79,7 +80,7 @@ jobs:
       run: python -m build
 
     - name: Publish package to PyPI
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish/@release/v1
       with:
         user: __token__
         password: ${{ secrets.PYPI_PASSWORD }}
@@ -106,7 +107,8 @@ jobs:
       run: |
         python -m pip install -U pip
         pip install -U setuptools wheel
-        pip install -U -e .[all]
+        pip install -r requirements.txt -r requirements-dev.txt -r requirements-client.txt -r requirements-http-client.txt -r requirements-docs.txt
+        pip install -e .[all]
 
     - name: Set git config
       run: |

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -24,10 +24,10 @@ jobs:
         submodules: true
         fetch-depth: 0
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.10
       uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: '3.10'
 
     - name: Install Python dependencies
       run: |
@@ -98,10 +98,10 @@ jobs:
         fetch-depth: 0
         ref: ${{ env.PUBLISH_UPDATE_BRANCH }}
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.10
       uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: '3.10'
 
     - name: Install Python dependencies
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,7 +331,9 @@ jobs:
         pip install --upgrade setuptools requests
 
     - name: Install package
-      run: pip install -U -e .[all]
+      run: |
+          pip install -r requirements.txt -r requirements-dev.txt -r requirements-client.txt -r requirements-http-client.txt -r requirements-docs.txt
+          pip install -e .[all]
 
     - name: Build source distribution
       run: python ./setup.py sdist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,7 +241,7 @@ jobs:
         OPTIMADE_INSERT_TEST_DATA: false # Must be specified as previous steps will have already inserted the test data
 
     - name: Run the OPTIMADE Client CLI
-      if: matrix.python-version == 3.8
+      if: matrix.python-version == 3.10
       run: |
         coverage run --append --source optimade optimade/client/cli.py \
            --filter 'nsites = 1' \

--- a/.github/workflows/ci_cd_updated_master.yml
+++ b/.github/workflows/ci_cd_updated_master.yml
@@ -43,18 +43,19 @@ jobs:
         fetch-depth: 0
         submodules: true
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.10
       if: env.RELEASE_RUN == 'false'
       uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: '3.10'
 
     - name: Install dependencies
       if: env.RELEASE_RUN == 'false'
       run: |
         python -m pip install --upgrade pip
         pip install -U setuptools wheel
-        pip install -U -e .[all]
+        pip install -r requirements.txt -r requirements-dev.txt -r requirements-client.txt -r requirements-http-client.txt -r requirements-docs.txt
+        pip install -e .[all]
 
     - name: Set up git user
       if: env.RELEASE_RUN == 'false'

--- a/.github/workflows/ci_dependabot.yml
+++ b/.github/workflows/ci_dependabot.yml
@@ -24,10 +24,10 @@ jobs:
       with:
         ref: ${{ env.DEFAULT_REPO_BRANCH }}
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.10
       uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: '3.10'
 
     - name: Install `pre-commit` and dependencies
       run: |


### PR DESCRIPTION
It is possible for some tests to fail on CD but not CI; this PR pins the CD workflows to the same requirements file versions.