### PR TITLE
Cache `/info` and `/info/<entry>` responses

### DIFF
--- a/optimade/server/routers/info.py
+++ b/optimade/server/routers/info.py
@@ -1,8 +1,11 @@
+import functools
+
 from fastapi import APIRouter, Request
 from fastapi.exceptions import StarletteHTTPException
 
 from optimade import __api_version__
-from optimade.models import EntryInfoResponse, InfoResponse
+from optimade.models import EntryInfoResource, EntryInfoResponse, InfoResponse
+from optimade.models.baseinfo import BaseInfoAttributes, BaseInfoResource
 from optimade.server.config import CONFIG
 from optimade.server.routers.utils import get_base_url, meta_values
 from optimade.server.schemas import (
@@ -22,13 +25,11 @@ router = APIRouter(redirect_slashes=True)
     responses=ERROR_RESPONSES,
 )
 def get_info(request: Request) -> InfoResponse:
-    from optimade.models import BaseInfoAttributes, BaseInfoResource
+    @functools.lru_cache(maxsize=1)
+    def _generate_info_response() -> BaseInfoResource:
+        """Cached closure that generates the info response for the implementation."""
 
-    return InfoResponse(
-        meta=meta_values(
-            request.url, 1, 1, more_data_available=False, schema=CONFIG.schema_url
-        ),
-        data=BaseInfoResource(
+        return BaseInfoResource(
             id=BaseInfoResource.schema()["properties"]["id"]["default"],
             type=BaseInfoResource.schema()["properties"]["type"]["default"],
             attributes=BaseInfoAttributes(
@@ -44,7 +45,13 @@ def get_info(request: Request) -> InfoResponse:
                 entry_types_by_format={"json": list(ENTRY_INFO_SCHEMAS.keys())},
                 is_index=False,
             ),
+        )
+
+    return InfoResponse(
+        meta=meta_values(
+            request.url, 1, 1, more_data_available=False, schema=CONFIG.schema_url
         ),
+        data=_generate_info_response(),
     )
 
 
@@ -56,32 +63,41 @@ def get_info(request: Request) -> InfoResponse:
     responses=ERROR_RESPONSES,
 )
 def get_entry_info(request: Request, entry: str) -> EntryInfoResponse:
-    from optimade.models import EntryInfoResource
+    @functools.lru_cache(maxsize=len(ENTRY_INFO_SCHEMAS))
+    def _generate_entry_info_response(entry: str) -> EntryInfoResource:
+        """Cached closure that generates the entry info response for the given type.
 
-    valid_entry_info_endpoints = ENTRY_INFO_SCHEMAS.keys()
-    if entry not in valid_entry_info_endpoints:
-        raise StarletteHTTPException(
-            status_code=404,
-            detail=f"Entry info not found for {entry}, valid entry info endpoints are: {', '.join(valid_entry_info_endpoints)}",
+        Parameters:
+            entry: The OPTIMADE type to generate the info response for, e.g., `"structures"`.
+                Must be a key in `ENTRY_INFO_SCHEMAS`.
+
+        """
+        valid_entry_info_endpoints = ENTRY_INFO_SCHEMAS.keys()
+        if entry not in valid_entry_info_endpoints:
+            raise StarletteHTTPException(
+                status_code=404,
+                detail=f"Entry info not found for {entry}, valid entry info endpoints are: {', '.join(valid_entry_info_endpoints)}",
+            )
+
+        schema = ENTRY_INFO_SCHEMAS[entry]()
+        queryable_properties = {"id", "type", "attributes"}
+        properties = retrieve_queryable_properties(
+            schema, queryable_properties, entry_type=entry
         )
 
-    schema = ENTRY_INFO_SCHEMAS[entry]()
-    queryable_properties = {"id", "type", "attributes"}
-    properties = retrieve_queryable_properties(
-        schema, queryable_properties, entry_type=entry
-    )
+        output_fields_by_format = {"json": list(properties.keys())}
 
-    output_fields_by_format = {"json": list(properties.keys())}
-
-    return EntryInfoResponse(
-        meta=meta_values(
-            request.url, 1, 1, more_data_available=False, schema=CONFIG.schema_url
-        ),
-        data=EntryInfoResource(
+        return EntryInfoResource(
             formats=list(output_fields_by_format.keys()),
             description=schema.get("description", "Entry Resources"),
             properties=properties,
             output_fields_by_format=output_fields_by_format,
             schema=CONFIG.schema_url,
+        )
+
+    return EntryInfoResponse(
+        meta=meta_values(
+            request.url, 1, 1, more_data_available=False, schema=CONFIG.schema_url
         ),
+        data=_generate_entry_info_response(entry),
     )


### PR DESCRIPTION
This is a feature I want to use in the 1.2 changes, so it may as well be "backported" here ready for the final 1.1 release.