### PR TITLE
Docs fixes: revert mkdocstrings handler and fix JOSS badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ OPTIMADE Python tools
   <td align="center">
     <a href="https://pypi.org/project/optimade"><img alt="PyPI version" src="https://img.shields.io/pypi/v/optimade?logo=pypi&logoColor=white"></a><br>
     <a href="https://pypi.org/project/optimade"><img alt="PyPI - Python Version"  src="https://img.shields.io/pypi/pyversions/optimade?logo=python&logoColor=white"></a><br>
-    <a href="https://github.com/Materials-Consortia/OPTIMADE"><img alt="OPTIMADE version" src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Materials-Consortia/optimade-python-tools/master/optimade-version.json">
+    <a href="https://github.com/Materials-Consortia/OPTIMADE"><img alt="OPTIMADE version" src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Materials-Consortia/optimade-python-tools/master/optimade-version.json"></a>
   </td>
   <td align="center">
     <a href="https://github.com/Materials-Consortia/optimade-python-tools/actions?query=branch%3Amaster+"><img alt="Build Status" src="https://img.shields.io/github/workflow/status/Materials-Consortia/optimade-python-tools/CI%20tests?logo=github"></a><br>

--- a/README.md
+++ b/README.md
@@ -11,7 +11,10 @@ OPTIMADE Python tools
 
 <div align="center">
 
-[![JOSS DOI](https://joss.theoj.org/papers/10.21105/joss.03458/status.svg)](https://doi.org/10.21105/joss.03458)
+<a href="https://doi.org/10.21105/joss.03458"><img alt="JOSS DOI" src="https://joss.theoj.org/papers/10.21105/joss.03458/status.svg"></a>
+</div>
+
+<div align="center">
 
 <table>
 <thead align="center">

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -2,4 +2,4 @@ mike==1.1.2
 mkdocs==1.3.1
 mkdocs-awesome-pages-plugin==2.8.0
 mkdocs-material==8.5.3
-mkdocstrings[python]==0.19.0
+mkdocstrings[python-legacy]==0.19.0

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ docs_deps = [
     "mkdocs~=1.3",
     "mkdocs-awesome-pages-plugin~=2.8",
     "mkdocs-material~=8.3",
-    "mkdocstrings[python]~=0.19.0",
+    "mkdocstrings[python-legacy]~=0.19.0",
 ]
 testing_deps = [
     "build~=0.8.0",


### PR DESCRIPTION
As above. 

Lets revert to the old renderer for now, as most of the hard work was just updating the mkdocs config for the new version. Once griffe supports pydantic we can upgrade again.