### PR TITLE
Enable `mypy` and `isort` in pre-commit & CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,3 +50,9 @@ repos:
       - id: mypy
         name: "MyPy"
         additional_dependencies: ["types-all", "pydantic~=1.10"]
+
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+        name: "isort"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,3 +43,10 @@ repos:
       pass_filenames: false
       files: ^optimade/.*\.py$
       description: Update the API Reference documentation whenever a Python file is touched in the code base.
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.981
+    hooks:
+      - id: mypy
+        name: "MyPy"
+        additional_dependencies: ["types-all", "pydantic~=1.10"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
       description: Update the API Reference documentation whenever a Python file is touched in the code base.
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.981
+    rev: v0.991
     hooks:
       - id: mypy
         name: "MyPy"

--- a/optimade/adapters/__init__.py
+++ b/optimade/adapters/__init__.py
@@ -3,4 +3,4 @@ from .exceptions import *  # noqa: F403
 from .references import *  # noqa: F403
 from .structures import *  # noqa: F403
 
-__all__ = exceptions.__all__ + references.__all__ + structures.__all__  # noqa: F405
+__all__ = exceptions.__all__ + references.__all__ + structures.__all__  # type: ignore[name-defined]  # noqa: F405

--- a/optimade/adapters/__init__.py
+++ b/optimade/adapters/__init__.py
@@ -3,5 +3,4 @@ from .exceptions import *  # noqa: F403
 from .references import *  # noqa: F403
 from .structures import *  # noqa: F403
 
-
 __all__ = exceptions.__all__ + references.__all__ + structures.__all__  # noqa: F405

--- a/optimade/adapters/base.py
+++ b/optimade/adapters/base.py
@@ -19,12 +19,12 @@ resources can be converted to for [`ReferenceResource`][optimade.models.referenc
 and [`StructureResource`][optimade.models.structures.StructureResource]s, respectively.
 """
 import re
-from typing import Any, Callable, Dict, List, Tuple, Type, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 
 from pydantic import BaseModel  # pylint: disable=no-name-in-module
 
 from optimade.adapters.logger import LOGGER
-from optimade.models import EntryResource
+from optimade.models.entries import EntryResource
 
 
 class EntryAdapter:
@@ -48,15 +48,17 @@ class EntryAdapter:
         Parameters:
             entry (dict): A JSON OPTIMADE single resource entry.
         """
-        self._entry = None
-        self._converted = {}
+        self._entry: Optional[EntryResource] = None
+        self._converted: Dict[str, Any] = {}
 
-        self.entry = entry
+        self.entry: EntryResource = entry  # type: ignore[assignment]
 
         # Note that these return also the default values for otherwise non-provided properties.
         self._common_converters = {
-            "json": self.entry.json,  # Return JSON serialized string, see https://pydantic-docs.helpmanual.io/usage/exporting_models/#modeljson
-            "dict": self.entry.dict,  # Return Python dict, see https://pydantic-docs.helpmanual.io/usage/exporting_models/#modeldict
+            # Return JSON serialized string, see https://pydantic-docs.helpmanual.io/usage/exporting_models/#modeljson
+            "json": self.entry.json,  # type: ignore[attr-defined]
+            # Return Python dict, see https://pydantic-docs.helpmanual.io/usage/exporting_models/#modeldict
+            "dict": self.entry.dict,  # type: ignore[attr-defined]
         }
 
     @property
@@ -67,7 +69,7 @@ class EntryAdapter:
             The entry resource.
 
         """
-        return self._entry
+        return self._entry  # type: ignore[return-value]
 
     @entry.setter
     def entry(self, value: dict) -> None:
@@ -171,12 +173,12 @@ class EntryAdapter:
             return res
 
         # Non-valid attribute
-        entry_resource_name = re.match(
+        _entry_resource_name = re.match(
             r"(<class ')([a-zA-Z_]+\.)*([a-zA-Z_]+)('>)", str(self.ENTRY_RESOURCE)
         )
         entry_resource_name = (
-            entry_resource_name.group(3)
-            if entry_resource_name is not None
+            _entry_resource_name.group(3)
+            if _entry_resource_name is not None
             else "UNKNOWN RESOURCE"
         )
         raise AttributeError(

--- a/optimade/adapters/base.py
+++ b/optimade/adapters/base.py
@@ -19,13 +19,12 @@ resources can be converted to for [`ReferenceResource`][optimade.models.referenc
 and [`StructureResource`][optimade.models.structures.StructureResource]s, respectively.
 """
 import re
-from typing import Union, Dict, Callable, Any, Tuple, List, Type
+from typing import Any, Callable, Dict, List, Tuple, Type, Union
 
 from pydantic import BaseModel  # pylint: disable=no-name-in-module
 
-from optimade.models import EntryResource
-
 from optimade.adapters.logger import LOGGER
+from optimade.models import EntryResource
 
 
 class EntryAdapter:

--- a/optimade/adapters/references/__init__.py
+++ b/optimade/adapters/references/__init__.py
@@ -1,4 +1,3 @@
 from .adapter import Reference
 
-
 __all__ = ("Reference",)

--- a/optimade/adapters/references/adapter.py
+++ b/optimade/adapters/references/adapter.py
@@ -1,3 +1,5 @@
+from typing import Type
+
 from optimade.adapters.base import EntryAdapter
 from optimade.models import ReferenceResource
 
@@ -19,4 +21,4 @@ class Reference(EntryAdapter):
 
     """
 
-    ENTRY_RESOURCE: ReferenceResource = ReferenceResource
+    ENTRY_RESOURCE: Type[ReferenceResource] = ReferenceResource

--- a/optimade/adapters/references/adapter.py
+++ b/optimade/adapters/references/adapter.py
@@ -1,5 +1,5 @@
-from optimade.models import ReferenceResource
 from optimade.adapters.base import EntryAdapter
+from optimade.models import ReferenceResource
 
 
 class Reference(EntryAdapter):

--- a/optimade/adapters/structures/__init__.py
+++ b/optimade/adapters/structures/__init__.py
@@ -1,4 +1,3 @@
 from .adapter import Structure
 
-
 __all__ = ("Structure",)

--- a/optimade/adapters/structures/adapter.py
+++ b/optimade/adapters/structures/adapter.py
@@ -1,13 +1,14 @@
 from typing import Callable, Dict, Type
-from optimade.models import StructureResource
+
 from optimade.adapters.base import EntryAdapter
+from optimade.models import StructureResource
 
 from .aiida import get_aiida_structure_data
 from .ase import get_ase_atoms
 from .cif import get_cif
-from .proteindatabank import get_pdb, get_pdbx_mmcif
-from .pymatgen import get_pymatgen, from_pymatgen
 from .jarvis import get_jarvis_atoms
+from .proteindatabank import get_pdb, get_pdbx_mmcif
+from .pymatgen import from_pymatgen, get_pymatgen
 
 
 class Structure(EntryAdapter):

--- a/optimade/adapters/structures/aiida.py
+++ b/optimade/adapters/structures/aiida.py
@@ -44,13 +44,13 @@ def get_aiida_structure_data(optimade_structure: OptimadeStructure) -> Structure
     attributes = optimade_structure.attributes
 
     # Convert null/None values to float("nan")
-    lattice_vectors, adjust_cell = pad_cell(attributes.lattice_vectors)
+    lattice_vectors, adjust_cell = pad_cell(attributes.lattice_vectors)  # type: ignore[arg-type]
     structure = StructureData(cell=lattice_vectors)
 
     # If species not provided, infer data from species_at_sites
     species: Optional[List[OptimadeStructureSpecies]] = attributes.species
     if not species:
-        species = species_from_species_at_sites(attributes.species_at_sites)
+        species = species_from_species_at_sites(attributes.species_at_sites)  # type: ignore[arg-type]
 
     # Add Kinds
     for kind in species:
@@ -86,18 +86,18 @@ def get_aiida_structure_data(optimade_structure: OptimadeStructure) -> Structure
         )
 
     # Add Sites
-    for index in range(attributes.nsites):
+    for index in range(attributes.nsites):  # type: ignore[arg-type]
         # range() to ensure 1-to-1 between kind and site
         structure.append_site(
             Site(
-                kind_name=attributes.species_at_sites[index],
-                position=attributes.cartesian_site_positions[index],
+                kind_name=attributes.species_at_sites[index],  # type: ignore[index]
+                position=attributes.cartesian_site_positions[index],  # type: ignore[index]
             )
         )
 
     if adjust_cell:
         structure._adjust_default_cell(
-            pbc=[bool(dim.value) for dim in attributes.dimension_types]
+            pbc=[bool(dim.value) for dim in attributes.dimension_types]  # type: ignore[union-attr]
         )
 
     return structure

--- a/optimade/adapters/structures/aiida.py
+++ b/optimade/adapters/structures/aiida.py
@@ -7,17 +7,16 @@ For more information on the AiiDA code see [their website](http://www.aiida.net)
 
 This conversion function relies on the [`aiida-core`](https://github.com/aiidateam/aiida-core) package.
 """
-from warnings import warn
 from typing import List, Optional
+from warnings import warn
 
-from optimade.models import StructureResource as OptimadeStructure
-from optimade.models import Species as OptimadeStructureSpecies
-
-from optimade.adapters.warnings import AdapterPackageNotFound, ConversionWarning
 from optimade.adapters.structures.utils import pad_cell, species_from_species_at_sites
+from optimade.adapters.warnings import AdapterPackageNotFound, ConversionWarning
+from optimade.models import Species as OptimadeStructureSpecies
+from optimade.models import StructureResource as OptimadeStructure
 
 try:
-    from aiida.orm.nodes.data.structure import StructureData, Kind, Site
+    from aiida.orm.nodes.data.structure import Kind, Site, StructureData
 except (ImportError, ModuleNotFoundError):
     StructureData = type("StructureData", (), {})
     AIIDA_NOT_FOUND = (

--- a/optimade/adapters/structures/ase.py
+++ b/optimade/adapters/structures/ase.py
@@ -9,17 +9,17 @@ For more information on the ASE code see [their documentation](https://wiki.fysi
 """
 from typing import Dict
 
-from optimade.models import Species as OptimadeStructureSpecies
-from optimade.models import StructureResource as OptimadeStructure
-from optimade.models import StructureFeatures
-
 from optimade.adapters.exceptions import ConversionError
 from optimade.adapters.structures.utils import species_from_species_at_sites
+from optimade.models import Species as OptimadeStructureSpecies
+from optimade.models import StructureFeatures
+from optimade.models import StructureResource as OptimadeStructure
 
 try:
-    from ase import Atoms, Atom
+    from ase import Atom, Atoms
 except (ImportError, ModuleNotFoundError):
     from warnings import warn
+
     from optimade.adapters.warnings import AdapterPackageNotFound
 
     Atoms = type("Atoms", (), {})

--- a/optimade/adapters/structures/ase.py
+++ b/optimade/adapters/structures/ase.py
@@ -57,7 +57,7 @@ def get_ase_atoms(optimade_structure: OptimadeStructure) -> Atoms:
     species = attributes.species
     # If species is missing, infer data from species_at_sites
     if not species:
-        species = species_from_species_at_sites(attributes.species_at_sites)
+        species = species_from_species_at_sites(attributes.species_at_sites)  # type: ignore[arg-type]
 
     optimade_species: Dict[str, OptimadeStructureSpecies] = {_.name: _ for _ in species}
 
@@ -69,9 +69,9 @@ def get_ase_atoms(optimade_structure: OptimadeStructure) -> Atoms:
         )
 
     atoms = []
-    for site_number in range(attributes.nsites):
-        species_name = attributes.species_at_sites[site_number]
-        site = attributes.cartesian_site_positions[site_number]
+    for site_number in range(attributes.nsites):  # type: ignore[arg-type]
+        species_name = attributes.species_at_sites[site_number]  # type: ignore[index]
+        site = attributes.cartesian_site_positions[site_number]  # type: ignore[index]
 
         current_species = optimade_species[species_name]
 

--- a/optimade/adapters/structures/cif.py
+++ b/optimade/adapters/structures/cif.py
@@ -33,7 +33,7 @@ except ImportError:
 
     from optimade.adapters.warnings import AdapterPackageNotFound
 
-    np = None
+    np = None  # type: ignore[assignment]
     NUMPY_NOT_FOUND = "NumPy not found, cannot convert structure to CIF"
 
 
@@ -55,7 +55,7 @@ def get_cif(  # pylint: disable=too-many-locals,too-many-branches
     # NumPy is needed for calculations
     if globals().get("np", None) is None:
         warn(NUMPY_NOT_FOUND, AdapterPackageNotFound)
-        return None
+        return None  # type: ignore[return-value]
 
     cif = """#
 # Created from an OPTIMADE structure.
@@ -71,9 +71,9 @@ def get_cif(  # pylint: disable=too-many-locals,too-many-branches
 
     # Do this only if there's three non-zero lattice vectors
     # NOTE: This also negates handling of lattice_vectors with null/None values
-    if valid_lattice_vector(attributes.lattice_vectors):
+    if valid_lattice_vector(attributes.lattice_vectors):  # type:ignore[arg-type]
         a_vector, b_vector, c_vector, alpha, beta, gamma = cell_to_cellpar(
-            attributes.lattice_vectors
+            attributes.lattice_vectors  # type: ignore[arg-type]
         )
 
         cif += (
@@ -96,8 +96,8 @@ def get_cif(  # pylint: disable=too-many-locals,too-many-branches
         # we calculate the fractional coordinates if this is a 3D structure and we have all the necessary information.
         if not hasattr(attributes, "fractional_site_positions"):
             attributes.fractional_site_positions = fractional_coordinates(
-                cell=attributes.lattice_vectors,
-                cartesian_positions=attributes.cartesian_site_positions,
+                cell=attributes.lattice_vectors,  # type:ignore[arg-type]
+                cartesian_positions=attributes.cartesian_site_positions,  # type:ignore[arg-type]
             )
 
     # NOTE: This is otherwise a bit ahead of its time, since this OPTIMADE property is part of an open PR.
@@ -124,12 +124,12 @@ def get_cif(  # pylint: disable=too-many-locals,too-many-branches
         sites = attributes.cartesian_site_positions
 
     species: Dict[str, OptimadeStructureSpecies] = {
-        species.name: species for species in attributes.species
+        species.name: species for species in attributes.species  # type: ignore[union-attr]
     }
 
-    symbol_occurences = {}
-    for site_number in range(attributes.nsites):
-        species_name = attributes.species_at_sites[site_number]
+    symbol_occurences: Dict[str, int] = {}
+    for site_number in range(attributes.nsites):  # type: ignore[arg-type]
+        species_name = attributes.species_at_sites[site_number]  # type: ignore[index]
         site = sites[site_number]
 
         current_species = species[species_name]

--- a/optimade/adapters/structures/cif.py
+++ b/optimade/adapters/structures/cif.py
@@ -18,19 +18,19 @@ This conversion function relies on the [NumPy](https://numpy.org/) library.
 """
 from typing import Dict
 
-from optimade.models import Species as OptimadeStructureSpecies
-from optimade.models import StructureResource as OptimadeStructure
-
 from optimade.adapters.structures.utils import (
     cell_to_cellpar,
     fractional_coordinates,
     valid_lattice_vector,
 )
+from optimade.models import Species as OptimadeStructureSpecies
+from optimade.models import StructureResource as OptimadeStructure
 
 try:
     import numpy as np
 except ImportError:
     from warnings import warn
+
     from optimade.adapters.warnings import AdapterPackageNotFound
 
     np = None

--- a/optimade/adapters/structures/jarvis.py
+++ b/optimade/adapters/structures/jarvis.py
@@ -10,14 +10,15 @@ This conversion function relies on the [jarvis-tools](https://github.com/usnistg
 !!! success "Contributing author"
     This conversion function was contributed by Kamal Choudhary ([@knc6](https://github.com/knc6)).
 """
-from optimade.models import StructureResource as OptimadeStructure
-from optimade.models import StructureFeatures
 from optimade.adapters.exceptions import ConversionError
+from optimade.models import StructureFeatures
+from optimade.models import StructureResource as OptimadeStructure
 
 try:
     from jarvis.core.atoms import Atoms
 except (ImportError, ModuleNotFoundError):
     from warnings import warn
+
     from optimade.adapters.warnings import AdapterPackageNotFound
 
     Atoms = type("Atoms", (), {})

--- a/optimade/adapters/structures/jarvis.py
+++ b/optimade/adapters/structures/jarvis.py
@@ -55,7 +55,7 @@ def get_jarvis_atoms(optimade_structure: OptimadeStructure) -> Atoms:
 
     return Atoms(
         lattice_mat=attributes.lattice_vectors,
-        elements=[specie.name for specie in attributes.species],
+        elements=[specie.name for specie in attributes.species],  # type: ignore[union-attr]
         coords=attributes.cartesian_site_positions,
         cartesian=True,
     )

--- a/optimade/adapters/structures/proteindatabank.py
+++ b/optimade/adapters/structures/proteindatabank.py
@@ -30,7 +30,7 @@ except ImportError:
 
     from optimade.adapters.warnings import AdapterPackageNotFound
 
-    np = None
+    np = None  # type: ignore[assignment]
     NUMPY_NOT_FOUND = "NumPy not found, cannot convert structure to your desired format"
 
 from optimade.adapters.structures.utils import (
@@ -63,7 +63,7 @@ def get_pdbx_mmcif(  # pylint: disable=too-many-locals
     """
     if globals().get("np", None) is None:
         warn(NUMPY_NOT_FOUND, AdapterPackageNotFound)
-        return None
+        return None  # type: ignore[return-value]
 
     cif = """#
 # Created from an OPTIMADE structure.
@@ -82,9 +82,9 @@ def get_pdbx_mmcif(  # pylint: disable=too-many-locals
     attributes = optimade_structure.attributes
 
     # Do this only if there's three non-zero lattice vectors
-    if valid_lattice_vector(attributes.lattice_vectors):
+    if valid_lattice_vector(attributes.lattice_vectors):  # type: ignore[arg-type]
         a_vector, b_vector, c_vector, alpha, beta, gamma = cell_to_cellpar(
-            attributes.lattice_vectors
+            attributes.lattice_vectors  # type: ignore[arg-type]
         )
 
         cif += (
@@ -107,8 +107,8 @@ def get_pdbx_mmcif(  # pylint: disable=too-many-locals
         # we calculate the fractional coordinates if this is a 3D structure and we have all the necessary information.
         if not hasattr(attributes, "fractional_site_positions"):
             attributes.fractional_site_positions = fractional_coordinates(
-                cell=attributes.lattice_vectors,
-                cartesian_positions=attributes.cartesian_site_positions,
+                cell=attributes.lattice_vectors,  # type: ignore[arg-type]
+                cartesian_positions=attributes.cartesian_site_positions,  # type: ignore[arg-type]
             )
 
     # NOTE: The following lines are perhaps needed to create a "valid" PDBx/mmCIF file.
@@ -165,11 +165,11 @@ def get_pdbx_mmcif(  # pylint: disable=too-many-locals
         sites = attributes.cartesian_site_positions
 
     species: Dict[str, OptimadeStructureSpecies] = {
-        species.name: species for species in attributes.species
+        species.name: species for species in attributes.species  # type: ignore[union-attr]
     }
 
-    for site_number in range(attributes.nsites):
-        species_name = attributes.species_at_sites[site_number]
+    for site_number in range(attributes.nsites):  # type: ignore[arg-type]
+        species_name = attributes.species_at_sites[site_number]  # type: ignore[index]
         site = sites[site_number]
 
         current_species = species[species_name]
@@ -211,14 +211,14 @@ def get_pdb(  # pylint: disable=too-many-locals
     """
     if globals().get("np", None) is None:
         warn(NUMPY_NOT_FOUND, AdapterPackageNotFound)
-        return None
+        return None  # type: ignore[return-value]
 
     pdb = ""
 
     attributes = optimade_structure.attributes
 
     rotation = None
-    if valid_lattice_vector(attributes.lattice_vectors):
+    if valid_lattice_vector(attributes.lattice_vectors):  # type: ignore[arg-type]
         currentcell = np.asarray(attributes.lattice_vectors)
         cellpar = cell_to_cellpar(currentcell)
         exportedcell = cellpar_to_cell(cellpar)
@@ -241,15 +241,16 @@ def get_pdb(  # pylint: disable=too-many-locals
     pdb += "MODEL     1\n"
 
     species: Dict[str, OptimadeStructureSpecies] = {
-        species.name: species for species in attributes.species
+        species.name: species
+        for species in attributes.species  # type:ignore[union-attr]
     }
 
     sites = np.asarray(attributes.cartesian_site_positions)
     if rotation is not None:
         sites = sites.dot(rotation)
 
-    for site_number in range(attributes.nsites):
-        species_name = attributes.species_at_sites[site_number]
+    for site_number in range(attributes.nsites):  # type: ignore[arg-type]
+        species_name = attributes.species_at_sites[site_number]  # type: ignore[index]
         site = sites[site_number]
 
         current_species = species[species_name]

--- a/optimade/adapters/structures/proteindatabank.py
+++ b/optimade/adapters/structures/proteindatabank.py
@@ -27,13 +27,11 @@ try:
     import numpy as np
 except ImportError:
     from warnings import warn
+
     from optimade.adapters.warnings import AdapterPackageNotFound
 
     np = None
     NUMPY_NOT_FOUND = "NumPy not found, cannot convert structure to your desired format"
-
-from optimade.models import Species as OptimadeStructureSpecies
-from optimade.models import StructureResource as OptimadeStructure
 
 from optimade.adapters.structures.utils import (
     cell_to_cellpar,
@@ -42,7 +40,8 @@ from optimade.adapters.structures.utils import (
     scaled_cell,
     valid_lattice_vector,
 )
-
+from optimade.models import Species as OptimadeStructureSpecies
+from optimade.models import StructureResource as OptimadeStructure
 
 __all__ = ("get_pdb", "get_pdbx_mmcif")
 

--- a/optimade/adapters/structures/pymatgen.py
+++ b/optimade/adapters/structures/pymatgen.py
@@ -61,9 +61,9 @@ def get_pymatgen(optimade_structure: OptimadeStructure) -> Union[Structure, Mole
         warn(PYMATGEN_NOT_FOUND, AdapterPackageNotFound)
         return None
 
-    if valid_lattice_vector(optimade_structure.attributes.lattice_vectors) and (
-        optimade_structure.attributes.nperiodic_dimensions > 0
-        or any(optimade_structure.attributes.dimension_types)
+    if valid_lattice_vector(optimade_structure.attributes.lattice_vectors) and (  # type: ignore[arg-type]
+        optimade_structure.attributes.nperiodic_dimensions > 0  # type: ignore[operator]
+        or any(optimade_structure.attributes.dimension_types)  # type: ignore[arg-type]
     ):
         return _get_structure(optimade_structure)
 
@@ -78,9 +78,9 @@ def _get_structure(optimade_structure: OptimadeStructure) -> Structure:
     return Structure(
         lattice=Lattice(attributes.lattice_vectors, attributes.dimension_types),
         species=_pymatgen_species(
-            nsites=attributes.nsites,
+            nsites=attributes.nsites,  # type: ignore[arg-type]
             species=attributes.species,
-            species_at_sites=attributes.species_at_sites,
+            species_at_sites=attributes.species_at_sites,  # type: ignore[arg-type]
         ),
         coords=attributes.cartesian_site_positions,
         coords_are_cartesian=True,
@@ -94,9 +94,9 @@ def _get_molecule(optimade_structure: OptimadeStructure) -> Molecule:
 
     return Molecule(
         species=_pymatgen_species(
-            nsites=attributes.nsites,
-            species=attributes.species,
-            species_at_sites=attributes.species_at_sites,
+            nsites=attributes.nsites,  # type: ignore[arg-type]
+            species=attributes.species,  # type: ignore[arg-type]
+            species_at_sites=attributes.species_at_sites,  # type: ignore[arg-type]
         ),
         coords=attributes.cartesian_site_positions,
     )

--- a/optimade/adapters/structures/pymatgen.py
+++ b/optimade/adapters/structures/pymatgen.py
@@ -7,22 +7,22 @@ This conversion function relies on the [pymatgen](https://github.com/materialspr
 
 For more information on the pymatgen code see [their documentation](https://pymatgen.org).
 """
-from typing import Union, Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
-from optimade.models import Species as OptimadeStructureSpecies
-from optimade.models import StructureResource as OptimadeStructure
 from optimade.adapters.structures.utils import (
     species_from_species_at_sites,
     valid_lattice_vector,
 )
+from optimade.models import Species as OptimadeStructureSpecies
+from optimade.models import StructureResource as OptimadeStructure
 from optimade.models import StructureResourceAttributes
 
-
 try:
-    from pymatgen.core import Structure, Molecule, Composition, Lattice
+    from pymatgen.core import Composition, Lattice, Molecule, Structure
 
 except (ImportError, ModuleNotFoundError):
     from warnings import warn
+
     from optimade.adapters.warnings import AdapterPackageNotFound
 
     Structure = type("Structure", (), {})
@@ -193,6 +193,7 @@ def from_pymatgen(pmg_structure: Structure) -> StructureResourceAttributes:
 def _pymatgen_anonymized_formula_to_optimade(composition: Composition) -> str:
     """Construct an OPTIMADE `chemical_formula_anonymous` from a pymatgen `Composition`."""
     import re
+
     from optimade.models.utils import anonymous_element_generator
 
     return "".join(

--- a/optimade/adapters/structures/utils.py
+++ b/optimade/adapters/structures/utils.py
@@ -3,14 +3,16 @@ Utility functions to help the conversion functions along.
 
 Most of these functions rely on the [NumPy](https://numpy.org/) library.
 """
-from typing import List, Optional, Tuple, Iterable
-from optimade.models.structures import Vector3D
+from typing import Iterable, List, Optional, Tuple
+
 from optimade.models.structures import Species as OptimadeStructureSpecies
+from optimade.models.structures import Vector3D
 
 try:
     import numpy as np
 except ImportError:
     from warnings import warn
+
     from optimade.adapters.warnings import AdapterPackageNotFound
 
     np = None

--- a/optimade/adapters/structures/utils.py
+++ b/optimade/adapters/structures/utils.py
@@ -3,7 +3,7 @@ Utility functions to help the conversion functions along.
 
 Most of these functions rely on the [NumPy](https://numpy.org/) library.
 """
-from typing import Iterable, List, Optional, Tuple
+from typing import Iterable, List, Optional, Tuple, Type
 
 from optimade.models.structures import Species as OptimadeStructureSpecies
 from optimade.models.structures import Vector3D
@@ -15,7 +15,7 @@ except ImportError:
 
     from optimade.adapters.warnings import AdapterPackageNotFound
 
-    np = None
+    np = None  # type: ignore[assignment]
     NUMPY_NOT_FOUND = "NumPy not found, cannot convert structure to your desired format"
 
 
@@ -49,7 +49,7 @@ def scaled_cell(
     """
     if globals().get("np", None) is None:
         warn(NUMPY_NOT_FOUND, AdapterPackageNotFound)
-        return None
+        return None  # type: ignore[return-value]
 
     cell = np.asarray(cell)
 
@@ -58,7 +58,7 @@ def scaled_cell(
     for i in range(3):
         vector = np.cross(cell[(i + 1) % 3], cell[(i + 2) % 3]) / volume
         scale.append(tuple(vector))
-    return tuple(scale)
+    return tuple(scale)  # type: ignore[return-value]
 
 
 def fractional_coordinates(
@@ -82,12 +82,12 @@ def fractional_coordinates(
     """
     if globals().get("np", None) is None:
         warn(NUMPY_NOT_FOUND, AdapterPackageNotFound)
-        return None
+        return None  # type: ignore[return-value]
 
-    cell = np.asarray(cell)
-    cartesian_positions = np.asarray(cartesian_positions)
+    cell_array = np.asarray(cell)
+    cartesian_positions_array = np.asarray(cartesian_positions)
 
-    fractional = np.linalg.solve(cell.T, cartesian_positions.T).T
+    fractional = np.linalg.solve(cell_array.T, cartesian_positions_array.T).T
 
     # Expecting a bulk 3D structure here, note, this may change in the future.
     # See `ase.atoms:Atoms.get_scaled_positions()` for ideas on how to handle lower dimensional structures.
@@ -121,7 +121,7 @@ def cell_to_cellpar(
     """
     if globals().get("np", None) is None:
         warn(NUMPY_NOT_FOUND, AdapterPackageNotFound)
-        return None
+        return None  # type: ignore[return-value]
 
     cell = np.asarray(cell)
 
@@ -154,7 +154,7 @@ def unit_vector(x: Vector3D) -> Vector3D:
     """
     if globals().get("np", None) is None:
         warn(NUMPY_NOT_FOUND, AdapterPackageNotFound)
-        return None
+        return None  # type: ignore[return-value]
 
     y = np.array(x, dtype="float")
     return y / np.linalg.norm(y)
@@ -163,7 +163,7 @@ def unit_vector(x: Vector3D) -> Vector3D:
 def cellpar_to_cell(
     cellpar: List[float],
     ab_normal: Tuple[int, int, int] = (0, 0, 1),
-    a_direction: Tuple[int, int, int] = None,
+    a_direction: Optional[Tuple[int, int, int]] = None,
 ) -> List[Vector3D]:
     """Return a 3x3 cell matrix from `cellpar=[a,b,c,alpha,beta,gamma]`.
 
@@ -207,7 +207,7 @@ def cellpar_to_cell(
     """
     if globals().get("np", None) is None:
         warn(NUMPY_NOT_FOUND, AdapterPackageNotFound)
-        return None
+        return None  # type: ignore[return-value]
 
     if a_direction is None:
         if np.linalg.norm(np.cross(ab_normal, (1, 0, 0))) < 1e-5:
@@ -277,12 +277,12 @@ def cellpar_to_cell(
 def _pad_iter_of_iters(
     iterable: Iterable[Iterable],
     padding: Optional[float] = None,
-    outer: Optional[Iterable] = None,
-    inner: Optional[Iterable] = None,
+    outer: Optional[Type] = None,
+    inner: Optional[Type] = None,
 ) -> Tuple[Iterable[Iterable], bool]:
     """Turn any null/None values into a float in given iterable of iterables"""
     try:
-        padding = float(padding)
+        padding = float(padding)  # type: ignore[arg-type]
     except (TypeError, ValueError):
         padding = float("nan")
 
@@ -296,7 +296,7 @@ def _pad_iter_of_iters(
     if padded_iterable:
         padded_iterable_of_iterables = []
         for inner_iterable in iterable:
-            new_inner_iterable = inner(
+            new_inner_iterable = inner(  # type: ignore[misc]
                 value if value is not None else padding for value in inner_iterable
             )
             padded_iterable_of_iterables.append(new_inner_iterable)

--- a/optimade/client/cli.py
+++ b/optimade/client/cli.py
@@ -1,6 +1,6 @@
-import sys
 import json
 import pathlib
+import sys
 
 import click
 import rich

--- a/optimade/client/client.py
+++ b/optimade/client/client.py
@@ -91,7 +91,7 @@ class OptimadeClient:
 
     def __init__(
         self,
-        base_urls: Optional[Union[str, List[str]]] = None,
+        base_urls: Optional[Union[str, Iterable[str]]] = None,
         max_results_per_provider: int = 1000,
         headers: Optional[Dict] = None,
         http_timeout: int = 10,
@@ -111,14 +111,15 @@ class OptimadeClient:
 
         """
 
-        if not base_urls:
-            base_urls = get_all_databases()  # type: ignore[assignment]
-
         self.max_results_per_provider = max_results_per_provider
         if self.max_results_per_provider in (-1, 0):
             self.max_results_per_provider = None
 
-        self.base_urls = base_urls  # type: ignore[assignment]
+        if not base_urls:
+            self.base_urls = get_all_databases()
+        else:
+            self.base_urls = base_urls
+
         if isinstance(self.base_urls, str):
             self.base_urls = [self.base_urls]
         self.base_urls = list(self.base_urls)

--- a/optimade/client/client.py
+++ b/optimade/client/client.py
@@ -5,21 +5,21 @@
 
 """
 
-from typing import Dict, List, Union, Iterable, Optional, Any, Tuple
-from urllib.parse import urlparse
-from collections import defaultdict
 import asyncio
-import time
-import json
 import functools
+import json
+import time
+from collections import defaultdict
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
+from urllib.parse import urlparse
 
 from pydantic import AnyUrl
 
 # External deps that are only used in the client code
 try:
     import httpx
-    from rich.progress import TaskID
     from rich.panel import Panel
+    from rich.progress import TaskID
 except ImportError as exc:
     raise ImportError(
         "Could not find dependencies required for the `OptimadeClient`. "
@@ -28,17 +28,17 @@ except ImportError as exc:
     ) from exc
 
 
-from optimade.utils import get_all_databases
-from optimade.filterparser import LarkParser
 from optimade import __api_version__, __version__
 from optimade.client.utils import (
     OptimadeClientProgress,
-    TooManyRequestsException,
     QueryResults,
     RecoverableHTTPError,
+    TooManyRequestsException,
     silent_raise,
 )
+from optimade.filterparser import LarkParser
 from optimade.server.exceptions import BadRequest
+from optimade.utils import get_all_databases
 
 ENDPOINTS = ("structures", "references", "calculations", "info", "extensions")
 

--- a/optimade/client/client.py
+++ b/optimade/client/client.py
@@ -13,8 +13,6 @@ from collections import defaultdict
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 from urllib.parse import urlparse
 
-from pydantic import AnyUrl
-
 # External deps that are only used in the client code
 try:
     import httpx
@@ -57,7 +55,7 @@ class OptimadeClient:
 
     """
 
-    base_urls: Union[AnyUrl, Iterable[AnyUrl]]
+    base_urls: Union[str, Iterable[str]]
     """A list (or any iterable) of OPTIMADE base URLs to query."""
 
     all_results: Dict[str, Dict[str, Dict[str, QueryResults]]] = defaultdict(dict)
@@ -93,7 +91,7 @@ class OptimadeClient:
 
     def __init__(
         self,
-        base_urls: Union[None, AnyUrl, List[AnyUrl]] = None,
+        base_urls: Optional[Union[str, List[str]]] = None,
         max_results_per_provider: int = 1000,
         headers: Optional[Dict] = None,
         http_timeout: int = 10,
@@ -114,13 +112,13 @@ class OptimadeClient:
         """
 
         if not base_urls:
-            base_urls = get_all_databases()
+            base_urls = get_all_databases()  # type: ignore[assignment]
 
         self.max_results_per_provider = max_results_per_provider
         if self.max_results_per_provider in (-1, 0):
             self.max_results_per_provider = None
 
-        self.base_urls = base_urls
+        self.base_urls = base_urls  # type: ignore[assignment]
         if isinstance(self.base_urls, str):
             self.base_urls = [self.base_urls]
         self.base_urls = list(self.base_urls)
@@ -170,7 +168,7 @@ class OptimadeClient:
 
     def get(
         self,
-        filter: str = None,
+        filter: Optional[str] = None,
         endpoint: Optional[str] = None,
         response_fields: Optional[List[str]] = None,
         sort: Optional[str] = None,
@@ -226,7 +224,7 @@ class OptimadeClient:
             return {endpoint: {filter: {k: results[k].dict() for k in results}}}
 
     def count(
-        self, filter: str = None, endpoint: Optional[str] = None
+        self, filter: Optional[str] = None, endpoint: Optional[str] = None
     ) -> Dict[str, Dict[str, Dict[str, Optional[int]]]]:
         """Counts the number of results for the filter, requiring
         only 1 request per provider by making use of the `meta->data_returned`
@@ -325,7 +323,7 @@ class OptimadeClient:
                 event_loop = None
 
         if self.use_async and not event_loop:
-            results = asyncio.run(
+            return asyncio.run(
                 self._get_all_async(
                     endpoint,
                     filter,
@@ -335,17 +333,15 @@ class OptimadeClient:
                     sort=sort,
                 )
             )
-        else:
-            results = self._get_all(
-                endpoint,
-                filter,
-                page_limit=page_limit,
-                paginate=paginate,
-                response_fields=response_fields,
-                sort=sort,
-            )
 
-        return results
+        return self._get_all(
+            endpoint,
+            filter,
+            page_limit=page_limit,
+            paginate=paginate,
+            response_fields=response_fields,
+            sort=sort,
+        )
 
     def get_one(
         self,
@@ -477,7 +473,8 @@ class OptimadeClient:
         ]
         if results:
             return functools.reduce(lambda r1, r2: {**r1, **r2}, results)
-        return None
+
+        return {}
 
     async def get_one_async(
         self,
@@ -731,8 +728,9 @@ class OptimadeClient:
         if sort:
             _sort = f"sort={sort}"
 
-        params = (_filter, _response_fields, _page_limit, _sort)
-        params = "&".join(p for p in params if p)
+        params = "&".join(
+            p for p in (_filter, _response_fields, _page_limit, _sort) if p
+        )
         if params:
             url += f"?{params}"
 

--- a/optimade/client/utils.py
+++ b/optimade/client/utils.py
@@ -34,8 +34,8 @@ class TooManyRequestsException(RecoverableHTTPError):
 class QueryResults:
     """A container dataclass for the results from a given query."""
 
-    data: Union[Dict, List[Dict]] = field(default_factory=list, init=False)
-    errors: List[Dict] = field(default_factory=list, init=False)
+    data: Union[Dict, List[Dict]] = field(default_factory=list, init=False)  # type: ignore[assignment]
+    errors: List[str] = field(default_factory=list, init=False)
     links: Dict = field(default_factory=dict, init=False)
     included: List[Dict] = field(default_factory=list, init=False)
     meta: Dict = field(default_factory=dict, init=False)
@@ -62,7 +62,7 @@ class QueryResults:
             # Otherwise, as is the case for `info` endpoints, `data` is a dictionary (or null)
             # and should be added as the only `data` field for these results.
             if isinstance(page_results["data"], list):
-                self.data.extend(page_results["data"])
+                self.data.extend(page_results["data"])  # type: ignore[union-attr]
             elif not self.data:
                 self.data = page_results["data"]
             else:

--- a/optimade/client/utils.py
+++ b/optimade/client/utils.py
@@ -1,17 +1,17 @@
-from dataclasses import dataclass, field, asdict
-from contextlib import contextmanager
-from typing import List, Dict, Set, Union
 import sys
+from contextlib import contextmanager
+from dataclasses import asdict, dataclass, field
+from typing import Dict, List, Set, Union
 
+from rich.console import Console
 from rich.progress import (
+    BarColumn,
     Progress,
     SpinnerColumn,
-    TimeElapsedColumn,
     TaskProgressColumn,
-    BarColumn,
     TextColumn,
+    TimeElapsedColumn,
 )
-from rich.console import Console
 
 __all__ = (
     "RecoverableHTTPError",

--- a/optimade/filterparser/lark_parser.py
+++ b/optimade/filterparser/lark_parser.py
@@ -4,9 +4,9 @@ into `Lark.Tree` objects for use by the filter transformers.
 
 """
 
+from collections import defaultdict
 from pathlib import Path
 from typing import Dict, Tuple
-from collections import defaultdict
 
 from lark import Lark, Tree
 

--- a/optimade/filterparser/lark_parser.py
+++ b/optimade/filterparser/lark_parser.py
@@ -4,7 +4,6 @@ into `Lark.Tree` objects for use by the filter transformers.
 
 """
 
-from collections import defaultdict
 from pathlib import Path
 from typing import Dict, Optional, Tuple
 
@@ -21,7 +20,7 @@ class ParserError(Exception):
     """
 
 
-def get_versions() -> Dict[Tuple[int, int, int], Dict[str, str]]:
+def get_versions() -> Dict[Tuple[int, int, int], Dict[str, Path]]:
     """Find grammar files within this package's grammar directory,
     returning a dictionary broken down by scraped grammar version
     (major, minor, patch) and variant (a string tag).
@@ -30,13 +29,15 @@ def get_versions() -> Dict[Tuple[int, int, int], Dict[str, str]]:
         A mapping from version, variant to grammar file name.
 
     """
-    dct: Dict[Tuple[int, int, int], Dict[str, Path]] = defaultdict(dict)
+    dct: Dict[Tuple[int, int, int], Dict[str, Path]] = {}
     for filename in Path(__file__).parent.joinpath("../grammar").glob("*.lark"):
         tags = filename.stem.lstrip("v").split(".")
-        version = tuple(map(int, tags[:3]))  # ignore: type[index]
-        variant = "default" if len(tags) == 3 else tags[-1]
-        dct[version][variant] = filename  # type: ignore[index]
-    return dict(dct)  # type: ignore[arg-type]
+        version: Tuple[int, int, int] = (int(tags[0]), int(tags[1]), int(tags[2]))
+        variant: str = "default" if len(tags) == 3 else str(tags[-1])
+        if version not in dct:
+            dct[version] = {}
+        dct[version][variant] = filename
+    return dct
 
 
 AVAILABLE_PARSERS = get_versions()
@@ -98,7 +99,7 @@ class LarkParser:
         """
         try:
             self.tree = self.lark.parse(filter_)
-            self.filter = filter_  # type: ignore[assignment]
+            self.filter = filter_
             return self.tree
         except Exception as exc:
             raise BadRequest(

--- a/optimade/filtertransformers/base_transformer.py
+++ b/optimade/filtertransformers/base_transformer.py
@@ -46,8 +46,8 @@ class Quantity:
     def __init__(
         self,
         name: str,
-        backend_field: str = None,
-        length_quantity: "Quantity" = None,
+        backend_field: Optional[str] = None,
+        length_quantity: Optional["Quantity"] = None,
     ):
         """Initialise the `quantity` from it's name and aliases.
 
@@ -79,8 +79,8 @@ class BaseTransformer(Transformer, abc.ABC):
 
     """
 
-    mapper: Optional[BaseResourceMapper] = None
-    operator_map: Dict[str, str] = {
+    mapper: Optional[Type[BaseResourceMapper]] = None
+    operator_map: Dict[str, Optional[str]] = {
         "<": None,
         "<=": None,
         ">": None,
@@ -104,7 +104,7 @@ class BaseTransformer(Transformer, abc.ABC):
     _quantities = None
 
     def __init__(
-        self, mapper: BaseResourceMapper = None
+        self, mapper: Optional[Type[BaseResourceMapper]] = None
     ):  # pylint: disable=super-init-not-called
         """Initialise the transformer object, optionally loading in a
         resource mapper for use when post-processing.
@@ -118,7 +118,7 @@ class BaseTransformer(Transformer, abc.ABC):
         [`Quantity`][optimade.filtertransformers.base_transformer.Quantity] object.
         """
         return {
-            quantity.backend_field: quantity for _, quantity in self.quantities.items()
+            quantity.backend_field: quantity for _, quantity in self.quantities.items()  # type: ignore[misc]
         }
 
     @property

--- a/optimade/filtertransformers/base_transformer.py
+++ b/optimade/filtertransformers/base_transformer.py
@@ -6,15 +6,14 @@ for turning filters parsed by lark into backend-specific queries.
 """
 
 import abc
-from typing import Dict, Any, Type, Optional
 import warnings
+from typing import Any, Dict, Optional, Type
 
-from lark import Transformer, v_args, Tree
+from lark import Transformer, Tree, v_args
 
-from optimade.server.mappers import BaseResourceMapper
 from optimade.server.exceptions import BadRequest
+from optimade.server.mappers import BaseResourceMapper
 from optimade.server.warnings import UnknownProviderProperty
-
 
 __all__ = (
     "BaseTransformer",

--- a/optimade/filtertransformers/elasticsearch.py
+++ b/optimade/filtertransformers/elasticsearch.py
@@ -44,11 +44,11 @@ class ElasticsearchQuantity(Quantity):
     def __init__(
         self,
         name: str,
-        backend_field: str = None,
-        length_quantity: "ElasticsearchQuantity" = None,
-        elastic_mapping_type: Field = None,
-        has_only_quantity: "ElasticsearchQuantity" = None,
-        nested_quantity: "ElasticsearchQuantity" = None,
+        backend_field: Optional[str] = None,
+        length_quantity: Optional["ElasticsearchQuantity"] = None,
+        elastic_mapping_type: Optional[Field] = None,
+        has_only_quantity: Optional["ElasticsearchQuantity"] = None,
+        nested_quantity: Optional["ElasticsearchQuantity"] = None,
     ):
         """Initialise the quantity from its name, aliases and mapping type.
 
@@ -100,14 +100,18 @@ class ElasticTransformer(BaseTransformer):
     _quantity_type: Type[ElasticsearchQuantity] = ElasticsearchQuantity
 
     def __init__(
-        self, mapper: BaseResourceMapper = None, quantities: Dict[str, Quantity] = None
+        self,
+        mapper: Type[BaseResourceMapper],
+        quantities: Optional[Dict[str, Quantity]] = None,
     ):
         if quantities is not None:
             self.quantities = quantities
 
         super().__init__(mapper=mapper)
 
-    def _field(self, quantity: Union[str, Quantity], nested: Quantity = None) -> str:
+    def _field(
+        self, quantity: Union[str, Quantity], nested: Optional[Quantity] = None
+    ) -> str:
         """Used to unwrap from `property` to the string backend field name.
 
         If passed a `Quantity` (or a derived `ElasticsearchQuantity`), this method
@@ -127,7 +131,7 @@ class ElasticTransformer(BaseTransformer):
         """
 
         if isinstance(quantity, str):
-            if quantity in self.mapper.RELATIONSHIP_ENTRY_TYPES:
+            if quantity in self.mapper.RELATIONSHIP_ENTRY_TYPES:  # type: ignore[union-attr]
                 raise NotImplementedError(
                     f"Unable to filter on relationships with type {quantity!r}"
                 )
@@ -139,16 +143,16 @@ class ElasticTransformer(BaseTransformer):
                 return quantity
 
         if nested is not None:
-            return "%s.%s" % (nested.backend_field, quantity.name)
+            return "%s.%s" % (nested.backend_field, quantity.name)  # type: ignore[union-attr]
 
-        return quantity.backend_field
+        return quantity.backend_field  # type: ignore[union-attr, return-value]
 
     def _query_op(
         self,
         quantity: Union[ElasticsearchQuantity, str],
         op: str,
         value: Union[str, float, int],
-        nested: ElasticsearchQuantity = None,
+        nested: Optional[ElasticsearchQuantity] = None,
     ) -> Q:
         """Return a range, match, or term query for the given quantity, comparison
         operator, and value.

--- a/optimade/filtertransformers/elasticsearch.py
+++ b/optimade/filtertransformers/elasticsearch.py
@@ -1,6 +1,7 @@
-from typing import Dict, Union, Type, Optional
+from typing import Dict, Optional, Type, Union
+
+from elasticsearch_dsl import Field, Integer, Keyword, Q, Text
 from lark import v_args
-from elasticsearch_dsl import Q, Text, Keyword, Integer, Field
 
 from optimade.filtertransformers import BaseTransformer, Quantity
 from optimade.server.mappers import BaseResourceMapper

--- a/optimade/filtertransformers/mongo.py
+++ b/optimade/filtertransformers/mongo.py
@@ -313,7 +313,7 @@ class MongoTransformer(BaseTransformer):
         if operator in self.inverse_operator_map:
             filter_ = {prop: {self.inverse_operator_map[operator]: value}}
             if operator in ("$in", "$eq"):
-                filter_ = {"$and": [filter_, {prop: {"$ne": None}}]}
+                filter_ = {"$and": [filter_, {prop: {"$ne": None}}]}  # type: ignore[dict-item]
             return filter_
 
         filter_ = {prop: {"$not": expr}}

--- a/optimade/filtertransformers/mongo.py
+++ b/optimade/filtertransformers/mongo.py
@@ -5,10 +5,12 @@ which takes the parsed filter and converts it to a valid pymongo/BSON query.
 
 
 import copy
-import warnings
 import itertools
-from typing import Dict, List, Any, Union
-from lark import v_args, Token
+import warnings
+from typing import Any, Dict, List, Union
+
+from lark import Token, v_args
+
 from optimade.filtertransformers.base_transformer import BaseTransformer, Quantity
 from optimade.server.exceptions import BadRequest
 from optimade.server.warnings import TimestampNotRFCCompliant

--- a/optimade/models/__init__.py
+++ b/optimade/models/__init__.py
@@ -11,14 +11,14 @@ from .structures import *  # noqa: F403
 from .utils import *  # noqa: F403
 
 __all__ = (
-    jsonapi.__all__  # noqa: F405
-    + utils.__all__  # noqa: F405
-    + baseinfo.__all__  # noqa: F405
-    + entries.__all__  # noqa: F405
-    + index_metadb.__all__  # noqa: F405
-    + links.__all__  # noqa: F405
-    + optimade_json.__all__  # noqa: F405
-    + references.__all__  # noqa: F405
-    + responses.__all__  # noqa: F405
-    + structures.__all__  # noqa: F405
+    jsonapi.__all__  # type: ignore[name-defined] # noqa: F405
+    + utils.__all__  # type: ignore[name-defined] # noqa: F405
+    + baseinfo.__all__  # type: ignore[name-defined] # noqa: F405
+    + entries.__all__  # type: ignore[name-defined] # noqa: F405
+    + index_metadb.__all__  # type: ignore[name-defined] # noqa: F405
+    + links.__all__  # type: ignore[name-defined] # noqa: F405
+    + optimade_json.__all__  # type: ignore[name-defined] # noqa: F405
+    + references.__all__  # type: ignore[name-defined] # noqa: F405
+    + responses.__all__  # type: ignore[name-defined] # noqa: F405
+    + structures.__all__  # type: ignore[name-defined] # noqa: F405
 )

--- a/optimade/models/__init__.py
+++ b/optimade/models/__init__.py
@@ -1,14 +1,14 @@
 # pylint: disable=undefined-variable
-from .jsonapi import *  # noqa: F403
-from .utils import *  # noqa: F403
 from .baseinfo import *  # noqa: F403
 from .entries import *  # noqa: F403
 from .index_metadb import *  # noqa: F403
+from .jsonapi import *  # noqa: F403
 from .links import *  # noqa: F403
 from .optimade_json import *  # noqa: F403
 from .references import *  # noqa: F403
 from .responses import *  # noqa: F403
 from .structures import *  # noqa: F403
+from .utils import *  # noqa: F403
 
 __all__ = (
     jsonapi.__all__  # noqa: F405

--- a/optimade/models/baseinfo.py
+++ b/optimade/models/baseinfo.py
@@ -1,12 +1,11 @@
 # pylint: disable=no-self-argument,no-name-in-module
 import re
-
 from typing import Dict, List, Optional
-from pydantic import BaseModel, AnyHttpUrl, Field, validator, root_validator
+
+from pydantic import AnyHttpUrl, BaseModel, Field, root_validator, validator
 
 from optimade.models.jsonapi import Resource
 from optimade.models.utils import SemanticVersion, StrictField
-
 
 __all__ = ("AvailableApiVersion", "BaseInfoAttributes", "BaseInfoResource")
 

--- a/optimade/models/entries.py
+++ b/optimade/models/entries.py
@@ -1,12 +1,12 @@
 # pylint: disable=line-too-long,no-self-argument
 from datetime import datetime
-from typing import Optional, Dict, List
+from typing import Dict, List, Optional
+
 from pydantic import BaseModel, validator  # pylint: disable=no-name-in-module
 
-from optimade.models.jsonapi import Relationships, Attributes, Resource
-from optimade.models.optimade_json import Relationship, DataType
-from optimade.models.utils import StrictField, OptimadeField, SupportLevel
-
+from optimade.models.jsonapi import Attributes, Relationships, Resource
+from optimade.models.optimade_json import DataType, Relationship
+from optimade.models.utils import OptimadeField, StrictField, SupportLevel
 
 __all__ = (
     "EntryRelationships",

--- a/optimade/models/index_metadb.py
+++ b/optimade/models/index_metadb.py
@@ -53,7 +53,7 @@ class IndexInfoResource(BaseInfoResource):
     attributes: IndexInfoAttributes = Field(...)
     relationships: Union[
         None, Dict[DefaultRelationship, IndexRelationship]
-    ] = StrictField(
+    ] = StrictField(  # type: ignore[assignment]
         ...,
         title="Relationships",
         description="""Reference to the Links identifier object under the `links` endpoint that the provider has chosen as their 'default' OPTIMADE API database.

--- a/optimade/models/index_metadb.py
+++ b/optimade/models/index_metadb.py
@@ -1,13 +1,12 @@
 # pylint: disable=no-self-argument
 from enum import Enum
+from typing import Dict, Union
 
-from pydantic import Field, BaseModel  # pylint: disable=no-name-in-module
-from typing import Union, Dict
+from pydantic import BaseModel, Field  # pylint: disable=no-name-in-module
 
-from optimade.models.jsonapi import BaseResource
 from optimade.models.baseinfo import BaseInfoAttributes, BaseInfoResource
+from optimade.models.jsonapi import BaseResource
 from optimade.models.utils import StrictField
-
 
 __all__ = (
     "IndexInfoAttributes",

--- a/optimade/models/jsonapi.py
+++ b/optimade/models/jsonapi.py
@@ -1,15 +1,16 @@
 """This module should reproduce JSON API v1.0 https://jsonapi.org/format/1.0/"""
 # pylint: disable=no-self-argument
-from typing import Optional, Union, List, Dict, Any, Type
 from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Type, Union
+
 from pydantic import (  # pylint: disable=no-name-in-module
-    BaseModel,
     AnyUrl,
+    BaseModel,
     parse_obj_as,
     root_validator,
 )
-from optimade.models.utils import StrictField
 
+from optimade.models.utils import StrictField
 
 __all__ = (
     "Meta",

--- a/optimade/models/links.py
+++ b/optimade/models/links.py
@@ -1,16 +1,12 @@
 # pylint: disable=no-self-argument
 from enum import Enum
+from typing import Optional, Union
 
-from pydantic import (  # pylint: disable=no-name-in-module
-    AnyUrl,
-    root_validator,
-)
-from typing import Union, Optional
+from pydantic import AnyUrl, root_validator  # pylint: disable=no-name-in-module
 
-from optimade.models.jsonapi import Link, Attributes
 from optimade.models.entries import EntryResource
+from optimade.models.jsonapi import Attributes, Link
 from optimade.models.utils import StrictField
-
 
 __all__ = (
     "LinksResourceAttributes",

--- a/optimade/models/optimade_json.py
+++ b/optimade/models/optimade_json.py
@@ -1,15 +1,13 @@
 """Modified JSON API v1.0 for OPTIMADE API"""
 # pylint: disable=no-self-argument,no-name-in-module
-from enum import Enum
-
-from typing import Optional, Union, List, Dict, Type, Any
 from datetime import datetime
+from enum import Enum
+from typing import Any, Dict, List, Optional, Type, Union
 
-from pydantic import root_validator, BaseModel, AnyHttpUrl, AnyUrl, EmailStr
+from pydantic import AnyHttpUrl, AnyUrl, BaseModel, EmailStr, root_validator
 
 from optimade.models import jsonapi
 from optimade.models.utils import SemanticVersion, StrictField
-
 
 __all__ = (
     "DataType",

--- a/optimade/models/references.py
+++ b/optimade/models/references.py
@@ -1,14 +1,10 @@
 # pylint: disable=line-too-long,no-self-argument
-from pydantic import (  # pylint: disable=no-name-in-module
-    BaseModel,
-    AnyUrl,
-    validator,
-)
 from typing import List, Optional
+
+from pydantic import AnyUrl, BaseModel, validator  # pylint: disable=no-name-in-module
 
 from optimade.models.entries import EntryResource, EntryResourceAttributes
 from optimade.models.utils import OptimadeField, SupportLevel
-
 
 __all__ = ("Person", "ReferenceResourceAttributes", "ReferenceResource")
 

--- a/optimade/models/responses.py
+++ b/optimade/models/responses.py
@@ -1,18 +1,17 @@
 # pylint: disable=no-self-argument
-from typing import Union, List, Optional, Dict, Any
+from typing import Any, Dict, List, Optional, Union
 
 from pydantic import Field, root_validator
 
-from optimade.models.jsonapi import Response
 from optimade.models.baseinfo import BaseInfoResource
 from optimade.models.entries import EntryInfoResource, EntryResource
 from optimade.models.index_metadb import IndexInfoResource
+from optimade.models.jsonapi import Response
 from optimade.models.links import LinksResource
-from optimade.models.optimade_json import Success, ResponseMeta, OptimadeError
+from optimade.models.optimade_json import OptimadeError, ResponseMeta, Success
 from optimade.models.references import ReferenceResource
 from optimade.models.structures import StructureResource
 from optimade.models.utils import StrictField
-
 
 __all__ = (
     "ErrorResponse",

--- a/optimade/models/responses.py
+++ b/optimade/models/responses.py
@@ -66,17 +66,17 @@ class InfoResponse(Success):
 
 
 class EntryResponseOne(Success):
-    data: Union[EntryResource, Dict[str, Any], None] = Field(...)
-    included: Optional[Union[List[EntryResource], List[Dict[str, Any]]]] = Field(
+    data: Union[EntryResource, Dict[str, Any], None] = Field(...)  # type: ignore[assignment]
+    included: Optional[Union[List[EntryResource], List[Dict[str, Any]]]] = Field(  # type: ignore[assignment]
         None, uniqueItems=True
     )
 
 
 class EntryResponseMany(Success):
-    data: Union[List[EntryResource], List[Dict[str, Any]]] = Field(
+    data: Union[List[EntryResource], List[Dict[str, Any]]] = Field(  # type: ignore[assignment]
         ..., uniqueItems=True
     )
-    included: Optional[Union[List[EntryResource], List[Dict[str, Any]]]] = Field(
+    included: Optional[Union[List[EntryResource], List[Dict[str, Any]]]] = Field(  # type: ignore[assignment]
         None, uniqueItems=True
     )
 

--- a/optimade/models/structures.py
+++ b/optimade/models/structures.py
@@ -39,8 +39,8 @@ __all__ = (
 EPS = 2**-23
 
 
-Vector3D = conlist(float, min_items=3, max_items=3)
-Vector3D_unknown = conlist(Union[float, None], min_items=3, max_items=3)
+Vector3D = conlist(float, min_items=3, max_items=3)  # type: ignore[valid-type]
+Vector3D_unknown = conlist(Union[float, None], min_items=3, max_items=3)  # type: ignore[valid-type]
 
 
 class Periodicity(IntEnum):
@@ -449,7 +449,7 @@ The proportion number MUST be omitted if it is 1.
         regex=CHEMICAL_FORMULA_REGEXP,
     )
 
-    dimension_types: Optional[
+    dimension_types: Optional[  # type: ignore[valid-type]
         conlist(Periodicity, min_items=3, max_items=3)
     ] = OptimadeField(
         None,
@@ -497,7 +497,7 @@ Note: the elements in this list each refer to the direction of the corresponding
         queryable=SupportLevel.MUST,
     )
 
-    lattice_vectors: Optional[
+    lattice_vectors: Optional[  # type: ignore[valid-type]
         conlist(Vector3D_unknown, min_items=3, max_items=3)
     ] = OptimadeField(
         None,
@@ -525,7 +525,7 @@ Note: the elements in this list each refer to the direction of the corresponding
         queryable=SupportLevel.OPTIONAL,
     )
 
-    cartesian_site_positions: Optional[List[Vector3D]] = OptimadeField(
+    cartesian_site_positions: Optional[List[Vector3D]] = OptimadeField(  # type: ignore[valid-type]
         ...,
         description="""Cartesian positions of each site in the structure.
 A site is usually used to describe positions of atoms; what atoms can be encountered at a given site is conveyed by the `species_at_sites` property, and the species themselves are described in the `species` property.

--- a/optimade/models/structures.py
+++ b/optimade/models/structures.py
@@ -39,8 +39,8 @@ __all__ = (
 EPS = 2**-23
 
 
-Vector3D = conlist(float, min_items=3, max_items=3)  # type: ignore[valid-type]
-Vector3D_unknown = conlist(Union[float, None], min_items=3, max_items=3)  # type: ignore[valid-type]
+Vector3D = conlist(float, min_items=3, max_items=3)
+Vector3D_unknown = conlist(Union[float, None], min_items=3, max_items=3)
 
 
 class Periodicity(IntEnum):

--- a/optimade/models/structures.py
+++ b/optimade/models/structures.py
@@ -1,23 +1,23 @@
 # pylint: disable=no-self-argument,line-too-long,no-name-in-module
-import re
-import warnings
-import sys
 import math
+import re
+import sys
+import warnings
+from enum import Enum, IntEnum
 from functools import reduce
-from enum import IntEnum, Enum
 from typing import List, Optional, Union
 
-from pydantic import BaseModel, validator, root_validator, conlist
+from pydantic import BaseModel, conlist, root_validator, validator
 
-from optimade.models.entries import EntryResourceAttributes, EntryResource
+from optimade.models.entries import EntryResource, EntryResourceAttributes
 from optimade.models.utils import (
+    ANONYMOUS_ELEMENTS,
+    CHEMICAL_FORMULA_REGEXP,
     CHEMICAL_SYMBOLS,
     EXTRA_SYMBOLS,
     OptimadeField,
     StrictField,
     SupportLevel,
-    ANONYMOUS_ELEMENTS,
-    CHEMICAL_FORMULA_REGEXP,
 )
 from optimade.server.warnings import MissingExpectedField
 

--- a/optimade/models/utils.py
+++ b/optimade/models/utils.py
@@ -1,9 +1,9 @@
 import inspect
-import warnings
-import re
 import itertools
+import re
+import warnings
 from enum import Enum
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from pydantic import Field
 from pydantic.fields import FieldInfo

--- a/optimade/models/utils.py
+++ b/optimade/models/utils.py
@@ -60,7 +60,7 @@ def StrictPydanticField(*args, **kwargs):
 
 def StrictField(
     *args: "Any",
-    description: str = None,
+    description: Optional[str] = None,
     **kwargs: "Any",
 ) -> StrictFieldInfo:
     """A wrapper around `pydantic.Field` that does the following:

--- a/optimade/server/config.py
+++ b/optimade/server/config.py
@@ -1,8 +1,8 @@
 # pylint: disable=no-self-argument
+import warnings
 from enum import Enum
 from pathlib import Path
-import warnings
-from typing import Any, Dict, List, Optional, Tuple, Union, Literal
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
 from pydantic import (  # pylint: disable=no-name-in-module
     AnyHttpUrl,
@@ -13,9 +13,8 @@ from pydantic import (  # pylint: disable=no-name-in-module
 )
 from pydantic.env_settings import SettingsSourceCallable
 
-from optimade import __version__, __api_version__
+from optimade import __api_version__, __version__
 from optimade.models import Implementation, Provider
-
 
 DEFAULT_CONFIG_FILE_PATH: str = str(Path.home().joinpath(".optimade.json"))
 """Default configuration file path.
@@ -87,6 +86,7 @@ def config_file_settings(settings: BaseSettings) -> Dict[str, Any]:
     """
     import json
     import os
+
     import yaml
 
     encoding = settings.__config__.env_file_encoding

--- a/optimade/server/data/__init__.py
+++ b/optimade/server/data/__init__.py
@@ -1,7 +1,7 @@
 """ Test Data to be used with the OPTIMADE server """
-import bson.json_util
 from pathlib import Path
 
+import bson.json_util
 
 data_paths = {
     "structures": "test_structures.json",

--- a/optimade/server/entry_collections/elasticsearch.py
+++ b/optimade/server/entry_collections/elasticsearch.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Type
 
 from optimade.filtertransformers.elasticsearch import ElasticTransformer
 from optimade.models import EntryResource
@@ -22,8 +22,8 @@ class ElasticCollection(EntryCollection):
     def __init__(
         self,
         name: str,
-        resource_cls: EntryResource,
-        resource_mapper: BaseResourceMapper,
+        resource_cls: Type[EntryResource],
+        resource_mapper: Type[BaseResourceMapper],
         client: Optional["Elasticsearch"] = None,
     ):
         """Initialize the ElasticCollection for the given parameters.
@@ -84,7 +84,7 @@ class ElasticCollection(EntryCollection):
 
     @staticmethod
     def create_elastic_index_from_mapper(
-        resource_mapper: BaseResourceMapper, fields: Iterable[str]
+        resource_mapper: Type[BaseResourceMapper], fields: Iterable[str]
     ) -> Dict[str, Any]:
         """Create a fallback elastic index based on a resource mapper.
 
@@ -147,7 +147,7 @@ class ElasticCollection(EntryCollection):
 
     def _run_db_query(
         self, criteria: Dict[str, Any], single_entry=False
-    ) -> Tuple[Union[List[Dict[str, Any]], Dict[str, Any]], int, bool]:
+    ) -> Tuple[List[Dict[str, Any]], int, bool]:
         """Run the query on the backend and collect the results.
 
         Arguments:

--- a/optimade/server/entry_collections/elasticsearch.py
+++ b/optimade/server/entry_collections/elasticsearch.py
@@ -1,14 +1,13 @@
 import json
 from pathlib import Path
-from typing import Tuple, List, Optional, Dict, Any, Iterable, Union
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
 from optimade.filtertransformers.elasticsearch import ElasticTransformer
-from optimade.server.config import CONFIG
-from optimade.server.logger import LOGGER
 from optimade.models import EntryResource
-from optimade.server.mappers import BaseResourceMapper
+from optimade.server.config import CONFIG
 from optimade.server.entry_collections import EntryCollection
-
+from optimade.server.logger import LOGGER
+from optimade.server.mappers import BaseResourceMapper
 
 if CONFIG.database_backend.value == "elastic":
     from elasticsearch import Elasticsearch

--- a/optimade/server/entry_collections/entry_collections.py
+++ b/optimade/server/entry_collections/entry_collections.py
@@ -91,7 +91,7 @@ class EntryCollection(ABC):
         self.provider_prefix = CONFIG.provider.prefix
         self.provider_fields = [
             field if isinstance(field, str) else field["name"]
-            for field in CONFIG.provider_fields.get(resource_mapper.ENDPOINT, [])  # type: ignore[call-overload]
+            for field in CONFIG.provider_fields.get(resource_mapper.ENDPOINT, [])
         ]
 
         self._all_fields: Set[str] = set()
@@ -376,7 +376,7 @@ class EntryCollection(ABC):
             BadRequest: if an invalid sort is requested.
 
         Returns:
-            A tuple of tuples containing the aliased field name and
+            A list of tuples containing the aliased field name and
             sort direction encoded as 1 (ascending) or -1 (descending).
 
         """

--- a/optimade/server/entry_collections/entry_collections.py
+++ b/optimade/server/entry_collections/entry_collections.py
@@ -1,7 +1,7 @@
-from abc import abstractmethod, ABC
-from typing import Tuple, List, Union, Dict, Any, Set
-import warnings
 import re
+import warnings
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Set, Tuple, Union
 
 from lark import Transformer
 
@@ -13,8 +13,8 @@ from optimade.server.mappers import BaseResourceMapper
 from optimade.server.query_params import EntryListingQueryParams, SingleEntryQueryParams
 from optimade.server.warnings import (
     FieldValueNotRecognized,
-    UnknownProviderProperty,
     QueryParamNotUsed,
+    UnknownProviderProperty,
 )
 
 

--- a/optimade/server/entry_collections/mongo.py
+++ b/optimade/server/entry_collections/mongo.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Dict, List, Tuple, Type, Union
 
 from optimade.filterparser import LarkParser
 from optimade.filtertransformers.mongo import MongoTransformer
@@ -38,8 +38,8 @@ class MongoCollection(EntryCollection):
     def __init__(
         self,
         name: str,
-        resource_cls: EntryResource,
-        resource_mapper: BaseResourceMapper,
+        resource_cls: Type[EntryResource],
+        resource_mapper: Type[BaseResourceMapper],
         database: str = CONFIG.mongo_database,
     ):
         """Initialize the MongoCollection for the given parameters.

--- a/optimade/server/entry_collections/mongo.py
+++ b/optimade/server/entry_collections/mongo.py
@@ -1,4 +1,4 @@
-from typing import Dict, Tuple, List, Any, Union
+from typing import Any, Dict, List, Tuple, Union
 
 from optimade.filterparser import LarkParser
 from optimade.filtertransformers.mongo import MongoTransformer
@@ -7,8 +7,7 @@ from optimade.server.config import CONFIG, SupportedBackend
 from optimade.server.entry_collections import EntryCollection
 from optimade.server.logger import LOGGER
 from optimade.server.mappers import BaseResourceMapper
-from optimade.server.query_params import SingleEntryQueryParams, EntryListingQueryParams
-
+from optimade.server.query_params import EntryListingQueryParams, SingleEntryQueryParams
 
 if CONFIG.database_backend.value == "mongodb":
     from pymongo import MongoClient, version_tuple

--- a/optimade/server/exception_handlers.py
+++ b/optimade/server/exception_handlers.py
@@ -1,19 +1,17 @@
 import traceback
-from typing import List, Tuple, Callable
+from typing import Callable, List, Tuple
 
-from lark.exceptions import VisitError
-
-from pydantic import ValidationError
+from fastapi import Request
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError, StarletteHTTPException
-from fastapi import Request
+from lark.exceptions import VisitError
+from pydantic import ValidationError
 
-from optimade.models import OptimadeError, ErrorResponse, ErrorSource
-
+from optimade.models import ErrorResponse, ErrorSource, OptimadeError
 from optimade.server.config import CONFIG
 from optimade.server.exceptions import BadRequest
 from optimade.server.logger import LOGGER
-from optimade.server.routers.utils import meta_values, JSONAPIResponse
+from optimade.server.routers.utils import JSONAPIResponse, meta_values
 
 
 def general_exception(

--- a/optimade/server/exceptions.py
+++ b/optimade/server/exceptions.py
@@ -1,4 +1,5 @@
 from abc import ABC
+from typing import Optional
 
 from fastapi import HTTPException as FastAPIHTTPException
 
@@ -27,10 +28,12 @@ class HTTPException(FastAPIHTTPException, ABC):
 
     """
 
-    status_code: int = None
+    status_code: int
     title: str
 
-    def __init__(self, detail: str = None, headers: dict = None) -> None:
+    def __init__(
+        self, detail: Optional[str] = None, headers: Optional[dict] = None
+    ) -> None:
         if self.status_code is None:
             raise AttributeError(
                 "HTTPException class {self.__class__.__name__} is missing required `status_code` attribute."

--- a/optimade/server/exceptions.py
+++ b/optimade/server/exceptions.py
@@ -1,4 +1,5 @@
 from abc import ABC
+
 from fastapi import HTTPException as FastAPIHTTPException
 
 __all__ = (

--- a/optimade/server/logger.py
+++ b/optimade/server/logger.py
@@ -1,5 +1,6 @@
 """Logging to both file and terminal"""
 import logging
+import logging.handlers
 import os
 import sys
 from pathlib import Path

--- a/optimade/server/logger.py
+++ b/optimade/server/logger.py
@@ -1,9 +1,8 @@
 """Logging to both file and terminal"""
 import logging
 import os
-from pathlib import Path
 import sys
-
+from pathlib import Path
 
 # Instantiate LOGGER
 LOGGER = logging.getLogger("optimade")

--- a/optimade/server/main.py
+++ b/optimade/server/main.py
@@ -18,10 +18,9 @@ with warnings.catch_warnings(record=True) as w:
 
 from optimade import __api_version__, __version__
 from optimade.server.entry_collections import EntryCollection
-from optimade.server.logger import LOGGER
 from optimade.server.exception_handlers import OPTIMADE_EXCEPTIONS
+from optimade.server.logger import LOGGER
 from optimade.server.middleware import OPTIMADE_MIDDLEWARE
-
 from optimade.server.routers import (
     info,
     landing,
@@ -64,6 +63,7 @@ This specification is generated using [`optimade-python-tools`](https://github.c
 if CONFIG.insert_test_data:
     import bson.json_util
     from bson.objectid import ObjectId
+
     import optimade.server.data as data
     from optimade.server.routers import ENTRY_COLLECTIONS
     from optimade.server.routers.utils import get_providers

--- a/optimade/server/main.py
+++ b/optimade/server/main.py
@@ -81,7 +81,7 @@ if CONFIG.insert_test_data:
             )
             providers = get_providers(add_mongo_id=True)
             for doc in providers:
-                endpoint_collection.collection.replace_one(
+                endpoint_collection.collection.replace_one(  # type: ignore[attr-defined]
                     filter={"_id": ObjectId(doc["_id"]["$oid"])},
                     replacement=bson.json_util.loads(bson.json_util.dumps(doc)),
                     upsert=True,

--- a/optimade/server/main_index.py
+++ b/optimade/server/main_index.py
@@ -18,8 +18,8 @@ with warnings.catch_warnings(record=True) as w:
     config_warnings = w
 
 from optimade import __api_version__, __version__
-from optimade.server.logger import LOGGER
 from optimade.server.exception_handlers import OPTIMADE_EXCEPTIONS
+from optimade.server.logger import LOGGER
 from optimade.server.middleware import OPTIMADE_MIDDLEWARE
 from optimade.server.routers import index_info, links, versions
 from optimade.server.routers.utils import BASE_URL_PREFIXES, JSONAPIResponse
@@ -59,8 +59,9 @@ This specification is generated using [`optimade-python-tools`](https://github.c
 if CONFIG.insert_test_data and CONFIG.index_links_path.exists():
     import bson.json_util
     from bson.objectid import ObjectId
+
     from optimade.server.routers.links import links_coll
-    from optimade.server.routers.utils import mongo_id_for_database, get_providers
+    from optimade.server.routers.utils import get_providers, mongo_id_for_database
 
     LOGGER.debug("Loading index links...")
     with open(CONFIG.index_links_path) as f:

--- a/optimade/server/main_index.py
+++ b/optimade/server/main_index.py
@@ -84,7 +84,7 @@ if CONFIG.insert_test_data and CONFIG.index_links_path.exists():
         )
         providers = get_providers(add_mongo_id=True)
         for doc in providers:
-            links_coll.collection.replace_one(
+            links_coll.collection.replace_one(  # type: ignore[attr-defined]
                 filter={"_id": ObjectId(doc["_id"]["$oid"])},
                 replacement=bson.json_util.loads(bson.json_util.dumps(doc)),
                 upsert=True,

--- a/optimade/server/mappers/__init__.py
+++ b/optimade/server/mappers/__init__.py
@@ -5,8 +5,8 @@ from .references import *  # noqa: F403
 from .structures import *  # noqa: F403
 
 __all__ = (
-    entries.__all__  # noqa: F405
-    + links.__all__  # noqa: F405
-    + references.__all__  # noqa: F405
-    + structures.__all__  # noqa: F405
+    entries.__all__  # type: ignore[name-defined]  # noqa: F405
+    + links.__all__  # type: ignore[name-defined]  # noqa: F405
+    + references.__all__  # type: ignore[name-defined]  # noqa: F405
+    + structures.__all__  # type: ignore[name-defined]  # noqa: F405
 )

--- a/optimade/server/mappers/entries.py
+++ b/optimade/server/mappers/entries.py
@@ -173,7 +173,7 @@ class BaseResourceMapper:
         from optimade.server.config import CONFIG
 
         return cls.LENGTH_ALIASES + tuple(
-            CONFIG.length_aliases.get(cls.ENDPOINT, {}).items()  # type: ignore[call-overload]
+            CONFIG.length_aliases.get(cls.ENDPOINT, {}).items()
         )
 
     @classmethod

--- a/optimade/server/mappers/entries.py
+++ b/optimade/server/mappers/entries.py
@@ -56,25 +56,19 @@ class BaseResourceMapper:
     """
 
     try:
-        from optimade.server.data import (
-            providers as PROVIDERS,  # pylint: disable=no-name-in-module
-        )
+        from optimade.server.data import providers as PROVIDERS  # type: ignore
     except (ImportError, ModuleNotFoundError):
         PROVIDERS = {}
 
     KNOWN_PROVIDER_PREFIXES: Set[str] = set(
         prov["id"] for prov in PROVIDERS.get("data", [])
     )
-    ALIASES: Tuple[Tuple[str, str]] = ()
-    LENGTH_ALIASES: Tuple[Tuple[str, str]] = ()
-    PROVIDER_FIELDS: Tuple[str] = ()
+    ALIASES: Tuple[Tuple[str, str], ...] = ()
+    LENGTH_ALIASES: Tuple[Tuple[str, str], ...] = ()
+    PROVIDER_FIELDS: Tuple[str, ...] = ()
     ENTRY_RESOURCE_CLASS: Type[EntryResource] = EntryResource
     RELATIONSHIP_ENTRY_TYPES: Set[str] = {"references", "structures"}
     TOP_LEVEL_NON_ATTRIBUTES_FIELDS: Set[str] = {"id", "type", "relationships", "links"}
-    SUPPORTED_PREFIXES: Set[str]
-    ALL_ATTRIBUTES: Set[str]
-    ENTRY_RESOURCE_ATTRIBUTES: Dict[str, Any]
-    ENDPOINT: str
 
     @classmethod
     @lru_cache(maxsize=1)
@@ -168,7 +162,7 @@ class BaseResourceMapper:
 
     @classmethod
     @lru_cache(maxsize=1)
-    def all_length_aliases(cls) -> Iterable[Tuple[str, str]]:
+    def all_length_aliases(cls) -> Tuple[Tuple[str, str], ...]:
         """Returns all of the associated length aliases for this class,
         including those defined by the server config.
 
@@ -179,7 +173,7 @@ class BaseResourceMapper:
         from optimade.server.config import CONFIG
 
         return cls.LENGTH_ALIASES + tuple(
-            CONFIG.length_aliases.get(cls.ENDPOINT, {}).items()
+            CONFIG.length_aliases.get(cls.ENDPOINT, {}).items()  # type: ignore[call-overload]
         )
 
     @classmethod

--- a/optimade/server/mappers/entries.py
+++ b/optimade/server/mappers/entries.py
@@ -1,6 +1,6 @@
-from typing import Tuple, Optional, Type, Set, Dict, Any, Union, List, Iterable
-from functools import lru_cache
 import warnings
+from functools import lru_cache
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Type, Union
 
 from optimade.models.entries import EntryResource
 
@@ -57,8 +57,8 @@ class BaseResourceMapper:
 
     try:
         from optimade.server.data import (
-            providers as PROVIDERS,
-        )  # pylint: disable=no-name-in-module
+            providers as PROVIDERS,  # pylint: disable=no-name-in-module
+        )
     except (ImportError, ModuleNotFoundError):
         PROVIDERS = {}
 

--- a/optimade/server/mappers/links.py
+++ b/optimade/server/mappers/links.py
@@ -1,5 +1,5 @@
-from optimade.server.mappers.entries import BaseResourceMapper
 from optimade.models.links import LinksResource
+from optimade.server.mappers.entries import BaseResourceMapper
 
 __all__ = ("LinksMapper",)
 

--- a/optimade/server/mappers/links.py
+++ b/optimade/server/mappers/links.py
@@ -6,8 +6,6 @@ __all__ = ("LinksMapper",)
 
 class LinksMapper(BaseResourceMapper):
 
-    ENDPOINT = "links"
-
     ENTRY_RESOURCE_CLASS = LinksResource
 
     @classmethod

--- a/optimade/server/mappers/references.py
+++ b/optimade/server/mappers/references.py
@@ -1,5 +1,5 @@
-from optimade.server.mappers.entries import BaseResourceMapper
 from optimade.models.references import ReferenceResource
+from optimade.server.mappers.entries import BaseResourceMapper
 
 __all__ = ("ReferenceMapper",)
 

--- a/optimade/server/mappers/structures.py
+++ b/optimade/server/mappers/structures.py
@@ -1,5 +1,5 @@
-from optimade.server.mappers.entries import BaseResourceMapper
 from optimade.models.structures import StructureResource
+from optimade.server.mappers.entries import BaseResourceMapper
 
 __all__ = ("StructureMapper",)
 

--- a/optimade/server/middleware.py
+++ b/optimade/server/middleware.py
@@ -176,14 +176,6 @@ class HandleApiHint(BaseHTTPMiddleware):
         major_api_hint = int(re.findall(r"/v([0-9]+)", api_hint_str)[0])
         major_implementation = int(BASE_URL_PREFIXES["major"][len("/v") :])
 
-        if major_api_hint > major_implementation:
-            # Let's not try to handle a request for a newer major version
-            raise VersionNotSupported(
-                detail=(
-                    f"The provided `api_hint` ({api_hint_str[1:]!r}) is not supported by this implementation. "
-                    f"Supported versions include: {', '.join(BASE_URL_PREFIXES.values())}"
-                )
-            )
         if major_api_hint <= major_implementation:
             # If less than:
             # Use the current implementation in hope that it can still handle older requests
@@ -192,7 +184,13 @@ class HandleApiHint(BaseHTTPMiddleware):
             # Go to /v<MAJOR>, since this should point to the latest available
             return BASE_URL_PREFIXES["major"]
 
-        return None
+        # Let's not try to handle a request for a newer major version
+        raise VersionNotSupported(
+            detail=(
+                f"The provided `api_hint` ({api_hint_str[1:]!r}) is not supported by this implementation. "
+                f"Supported versions include: {', '.join(BASE_URL_PREFIXES.values())}"
+            )
+        )
 
     @staticmethod
     def is_versioned_base_url(url: str) -> bool:

--- a/optimade/server/middleware.py
+++ b/optimade/server/middleware.py
@@ -5,15 +5,11 @@ These middleware are based on [Starlette](https://www.starlette.io)'s `BaseHTTPM
 See the specific Starlette [documentation page](https://www.starlette.io/middleware/) for more
 information on it's middleware implementation.
 """
+import json
 import re
-from typing import Optional, IO, Type, Generator, List, Union, Tuple
 import urllib.parse
 import warnings
-
-try:
-    import simplejson as json
-except ImportError:
-    import json
+from typing import IO, Generator, List, Optional, Tuple, Type, Union
 
 from starlette.datastructures import URL as StarletteURL
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -23,13 +19,13 @@ from starlette.responses import RedirectResponse, StreamingResponse
 from optimade.models import Warnings
 from optimade.server.config import CONFIG
 from optimade.server.exceptions import BadRequest, VersionNotSupported
+from optimade.server.routers.utils import BASE_URL_PREFIXES, get_base_url
 from optimade.server.warnings import (
     FieldValueNotRecognized,
     OptimadeWarning,
     QueryParamNotUsed,
     TooManyValues,
 )
-from optimade.server.routers.utils import get_base_url, BASE_URL_PREFIXES
 
 
 class EnsureQueryParamIntegrity(BaseHTTPMiddleware):

--- a/optimade/server/middleware.py
+++ b/optimade/server/middleware.py
@@ -9,7 +9,7 @@ import json
 import re
 import urllib.parse
 import warnings
-from typing import IO, Generator, List, Optional, Tuple, Type, Union
+from typing import Generator, Iterable, List, Optional, TextIO, Type, Union
 
 from starlette.datastructures import URL as StarletteURL
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -152,9 +152,8 @@ class HandleApiHint(BaseHTTPMiddleware):
         for value in api_hint:
             values = value.split(",")
             _api_hint.extend(values)
-        api_hint = _api_hint
 
-        if len(api_hint) > 1:
+        if len(_api_hint) > 1:
             warnings.warn(
                 TooManyValues(
                     detail="`api_hint` should only be supplied once, with a single value."
@@ -162,26 +161,26 @@ class HandleApiHint(BaseHTTPMiddleware):
             )
             return None
 
-        api_hint = f"/{api_hint[0]}"
-        if re.match(r"^/v[0-9]+(\.[0-9]+)?$", api_hint) is None:
+        api_hint_str: str = f"/{_api_hint[0]}"
+        if re.match(r"^/v[0-9]+(\.[0-9]+)?$", api_hint_str) is None:
             warnings.warn(
                 FieldValueNotRecognized(
-                    detail=f"{api_hint[1:]!r} is not recognized as a valid `api_hint` value."
+                    detail=f"{api_hint_str[1:]!r} is not recognized as a valid `api_hint` value."
                 )
             )
             return None
 
-        if api_hint in BASE_URL_PREFIXES.values():
-            return api_hint
+        if api_hint_str in BASE_URL_PREFIXES.values():
+            return api_hint_str
 
-        major_api_hint = int(re.findall(r"/v([0-9]+)", api_hint)[0])
+        major_api_hint = int(re.findall(r"/v([0-9]+)", api_hint_str)[0])
         major_implementation = int(BASE_URL_PREFIXES["major"][len("/v") :])
 
         if major_api_hint > major_implementation:
             # Let's not try to handle a request for a newer major version
             raise VersionNotSupported(
                 detail=(
-                    f"The provided `api_hint` ({api_hint[1:]!r}) is not supported by this implementation. "
+                    f"The provided `api_hint` ({api_hint_str[1:]!r}) is not supported by this implementation. "
                     f"Supported versions include: {', '.join(BASE_URL_PREFIXES.values())}"
                 )
             )
@@ -192,6 +191,8 @@ class HandleApiHint(BaseHTTPMiddleware):
             # If equal:
             # Go to /v<MAJOR>, since this should point to the latest available
             return BASE_URL_PREFIXES["major"]
+
+        return None
 
     @staticmethod
     def is_versioned_base_url(url: str) -> bool:
@@ -243,18 +244,18 @@ class HandleApiHint(BaseHTTPMiddleware):
                         f"{base_url}{version_path}{str(request.url)[len(base_url):]}"
                     )
                     url = urllib.parse.urlsplit(new_request)
-                    parsed_query = urllib.parse.parse_qsl(
-                        url.query, keep_blank_values=True
-                    )
-                    parsed_query = "&".join(
+                    q = "&".join(
                         [
                             f"{key}={value}"
-                            for key, value in parsed_query
+                            for key, value in urllib.parse.parse_qsl(
+                                url.query, keep_blank_values=True
+                            )
                             if key != "api_hint"
                         ]
                     )
+
                     return RedirectResponse(
-                        request.url.replace(path=url.path, query=parsed_query),
+                        request.url.replace(path=url.path, query=q),
                         headers=request.headers,
                     )
                     # This is the non-URL changing solution:
@@ -308,13 +309,15 @@ class AddWarnings(BaseHTTPMiddleware):
 
     """
 
+    _warnings: List[Warnings]
+
     def showwarning(
         self,
-        message: Warning,
+        message: Union[Warning, str],
         category: Type[Warning],
         filename: str,
         lineno: int,
-        file: Optional[IO] = None,
+        file: Optional[TextIO] = None,
         line: Optional[str] = None,
     ) -> None:
         """
@@ -357,7 +360,7 @@ class AddWarnings(BaseHTTPMiddleware):
         if not isinstance(message, OptimadeWarning):
             # If the Warning is not an OptimadeWarning or subclass thereof,
             # use the regular 'showwarning' function.
-            warnings._showwarning_orig(message, category, filename, lineno, file, line)
+            warnings._showwarning_orig(message, category, filename, lineno, file, line)  # type: ignore[attr-defined]
             return
 
         # Format warning
@@ -383,7 +386,7 @@ class AddWarnings(BaseHTTPMiddleware):
                     # When a warning is logged during Python shutdown, linecache
                     # and the import machinery don't work anymore
                     line = None
-                    linecache = None
+                    linecache = None  # type: ignore[assignment]
             meta = {
                 "filename": filename,
                 "lineno": lineno,
@@ -400,16 +403,16 @@ class AddWarnings(BaseHTTPMiddleware):
         self._warnings.append(new_warning.dict(exclude_unset=True))
 
         # Show warning message as normal in sys.stderr
-        warnings._showwarnmsg_impl(
+        warnings._showwarnmsg_impl(  # type: ignore[attr-defined]
             warnings.WarningMessage(message, category, filename, lineno, file, line)
         )
 
     @staticmethod
-    def chunk_it_up(content: str, chunk_size: int) -> Generator:
+    def chunk_it_up(content: Union[str, bytes], chunk_size: int) -> Generator:
         """Return generator for string in chunks of size `chunk_size`.
 
         Parameters:
-            content: String-content to separate into chunks.
+            content: String or bytes content to separate into chunks.
             chunk_size: The size of the chunks, i.e. the length of the string-chunks.
 
         Returns:
@@ -441,17 +444,17 @@ class AddWarnings(BaseHTTPMiddleware):
             if not isinstance(chunk, bytes):
                 chunk = chunk.encode(charset)
             body += chunk
-        body = body.decode(charset)
+        body_str = body.decode(charset)
 
         if self._warnings:
-            response = json.loads(body)
+            response = json.loads(body_str)
             response.get("meta", {})["warnings"] = self._warnings
-            body = json.dumps(response)
+            body_str = json.dumps(response)
             if "content-length" in headers:
-                headers["content-length"] = str(len(body))
+                headers["content-length"] = str(len(body_str))
 
         response = StreamingResponse(
-            content=self.chunk_it_up(body, chunk_size),
+            content=self.chunk_it_up(body_str, chunk_size),
             status_code=status,
             headers=headers,
             media_type=media_type,
@@ -461,7 +464,7 @@ class AddWarnings(BaseHTTPMiddleware):
         return response
 
 
-OPTIMADE_MIDDLEWARE: Tuple[BaseHTTPMiddleware] = (
+OPTIMADE_MIDDLEWARE: Iterable[BaseHTTPMiddleware] = (
     EnsureQueryParamIntegrity,
     CheckWronglyVersionedBaseUrls,
     HandleApiHint,

--- a/optimade/server/query_params.py
+++ b/optimade/server/query_params.py
@@ -1,12 +1,14 @@
+from abc import ABC
+from typing import Iterable, List
+from warnings import warn
+
 from fastapi import Query
 from pydantic import EmailStr  # pylint: disable=no-name-in-module
-from typing import Iterable, List
+
 from optimade.server.config import CONFIG
-from warnings import warn
-from optimade.server.mappers import BaseResourceMapper
 from optimade.server.exceptions import BadRequest
-from optimade.server.warnings import UnknownProviderQueryParameter, QueryParamNotUsed
-from abc import ABC
+from optimade.server.mappers import BaseResourceMapper
+from optimade.server.warnings import QueryParamNotUsed, UnknownProviderQueryParameter
 
 
 class BaseQueryParams(ABC):

--- a/optimade/server/routers/index_info.py
+++ b/optimade/server/routers/index_info.py
@@ -2,16 +2,15 @@ from fastapi import APIRouter, Request
 
 from optimade import __api_version__
 from optimade.models import (
-    IndexInfoResponse,
     IndexInfoAttributes,
     IndexInfoResource,
+    IndexInfoResponse,
     IndexRelationship,
     RelatedLinksResource,
 )
 from optimade.server.config import CONFIG
-from optimade.server.routers.utils import meta_values, get_base_url
+from optimade.server.routers.utils import get_base_url, meta_values
 from optimade.server.schemas import ERROR_RESPONSES
-
 
 router = APIRouter(redirect_slashes=True)
 

--- a/optimade/server/routers/info.py
+++ b/optimade/server/routers/info.py
@@ -2,15 +2,14 @@ from fastapi import APIRouter, Request
 from fastapi.exceptions import StarletteHTTPException
 
 from optimade import __api_version__
-from optimade.models import InfoResponse, EntryInfoResponse
-from optimade.server.routers.utils import meta_values, get_base_url
+from optimade.models import EntryInfoResponse, InfoResponse
 from optimade.server.config import CONFIG
+from optimade.server.routers.utils import get_base_url, meta_values
 from optimade.server.schemas import (
     ENTRY_INFO_SCHEMAS,
     ERROR_RESPONSES,
     retrieve_queryable_properties,
 )
-
 
 router = APIRouter(redirect_slashes=True)
 
@@ -23,7 +22,7 @@ router = APIRouter(redirect_slashes=True)
     responses=ERROR_RESPONSES,
 )
 def get_info(request: Request) -> InfoResponse:
-    from optimade.models import BaseInfoResource, BaseInfoAttributes
+    from optimade.models import BaseInfoAttributes, BaseInfoResource
 
     return InfoResponse(
         meta=meta_values(

--- a/optimade/server/routers/landing.py
+++ b/optimade/server/routers/landing.py
@@ -1,16 +1,16 @@
 """ OPTIMADE landing page router. """
 
-from pathlib import Path
 from functools import lru_cache
+from pathlib import Path
 
 from fastapi import Request
 from fastapi.responses import HTMLResponse
-from starlette.routing import Router, Route
-from optimade import __api_version__
+from starlette.routing import Route, Router
 
-from optimade.server.routers import ENTRY_COLLECTIONS
-from optimade.server.routers.utils import meta_values, get_base_url
+from optimade import __api_version__
 from optimade.server.config import CONFIG
+from optimade.server.routers import ENTRY_COLLECTIONS
+from optimade.server.routers.utils import get_base_url, meta_values
 
 
 @lru_cache()

--- a/optimade/server/routers/links.py
+++ b/optimade/server/routers/links.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, Request
 
-from optimade.models import LinksResponse, LinksResource
+from optimade.models import LinksResource, LinksResponse
 from optimade.server.config import CONFIG
 from optimade.server.entry_collections import create_collection
 from optimade.server.mappers import LinksMapper

--- a/optimade/server/routers/references.py
+++ b/optimade/server/routers/references.py
@@ -12,7 +12,6 @@ from optimade.server.query_params import EntryListingQueryParams, SingleEntryQue
 from optimade.server.routers.utils import get_entries, get_single_entry
 from optimade.server.schemas import ERROR_RESPONSES
 
-
 router = APIRouter(redirect_slashes=True)
 
 references_coll = create_collection(

--- a/optimade/server/routers/utils.py
+++ b/optimade/server/routers/utils.py
@@ -10,18 +10,17 @@ from starlette.datastructures import URL as StarletteURL
 
 from optimade import __api_version__
 from optimade.models import (
-    ResponseMeta,
     EntryResource,
     EntryResponseMany,
     EntryResponseOne,
+    ResponseMeta,
     ToplevelLinks,
 )
-
 from optimade.server.config import CONFIG
 from optimade.server.entry_collections import EntryCollection
 from optimade.server.exceptions import BadRequest, InternalServerError
 from optimade.server.query_params import EntryListingQueryParams, SingleEntryQueryParams
-from optimade.utils import mongo_id_for_database, get_providers, PROVIDER_LIST_URLS
+from optimade.utils import PROVIDER_LIST_URLS, get_providers, mongo_id_for_database
 
 __all__ = (
     "BASE_URL_PREFIXES",

--- a/optimade/server/routers/utils.py
+++ b/optimade/server/routers/utils.py
@@ -115,7 +115,7 @@ def handle_response_fields(
 
     new_results = []
     while results:
-        new_entry = results.pop(0).dict(exclude_unset=True, by_alias=True)  # type: ignore[union-attr]
+        new_entry = results.pop(0).dict(exclude_unset=True, by_alias=True)
 
         # Remove fields excluded by their omission in `response_fields`
         for field in exclude_fields:

--- a/optimade/server/routers/versions.py
+++ b/optimade/server/routers/versions.py
@@ -1,4 +1,4 @@
-from fastapi import Request, APIRouter
+from fastapi import APIRouter, Request
 from fastapi.responses import Response
 
 from optimade.server.routers.utils import BASE_URL_PREFIXES

--- a/optimade/server/schemas.py
+++ b/optimade/server/schemas.py
@@ -1,4 +1,4 @@
-from typing import Callable, Dict, Optional
+from typing import Callable, Dict, Iterable, Optional
 
 from optimade.models import (
     DataType,
@@ -9,7 +9,7 @@ from optimade.models import (
 
 __all__ = ("ENTRY_INFO_SCHEMAS", "ERROR_RESPONSES", "retrieve_queryable_properties")
 
-ENTRY_INFO_SCHEMAS: Dict[str, Callable[[None], Dict]] = {
+ENTRY_INFO_SCHEMAS: Dict[str, Callable[[], Dict]] = {
     "structures": StructureResource.schema,
     "references": ReferenceResource.schema,
 }
@@ -34,8 +34,8 @@ except ModuleNotFoundError:
 
 def retrieve_queryable_properties(
     schema: dict,
-    queryable_properties: list = None,
-    entry_type: str = None,
+    queryable_properties: Optional[Iterable[str]] = None,
+    entry_type: Optional[str] = None,
 ) -> dict:
     """Recursively loops through the schema of a pydantic model and
     resolves all references, returning a dictionary of all the
@@ -90,7 +90,7 @@ def retrieve_queryable_properties(
 
         described_provider_fields = [
             field
-            for field in CONFIG.provider_fields.get(entry_type, {})
+            for field in CONFIG.provider_fields.get(entry_type, {})  # type: ignore[call-overload]
             if isinstance(field, dict)
         ]
         for field in described_provider_fields:

--- a/optimade/server/warnings.py
+++ b/optimade/server/warnings.py
@@ -1,7 +1,12 @@
+from typing import Optional
+
+
 class OptimadeWarning(Warning):
     """Base Warning for the `optimade` package"""
 
-    def __init__(self, detail: str = None, title: str = None, *args) -> None:
+    def __init__(
+        self, detail: Optional[str] = None, title: Optional[str] = None, *args
+    ) -> None:
         detail = detail if detail else self.__doc__
         super().__init__(detail, *args)
         self.detail = detail

--- a/optimade/utils.py
+++ b/optimade/utils.py
@@ -4,9 +4,10 @@ with OPTIMADE providers that can be used in server or client code.
 """
 
 import json
-from typing import List, Iterable
+from typing import Iterable, List
 
 from pydantic import ValidationError
+
 from optimade.models.links import LinksResource
 
 PROVIDER_LIST_URLS = (
@@ -46,12 +47,9 @@ def get_providers(add_mongo_id: bool = False) -> list:
         List of raw JSON-decoded providers including MongoDB object IDs.
 
     """
-    import requests
+    import json
 
-    try:
-        import simplejson as json
-    except ImportError:
-        import json
+    import requests
 
     for provider_list_url in PROVIDER_LIST_URLS:
         try:
@@ -120,8 +118,9 @@ def get_child_database_links(
 
     """
     import requests
+
+    from optimade.models.links import Aggregate, LinkType
     from optimade.models.responses import LinksResponse
-    from optimade.models.links import LinkType, Aggregate
 
     base_url = provider.pop("base_url")
     if base_url is None:

--- a/optimade/validator/__init__.py
+++ b/optimade/validator/__init__.py
@@ -1,19 +1,21 @@
 """ This module contains the ImplementationValidator class and corresponding command line tools. """
 # pylint: disable=import-outside-toplevel
 import warnings
-from optimade import __version__, __api_version__
-from .validator import ImplementationValidator
+
+from optimade import __api_version__, __version__
+
 from .utils import DEFAULT_CONN_TIMEOUT, DEFAULT_READ_TIMEOUT
+from .validator import ImplementationValidator
 
 __all__ = ["ImplementationValidator", "validate"]
 
 
 def validate():  # pragma: no cover
     import argparse
-    import sys
-    import os
-    import traceback
     import json
+    import os
+    import sys
+    import traceback
 
     parser = argparse.ArgumentParser(
         prog="optimade-validator",

--- a/optimade/validator/config.py
+++ b/optimade/validator/config.py
@@ -7,27 +7,25 @@ the hardcoded values.
 
 """
 
-from typing import Dict, Any, Set, List, Container
+from typing import Any, Container, Dict, List, Set
+
 from pydantic import BaseSettings, Field
 
 from optimade.models import (
-    InfoResponse,
-    IndexInfoResponse,
     DataType,
+    IndexInfoResponse,
+    InfoResponse,
     StructureFeatures,
     SupportLevel,
 )
+from optimade.server.mappers import BaseResourceMapper
+from optimade.server.schemas import ENTRY_INFO_SCHEMAS, retrieve_queryable_properties
 from optimade.validator.utils import (
     ValidatorLinksResponse,
-    ValidatorReferenceResponseOne,
     ValidatorReferenceResponseMany,
-    ValidatorStructureResponseOne,
+    ValidatorReferenceResponseOne,
     ValidatorStructureResponseMany,
-)
-from optimade.server.mappers import BaseResourceMapper
-from optimade.server.schemas import (
-    ENTRY_INFO_SCHEMAS,
-    retrieve_queryable_properties,
+    ValidatorStructureResponseOne,
 )
 
 __all__ = ("ValidatorConfig", "VALIDATOR_CONFIG")

--- a/optimade/validator/utils.py
+++ b/optimade/validator/utils.py
@@ -232,13 +232,13 @@ class Client:  # pragma: no cover
         while retries < self.max_retries:
             retries += 1
             try:
-                self.response = requests.get(  # type: ignore[assignment]
-                    self.last_request,  # type: ignore[arg-type]
+                self.response = requests.get(
+                    self.last_request,
                     headers=self.headers,
                     timeout=(self.timeout, self.read_timeout),
                 )
 
-                status_code = self.response.status_code  # type: ignore[attr-defined]
+                status_code = self.response.status_code
                 # If we hit a 429 Too Many Requests status, then try again in 1 second
                 if status_code != 429:
                     return self.response
@@ -369,8 +369,7 @@ def test_case(test_fn: Callable[..., Tuple[Any, str]]):
                     if not isinstance(result, ValidationError):
                         message += traceback.split("\n")
 
-                message = "\n".join(message)  # type: ignore[assignment]
-
+                failure_type = None
                 if isinstance(result, InternalError):
                     summary = (
                         f"{request} - {test_fn.__name__} - failed with internal error"
@@ -378,10 +377,10 @@ def test_case(test_fn: Callable[..., Tuple[Any, str]]):
                     failure_type = "internal"
                 else:
                     summary = f"{request} - {test_fn.__name__} - failed with error"
-                    failure_type = "optional" if optional else None  # type: ignore[assignment]
+                    failure_type = "optional" if optional else None
 
                 validator.results.add_failure(
-                    summary, message, failure_type=failure_type
+                    summary, "\n".join(message), failure_type=failure_type
                 )
 
                 # set failure result to None as this is expected by other functions

--- a/optimade/validator/utils.py
+++ b/optimade/validator/utils.py
@@ -12,30 +12,26 @@ used by the validator. The two main features being:
 
 """
 
-import time
-import sys
-import urllib.parse
 import dataclasses
+import json
+import sys
+import time
 import traceback as tb
-from typing import List, Optional, Dict, Any, Callable, Tuple
-
-try:
-    import simplejson as json
-except ImportError:
-    import json
+import urllib.parse
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import requests
 from pydantic import Field, ValidationError
 
 from optimade import __version__
-from optimade.models.optimade_json import Success
 from optimade.models import (
-    ResponseMeta,
     EntryResource,
     LinksResource,
     ReferenceResource,
+    ResponseMeta,
     StructureResource,
 )
+from optimade.models.optimade_json import Success
 
 # Default connection timeout allows for one default-sized TCP retransmission window
 # (see https://docs.python-requests.org/en/latest/user/advanced/#timeouts)

--- a/optimade/validator/validator.py
+++ b/optimade/validator/validator.py
@@ -6,38 +6,33 @@ against the specification via the pydantic models implemented in this package.
 """
 # pylint: disable=import-outside-toplevel
 
-import re
-import sys
+import dataclasses
+import json
 import logging
 import random
+import re
+import sys
 import urllib.parse
-import dataclasses
-from typing import Union, Tuple, Any, List, Dict, Optional, Set
-
-try:
-    import simplejson as json
-except ImportError:
-    import json
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 import requests
 
 from optimade.models import DataType, EntryInfoResponse, SupportLevel
+from optimade.validator.config import VALIDATOR_CONFIG as CONF
 from optimade.validator.utils import (
     DEFAULT_CONN_TIMEOUT,
     DEFAULT_READ_TIMEOUT,
     Client,
-    test_case,
+    ResponseError,
+    ValidatorEntryResponseMany,
+    ValidatorEntryResponseOne,
+    ValidatorResults,
     print_failure,
     print_notify,
     print_success,
     print_warning,
-    ResponseError,
-    ValidatorEntryResponseOne,
-    ValidatorEntryResponseMany,
-    ValidatorResults,
+    test_case,
 )
-
-from optimade.validator.config import VALIDATOR_CONFIG as CONF
 
 VERSIONS_REGEXP = r".*/v[0-9]+(\.[0-9]+){,2}$"
 

--- a/optimade/validator/validator.py
+++ b/optimade/validator/validator.py
@@ -61,18 +61,18 @@ class ImplementationValidator:
 
     def __init__(  # pylint: disable=too-many-arguments
         self,
-        client: Any = None,
-        base_url: str = None,
+        client: Optional[Any] = None,
+        base_url: Optional[str] = None,
         verbosity: int = 0,
         respond_json: bool = False,
         page_limit: int = 4,
         max_retries: int = 5,
         run_optional_tests: bool = True,
         fail_fast: bool = False,
-        as_type: str = None,
+        as_type: Optional[str] = None,
         index: bool = False,
         minimal: bool = False,
-        http_headers: Dict[str, str] = None,
+        http_headers: Optional[Dict[str, str]] = None,
         timeout: float = DEFAULT_CONN_TIMEOUT,
         read_timeout: float = DEFAULT_READ_TIMEOUT,
     ):
@@ -148,11 +148,11 @@ class ImplementationValidator:
                         f"Not using specified request headers {http_headers} with custom client {self.client}."
                     )
         else:
-            while base_url.endswith("/"):
-                base_url = base_url[:-1]
+            while base_url.endswith("/"):  # type: ignore[union-attr]
+                base_url = base_url[:-1]  # type: ignore[index]
             self.base_url = base_url
             self.client = Client(
-                base_url,
+                self.base_url,  # type: ignore[arg-type]
                 max_retries=self.max_retries,
                 headers=http_headers,
                 timeout=timeout,
@@ -173,8 +173,8 @@ class ImplementationValidator:
 
         self.valid = None
 
-        self._test_id_by_type = {}
-        self._entry_info_by_type = {}
+        self._test_id_by_type: Dict[str, Any] = {}
+        self._entry_info_by_type: Dict[str, Any] = {}
 
         self.results = ValidatorResults(verbosity=self.verbosity)
 
@@ -350,7 +350,7 @@ class ImplementationValidator:
         self.print_summary()
 
     @test_case
-    def _recurse_through_endpoint(self, endp: str) -> Tuple[bool, str]:
+    def _recurse_through_endpoint(self, endp: str) -> Tuple[Optional[bool], str]:
         """For a given endpoint (`endp`), get the entry type
         and supported fields, testing that all mandatory fields
         are supported, then test queries on every property according
@@ -447,7 +447,9 @@ class ImplementationValidator:
             "Failed to handle field from unknown provider; should return without affecting filter results"
         )
 
-    def _check_entry_info(self, entry_info: Dict[str, Any], endp: str) -> List[str]:
+    def _check_entry_info(
+        self, entry_info: Dict[str, Any], endp: str
+    ) -> Dict[str, Dict[str, Any]]:
         """Checks that `entry_info` contains all the required properties,
         and returns the property list for the endpoint.
 
@@ -500,7 +502,7 @@ class ImplementationValidator:
     @test_case
     def _get_archetypal_entry(
         self, endp: str, properties: List[str]
-    ) -> Tuple[Dict[str, Any], str]:
+    ) -> Tuple[Optional[Dict[str, Any]], str]:
         """Get a random entry from the first page of results for this
         endpoint.
 
@@ -539,7 +541,9 @@ class ImplementationValidator:
         raise ResponseError(f"Failed to get archetypal entry. Details: {message}")
 
     @test_case
-    def _check_response_fields(self, endp: str, fields: List[str]) -> Tuple[bool, str]:
+    def _check_response_fields(
+        self, endp: str, fields: List[str]
+    ) -> Tuple[Optional[bool], str]:
         """Check that the response field query parameter is obeyed.
 
         Parameters:
@@ -1053,7 +1057,7 @@ class ImplementationValidator:
     @test_case
     def _test_data_available_matches_data_returned(
         self, deserialized: Any
-    ) -> Tuple[bool, str]:
+    ) -> Tuple[Optional[bool], str]:
         """In the case where no query is requested, `data_available`
         must equal `data_returned` in the meta response, which is tested
         here.
@@ -1153,13 +1157,13 @@ class ImplementationValidator:
                     f"Version numbers reported by `/{CONF.versions_endpoint}` must be integers specifying the major version, not {text_content}."
                 )
 
-        content_type = response.headers.get("content-type")
-        if not content_type:
+        _content_type = response.headers.get("content-type")
+        if not _content_type:
             raise ResponseError(
                 "Missing 'Content-Type' in response header from `/versions`."
             )
 
-        content_type = [_.replace(" ", "") for _ in content_type.split(";")]
+        content_type = [_.replace(" ", "") for _ in _content_type.split(";")]
 
         self._test_versions_headers(
             content_type,
@@ -1228,7 +1232,7 @@ class ImplementationValidator:
         error code.
 
         """
-        expected_status_code = 553
+        expected_status_code = [553]
         if re.match(VERSIONS_REGEXP, self.base_url_parsed.path) is not None:
             expected_status_code = [404, 400]
 
@@ -1284,12 +1288,12 @@ class ImplementationValidator:
         if previous_links is None:
             previous_links = set()
         try:
-            response = response.json()
+            response_json = response.json()
         except (AttributeError, json.JSONDecodeError):
             raise ResponseError("Unable to test endpoint `page_limit` parameter.")
 
         try:
-            num_entries = len(response["data"])
+            num_entries = len(response_json["data"])
         except (KeyError, TypeError):
             raise ResponseError(
                 "Response under `data` field was missing or had wrong type."
@@ -1301,13 +1305,13 @@ class ImplementationValidator:
             )
 
         try:
-            more_data_available = response["meta"]["more_data_available"]
+            more_data_available = response_json["meta"]["more_data_available"]
         except KeyError:
             raise ResponseError("Field `meta->more_data_available` was missing.")
 
         if more_data_available and check_next_link:
             try:
-                next_link = response["links"]["next"]
+                next_link = response_json["links"]["next"]
                 if isinstance(next_link, dict):
                     next_link = next_link["href"]
             except KeyError:
@@ -1372,7 +1376,10 @@ class ImplementationValidator:
 
     @test_case
     def _deserialize_response(
-        self, response: requests.models.Response, response_cls: Any, request: str = None
+        self,
+        response: requests.models.Response,
+        response_cls: Any,
+        request: Optional[str] = None,
     ) -> Tuple[Any, str]:
         """Try to create the appropriate pydantic model from the response.
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,14 @@
+black==22.10.0
 build==0.9.0
 codecov==2.1.12
+flake8==3.9.2
 invoke==1.7.3
+isort==5.10.1
 jsondiff==2.0.0
+mypy==0.991
 pre-commit==2.20.0
 pylint==2.15.5
 pytest==7.2.0
 pytest-cov==4.0.0
 pytest-httpx==0.21.2
+types-all==1.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,3 +22,7 @@ addopts = -rs
 
 [mypy]
 plugins = pydantic.mypy
+
+[isort]
+profile = black
+known_first_party = optimade

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,8 @@ addopts = -rs
 
 [mypy]
 plugins = pydantic.mypy
+ignore_missing_imports = true
+follow_imports = skip
 
 [isort]
 profile = black

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,3 +19,6 @@ filterwarnings =
     ignore:.*has an unrecognised prefix.*:
 testpaths = tests
 addopts = -rs
+
+[mypy]
+plugins = pydantic.mypy

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,16 @@ testing_deps = [
     "pytest-httpx~=0.21",
 ] + server_deps
 dev_deps = (
-    ["pylint~=2.15", "pre-commit~=2.20", "invoke~=1.7"]
+    [
+        "black~=22.10",
+        "flake8~=3.9",
+        "isort~=5.10",
+        "mypy~=0.981",
+        "pylint~=2.15",
+        "pre-commit~=2.20",
+        "invoke~=1.7",
+        "types-all==1.0.0",
+    ]
     + docs_deps
     + testing_deps
     + client_deps

--- a/tasks.py
+++ b/tasks.py
@@ -3,21 +3,19 @@ import os
 import re
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional, Tuple
 
 from invoke import task
 from jsondiff import diff
 
 if TYPE_CHECKING:
-    from typing import Tuple
-
     from invoke import Context, Result
 
 
 TOP_DIR = Path(__file__).parent.resolve()
 
 
-def update_file(filename: str, sub_line: "Tuple[str, str]", strip: str = None):
+def update_file(filename: str, sub_line: Tuple[str, str], strip: Optional[str] = None):
     """Utility function for tasks to read, update, and write files"""
     with open(filename, "r") as handle:
         lines = [

--- a/tests/adapters/structures/test_jarvis.py
+++ b/tests/adapters/structures/test_jarvis.py
@@ -12,6 +12,7 @@ jarvis = pytest.importorskip(
 )
 
 from jarvis.core.atoms import Atoms
+
 from optimade.adapters import Structure
 from optimade.adapters.exceptions import ConversionError
 from optimade.adapters.structures.jarvis import get_jarvis_atoms

--- a/tests/adapters/structures/test_pymatgen.py
+++ b/tests/adapters/structures/test_pymatgen.py
@@ -11,14 +11,15 @@ pymatgen = pytest.importorskip(
     " be able to run",
 )
 
-from pymatgen.core import Molecule, Structure as PymatgenStructure
+from pymatgen.core import Molecule
+from pymatgen.core import Structure as PymatgenStructure
 
 from optimade.adapters import Structure
 from optimade.adapters.structures.pymatgen import (
-    get_pymatgen,
-    _get_structure,
     _get_molecule,
+    _get_structure,
     from_pymatgen,
+    get_pymatgen,
 )
 
 

--- a/tests/adapters/structures/test_structures.py
+++ b/tests/adapters/structures/test_structures.py
@@ -1,5 +1,6 @@
 """Test Structure adapter"""
 import pytest
+
 from optimade.adapters import Structure
 from optimade.models import StructureResource
 

--- a/tests/adapters/structures/test_utils.py
+++ b/tests/adapters/structures/test_utils.py
@@ -19,7 +19,6 @@ from optimade.adapters.structures.utils import (
     species_from_species_at_sites,
 )
 
-
 # TODO: Add tests for cell_to_cellpar, unit_vector, cellpar_to_cell
 
 

--- a/tests/adapters/structures/utils.py
+++ b/tests/adapters/structures/utils.py
@@ -1,5 +1,5 @@
-from pathlib import Path
 import re
+from pathlib import Path
 
 
 def get_min_ver(dependency: str) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ def mapper():
     """Mapper-factory to import a mapper from optimade.server.mappers"""
     from optimade.server import mappers
 
-    def _mapper(name: str) -> mappers.BaseResourceMapper:
+    def _mapper(name: str) -> mappers.BaseResourceMapper:  # type: ignore[return]
         """Return named resource mapper"""
         try:
             res = getattr(mappers, name)

--- a/tests/filterparser/test_filterparser.py
+++ b/tests/filterparser/test_filterparser.py
@@ -2,7 +2,6 @@ import abc
 from typing import Tuple
 
 import pytest
-
 from lark import Tree
 
 from optimade.filterparser import LarkParser

--- a/tests/filtertransformers/test_mongo.py
+++ b/tests/filtertransformers/test_mongo.py
@@ -1,5 +1,4 @@
 import pytest
-
 from lark.exceptions import VisitError
 
 from optimade.filterparser import LarkParser
@@ -523,7 +522,9 @@ class TestMongoTransformer:
 
     def test_suspected_timestamp_fields(self, mapper):
         import datetime
+
         import bson.tz_util
+
         from optimade.filtertransformers.mongo import MongoTransformer
         from optimade.server.warnings import TimestampNotRFCCompliant
 
@@ -589,8 +590,9 @@ class TestMongoTransformer:
 
     def test_mongo_special_id(self, mapper):
 
-        from optimade.filtertransformers.mongo import MongoTransformer
         from bson import ObjectId
+
+        from optimade.filtertransformers.mongo import MongoTransformer
 
         class MyMapper(mapper("StructureMapper")):
             ALIASES = (("immutable_id", "_id"),)

--- a/tests/models/test_entries.py
+++ b/tests/models/test_entries.py
@@ -1,5 +1,4 @@
 import pytest
-
 from pydantic import ValidationError
 
 from optimade.models.entries import EntryRelationships

--- a/tests/models/test_jsonapi.py
+++ b/tests/models/test_jsonapi.py
@@ -1,5 +1,5 @@
-from pydantic import ValidationError
 import pytest
+from pydantic import ValidationError
 
 
 def test_hashability():

--- a/tests/models/test_links.py
+++ b/tests/models/test_links.py
@@ -3,7 +3,6 @@ import pytest
 
 from optimade.models.links import LinksResource
 
-
 MAPPER = "LinksMapper"
 
 

--- a/tests/models/test_references.py
+++ b/tests/models/test_references.py
@@ -3,7 +3,6 @@ import pytest
 
 from optimade.models.references import ReferenceResource
 
-
 MAPPER = "ReferenceMapper"
 
 

--- a/tests/models/test_structures.py
+++ b/tests/models/test_structures.py
@@ -2,9 +2,10 @@
 import itertools
 
 import pytest
+from pydantic import ValidationError
+
 from optimade.models.structures import CORRELATED_STRUCTURE_FIELDS, StructureResource
 from optimade.server.warnings import MissingExpectedField
-from pydantic import ValidationError
 
 MAPPER = "StructureMapper"
 

--- a/tests/models/test_utils.py
+++ b/tests/models/test_utils.py
@@ -1,7 +1,9 @@
+from typing import Callable, List
+
 import pytest
-from pydantic import BaseModel, ValidationError, Field
+from pydantic import BaseModel, Field, ValidationError
+
 from optimade.models.utils import OptimadeField, StrictField, SupportLevel
-from typing import List, Callable
 
 
 def make_bad_models(field: Callable):
@@ -82,6 +84,7 @@ def test_formula_regexp():
 
     """
     import re
+
     from optimade.models.utils import CHEMICAL_FORMULA_REGEXP
 
     class DummyModel(BaseModel):

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -1,4 +1,4 @@
-from typing import Dict, Union
+from typing import Dict, Optional, Union
 
 import pytest
 
@@ -134,9 +134,9 @@ def check_response(get_good_response):
         request: str,
         expected_ids: Union[str, List[str]],
         page_limit: int = CONFIG.page_limit,
-        expected_return: int = None,
+        expected_return: Optional[int] = None,
         expected_as_is: bool = False,
-        expected_warnings: List[Dict[str, str]] = None,
+        expected_warnings: Optional[List[Dict[str, str]]] = None,
         server: Union[str, OptimadeTestClient] = "regular",
     ):
         if expected_warnings:
@@ -181,9 +181,9 @@ def check_error_response(client, index_client):
 
     def inner(
         request: str,
-        expected_status: int = None,
-        expected_title: str = None,
-        expected_detail: str = None,
+        expected_status: Optional[int] = None,
+        expected_title: Optional[str] = None,
+        expected_detail: Optional[str] = None,
         server: Union[str, OptimadeTestClient] = "regular",
     ):
         response = None

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -1,8 +1,8 @@
-from typing import Union, Dict
-from optimade.server.warnings import OptimadeWarning
-
+from typing import Dict, Union
 
 import pytest
+
+from optimade.server.warnings import OptimadeWarning
 
 
 @pytest.fixture(scope="session")
@@ -54,10 +54,7 @@ def both_fake_remote_clients(request):
 @pytest.fixture
 def get_good_response(client, index_client):
     """Get response with some sanity checks, expecting '200 OK'"""
-    try:
-        import simplejson as json
-    except ImportError:
-        import json
+    import json
 
     from requests import Response
 
@@ -128,7 +125,9 @@ def check_response(get_good_response):
 
     """
     from typing import List
+
     from optimade.server.config import CONFIG
+
     from .utils import OptimadeTestClient
 
     def inner(

--- a/tests/server/middleware/test_api_hint.py
+++ b/tests/server/middleware/test_api_hint.py
@@ -1,6 +1,7 @@
 """Test HandleApiHint middleware and the `api_hint` query parameter"""
-import pytest
 from urllib.parse import unquote
+
+import pytest
 
 from optimade.server.exceptions import VersionNotSupported
 from optimade.server.middleware import HandleApiHint

--- a/tests/server/middleware/test_query_param.py
+++ b/tests/server/middleware/test_query_param.py
@@ -1,5 +1,6 @@
 """Test EntryListingQueryParams middleware"""
 import pytest
+
 from optimade.server.exceptions import BadRequest
 from optimade.server.middleware import EnsureQueryParamIntegrity
 from optimade.server.warnings import FieldValueNotRecognized

--- a/tests/server/query_params/conftest.py
+++ b/tests/server/query_params/conftest.py
@@ -12,13 +12,13 @@ def structures():
 @pytest.fixture
 def check_include_response(get_good_response):
     """Fixture to check "good" `include` response"""
-    from typing import List, Set, Union
+    from typing import List, Optional, Set, Union
 
     def inner(
         request: str,
         expected_included_types: Union[List, Set],
         expected_included_resources: Union[List, Set],
-        expected_relationship_types: Union[List, Set] = None,
+        expected_relationship_types: Optional[Union[List, Set]] = None,
         server: str = "regular",
     ):
         response = get_good_response(request, server)

--- a/tests/server/query_params/conftest.py
+++ b/tests/server/query_params/conftest.py
@@ -12,7 +12,7 @@ def structures():
 @pytest.fixture
 def check_include_response(get_good_response):
     """Fixture to check "good" `include` response"""
-    from typing import Union, List, Set
+    from typing import List, Set, Union
 
     def inner(
         request: str,

--- a/tests/server/query_params/test_filter.py
+++ b/tests/server/query_params/test_filter.py
@@ -1,5 +1,6 @@
 """Make sure filters are handled correctly"""
 import pytest
+
 from optimade.server.config import CONFIG, SupportedBackend
 
 

--- a/tests/server/routers/test_info.py
+++ b/tests/server/routers/test_info.py
@@ -1,6 +1,6 @@
-from optimade.models import InfoResponse, EntryInfoResponse, IndexInfoResponse, DataType
+from optimade.models import DataType, EntryInfoResponse, IndexInfoResponse, InfoResponse
 
-from ..utils import RegularEndpointTests, IndexEndpointTests
+from ..utils import IndexEndpointTests, RegularEndpointTests
 
 
 class TestInfoEndpoint(RegularEndpointTests):

--- a/tests/server/routers/test_structures.py
+++ b/tests/server/routers/test_structures.py
@@ -1,7 +1,7 @@
 from optimade.models import (
+    ReferenceResource,
     StructureResponseMany,
     StructureResponseOne,
-    ReferenceResource,
 )
 
 from ..utils import RegularEndpointTests

--- a/tests/server/routers/test_utils.py
+++ b/tests/server/routers/test_utils.py
@@ -2,9 +2,8 @@
 from typing import Mapping, Optional, Tuple, Union
 from unittest import mock
 
-from requests.exceptions import ConnectionError
-
 import pytest
+from requests.exceptions import ConnectionError
 
 
 def mocked_providers_list_response(
@@ -76,7 +75,8 @@ def test_get_providers():
 def test_get_providers_warning(caplog, top_dir):
     """Make sure a warning is logged as a last resort."""
     import copy
-    from optimade.server.routers.utils import get_providers, PROVIDER_LIST_URLS
+
+    from optimade.server.routers.utils import PROVIDER_LIST_URLS, get_providers
 
     providers_cache = False
     try:

--- a/tests/server/routers/test_utils.py
+++ b/tests/server/routers/test_utils.py
@@ -19,7 +19,7 @@ def mocked_providers_list_response(
         https://stackoverflow.com/questions/15753390/how-can-i-mock-requests-and-the-response
     """
     try:
-        from optimade.server.data import providers
+        from optimade.server.data import providers  # type: ignore[attr-defined]
     except ImportError:
         pytest.fail(
             "Cannot import providers from optimade.server.data, "

--- a/tests/server/routers/test_versions.py
+++ b/tests/server/routers/test_versions.py
@@ -1,4 +1,5 @@
 from optimade import __api_version__
+
 from ..utils import NoJsonEndpointTests
 
 

--- a/tests/server/test_client.py
+++ b/tests/server/test_client.py
@@ -2,8 +2,8 @@ import json
 from functools import partial
 from pathlib import Path
 
-
 import pytest
+
 from optimade.server.warnings import MissingExpectedField
 
 try:

--- a/tests/server/test_client.py
+++ b/tests/server/test_client.py
@@ -37,34 +37,42 @@ def test_client_endpoints(httpx_mocked_response, use_async):
     filter = ""
 
     cli = OptimadeClient(base_urls=[TEST_URL], use_async=use_async)
-    results = cli.get()
-    assert results["structures"][filter][TEST_URL]["data"]
-    assert results["structures"][filter][TEST_URL]["data"][0]["type"] == "structures"
+    get_results = cli.get()
+    assert get_results["structures"][filter][TEST_URL]["data"]
+    assert (
+        get_results["structures"][filter][TEST_URL]["data"][0]["type"] == "structures"
+    )
 
-    results = cli.structures.get()
-    assert results["structures"][filter][TEST_URL]["data"]
-    assert results["structures"][filter][TEST_URL]["data"][0]["type"] == "structures"
+    get_results = cli.structures.get()
+    assert get_results["structures"][filter][TEST_URL]["data"]
+    assert (
+        get_results["structures"][filter][TEST_URL]["data"][0]["type"] == "structures"
+    )
 
-    results = cli.references.get()
-    assert results["references"][filter][TEST_URL]["data"]
-    assert results["references"][filter][TEST_URL]["data"][0]["type"] == "references"
+    get_results = cli.references.get()
+    assert get_results["references"][filter][TEST_URL]["data"]
+    assert (
+        get_results["references"][filter][TEST_URL]["data"][0]["type"] == "references"
+    )
 
-    results = cli.get()
-    assert results["structures"][filter][TEST_URL]["data"]
-    assert results["structures"][filter][TEST_URL]["data"][0]["type"] == "structures"
+    get_results = cli.get()
+    assert get_results["structures"][filter][TEST_URL]["data"]
+    assert (
+        get_results["structures"][filter][TEST_URL]["data"][0]["type"] == "structures"
+    )
 
-    results = cli.references.count()
-    assert results["references"][filter][TEST_URL] > 0
+    count_results = cli.references.count()
+    assert count_results["references"][filter][TEST_URL] > 0
 
     filter = 'elements HAS "Ag"'
-    results = cli.count(filter)
-    assert results["structures"][filter][TEST_URL] > 0
+    count_results = cli.count(filter)
+    assert count_results["structures"][filter][TEST_URL] > 0
 
-    results = cli.info.get()
-    assert results["info"][""][TEST_URL]["data"]["type"] == "info"
+    count_results = cli.info.get()
+    assert count_results["info"][""][TEST_URL]["data"]["type"] == "info"
 
-    results = cli.info.structures.get()
-    assert "properties" in results["info/structures"][""][TEST_URL]["data"]
+    count_results = cli.info.structures.get()
+    assert "properties" in count_results["info/structures"][""][TEST_URL]["data"]
 
 
 @pytest.mark.parametrize("use_async", [False])

--- a/tests/server/test_config.py
+++ b/tests/server/test_config.py
@@ -1,7 +1,6 @@
 # pylint: disable=protected-access,pointless-statement,relative-beyond-top-level
 import json
 import os
-
 from pathlib import Path
 
 
@@ -141,7 +140,9 @@ def test_yaml_config_file():
     NOTE: Since pytest loads a JSON config file, there's no need to test that further.
     """
     import tempfile
+
     import pytest
+
     from optimade.server.config import ServerConfig
 
     yaml_content = """

--- a/tests/server/test_mappers.py
+++ b/tests/server/test_mappers.py
@@ -1,8 +1,7 @@
 import pytest
 
-from optimade.server.config import CONFIG
 from optimade.models import StructureResource
-
+from optimade.server.config import CONFIG
 
 MAPPER = "BaseResourceMapper"
 

--- a/tests/server/test_server_validation.py
+++ b/tests/server/test_server_validation.py
@@ -95,7 +95,6 @@ def test_versioned_base_urls(client, index_client, server: str):
 
     This depends on the routers for each kind of server.
     """
-    import json
 
     from optimade.server.routers.utils import BASE_URL_PREFIXES
 
@@ -129,7 +128,6 @@ def test_meta_schema_value_obeys_index(client, index_client, server: str):
     """Test that the reported `meta->schema` is correct for index/non-index
     servers.
     """
-    import json
 
     from optimade.server.config import CONFIG
     from optimade.server.routers.utils import BASE_URL_PREFIXES

--- a/tests/server/test_server_validation.py
+++ b/tests/server/test_server_validation.py
@@ -1,5 +1,5 @@
-import json
 import dataclasses
+import json
 
 import pytest
 
@@ -44,7 +44,7 @@ def test_with_validator_json_response(both_fake_remote_clients, capsys):
 
 
 def test_as_type_with_validator(client, capsys):
-    from unittest.mock import patch, Mock
+    from unittest.mock import Mock, patch
 
     test_urls = {
         f"{client.base_url}/structures": "structures",
@@ -95,10 +95,7 @@ def test_versioned_base_urls(client, index_client, server: str):
 
     This depends on the routers for each kind of server.
     """
-    try:
-        import simplejson as json
-    except ImportError:
-        import json
+    import json
 
     from optimade.server.routers.utils import BASE_URL_PREFIXES
 
@@ -132,13 +129,10 @@ def test_meta_schema_value_obeys_index(client, index_client, server: str):
     """Test that the reported `meta->schema` is correct for index/non-index
     servers.
     """
-    try:
-        import simplejson as json
-    except ImportError:
-        import json
+    import json
 
-    from optimade.server.routers.utils import BASE_URL_PREFIXES
     from optimade.server.config import CONFIG
+    from optimade.server.routers.utils import BASE_URL_PREFIXES
 
     clients = {
         "regular": client,

--- a/tests/server/utils.py
+++ b/tests/server/utils.py
@@ -49,7 +49,7 @@ class OptimadeTestClient(TestClient):
                 version = f"/v{__api_version__.split('.')[0]}"
         self.version = version
 
-    def request(  # type: ignore[override] # pylint: disable=too-many-locals
+    def request(  # pylint: disable=too-many-locals
         self,
         method: str,
         url: str,

--- a/tests/server/utils.py
+++ b/tests/server/utils.py
@@ -1,18 +1,13 @@
+import json
 import re
 import typing
-from urllib.parse import urlparse
 import warnings
-
-try:
-    import simplejson as json
-except ImportError:
-    import json
+from urllib.parse import urlparse
 
 import pytest
-from requests import Response
-
-from pydantic import BaseModel  # pylint: disable=no-name-in-module
 from fastapi.testclient import TestClient
+from pydantic import BaseModel  # pylint: disable=no-name-in-module
+from requests import Response
 from starlette import testclient
 
 from optimade import __api_version__
@@ -211,15 +206,15 @@ def client_factory():
         """
         if server == "regular":
             from optimade.server.main import (
-                app,
                 add_major_version_base_url,
                 add_optional_versioned_base_urls,
+                app,
             )
         elif server == "index":
             from optimade.server.main_index import (
-                app,
                 add_major_version_base_url,
                 add_optional_versioned_base_urls,
+                app,
             )
         else:
             pytest.fail(
@@ -231,8 +226,8 @@ def client_factory():
 
         if add_empty_endpoint:
 
-            from starlette.routing import Router, Route
             from fastapi.responses import PlainTextResponse
+            from starlette.routing import Route, Router
 
             async def empty(_):
                 return PlainTextResponse(b"", 200)

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,11 +1,6 @@
 """Distribution tests."""
-from typing import TYPE_CHECKING
 
 import pytest
-
-if TYPE_CHECKING:
-    from typing import List
-
 
 package_data = [
     ".lark",
@@ -38,7 +33,7 @@ def build_dist() -> str:
 
 
 @pytest.mark.parametrize("package_file", package_data)
-def test_distribution_package_data(package_file: "List[str]", build_dist: str) -> None:
+def test_distribution_package_data(package_file: str, build_dist: str) -> None:
     """Make sure a distribution has all the needed package data."""
     import re
 

--- a/tests/validator/test_utils.py
+++ b/tests/validator/test_utils.py
@@ -1,12 +1,10 @@
-import pytest
-from optimade.validator.utils import test_case as validator_test_case
-from optimade.validator.utils import ResponseError
-from optimade.validator.validator import ImplementationValidator
+import json
 
-try:
-    import simplejson as json
-except ImportError:
-    import json
+import pytest
+
+from optimade.validator.utils import ResponseError
+from optimade.validator.utils import test_case as validator_test_case
+from optimade.validator.validator import ImplementationValidator
 
 
 @validator_test_case
@@ -371,8 +369,9 @@ def test_that_system_exit_is_fatal_in_test_case():
 
 def test_versions_test_cases():
     """Check the `/versions` test cases."""
-    from requests import Response
     from functools import partial
+
+    from requests import Response
 
     unversioned_base_url = "https://example.org"
     versioned_base_url = unversioned_base_url + "/v1"


### PR DESCRIPTION
This PR fixes many broken/dodgy type hints in the code, and a few associated bugs/undefined behaviours.

- [x] Enable mypy in CI
- [x] Enable and apply isort
- [x] Remove simplejson (not really needed since we dropped 3.7 support)
- [x] Update pre-commit
- [x] Add linters and fixers to dev requirements