### PR TITLE
Explicitly use Python 3.8 environment for pre-commit in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,10 +49,10 @@ jobs:
       with:
         submodules: true
 
-    - name: Set up Python 3.10
+    - name: Set up Python 3.8
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.8'
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
Closes #1417 