### PR TITLE
Fix for mapper caches

### DIFF
--- a/optimade/server/mappers/entries.py
+++ b/optimade/server/mappers/entries.py
@@ -4,6 +4,12 @@ from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Type, Union
 
 from optimade.models.entries import EntryResource
 
+# A number that approximately tracks the number of types with mappers
+# so that the global caches can be set to the correct size.
+# See https://github.com/Materials-Consortia/optimade-python-tools/issues/1434
+# for the details.
+NUM_ENTRY_TYPES = 4
+
 __all__ = ("BaseResourceMapper",)
 
 
@@ -27,8 +33,7 @@ class classproperty(property):
 
 
 class BaseResourceMapper:
-    """
-    Generic Resource Mapper that defines and performs the mapping
+    """Generic Resource Mapper that defines and performs the mapping
     between objects in the database and the resource objects defined by
     the specification.
 
@@ -70,8 +75,13 @@ class BaseResourceMapper:
     RELATIONSHIP_ENTRY_TYPES: Set[str] = {"references", "structures"}
     TOP_LEVEL_NON_ATTRIBUTES_FIELDS: Set[str] = {"id", "type", "relationships", "links"}
 
+    def __init__(self):
+        raise RuntimeError(
+            f"{self.__class__.__name__!r} should not be instantiated directly, instead use its functionality via the `@classmethods`"
+        )
+
     @classmethod
-    @lru_cache(maxsize=1)
+    @lru_cache(maxsize=NUM_ENTRY_TYPES)
     def all_aliases(cls) -> Iterable[Tuple[str, str]]:
         """Returns all of the associated aliases for this entry type,
         including those defined by the server config. The first member
@@ -147,7 +157,7 @@ class BaseResourceMapper:
         return retrieve_queryable_properties(cls.ENTRY_RESOURCE_CLASS.schema())
 
     @classproperty
-    @lru_cache(maxsize=1)
+    @lru_cache(maxsize=NUM_ENTRY_TYPES)
     def ENDPOINT(cls) -> str:
         """Returns the expected endpoint for this mapper, corresponding
         to the `type` property of the resource class.
@@ -161,7 +171,7 @@ class BaseResourceMapper:
         )
 
     @classmethod
-    @lru_cache(maxsize=1)
+    @lru_cache(maxsize=NUM_ENTRY_TYPES)
     def all_length_aliases(cls) -> Tuple[Tuple[str, str], ...]:
         """Returns all of the associated length aliases for this class,
         including those defined by the server config.
@@ -300,7 +310,7 @@ class BaseResourceMapper:
         return cls.get_optimade_field(field)
 
     @classmethod
-    @lru_cache(maxsize=1)
+    @lru_cache(maxsize=NUM_ENTRY_TYPES)
     def get_required_fields(cls) -> set:
         """Get REQUIRED response fields.
 

--- a/optimade/server/mappers/entries.py
+++ b/optimade/server/mappers/entries.py
@@ -75,11 +75,6 @@ class BaseResourceMapper:
     RELATIONSHIP_ENTRY_TYPES: Set[str] = {"references", "structures"}
     TOP_LEVEL_NON_ATTRIBUTES_FIELDS: Set[str] = {"id", "type", "relationships", "links"}
 
-    def __init__(self):
-        raise RuntimeError(
-            f"{self.__class__.__name__!r} should not be instantiated directly, instead use its functionality via the `@classmethods`"
-        )
-
     @classmethod
     @lru_cache(maxsize=NUM_ENTRY_TYPES)
     def all_aliases(cls) -> Iterable[Tuple[str, str]]:

--- a/tests/filtertransformers/test_elasticsearch.py
+++ b/tests/filtertransformers/test_elasticsearch.py
@@ -18,7 +18,7 @@ def parser():
 def transformer():
     from optimade.server.mappers import StructureMapper
 
-    return ElasticTransformer(mapper=StructureMapper())
+    return ElasticTransformer(mapper=StructureMapper)
 
 
 test_queries = [

--- a/tests/server/test_mappers.py
+++ b/tests/server/test_mappers.py
@@ -16,7 +16,7 @@ def test_disallowed_aliases(mapper):
     class MyMapper(mapper(MAPPER)):
         ALIASES = (("$and", "my_special_and"), ("not", "$not"))
 
-    mapper = MyMapper()
+    mapper = MyMapper
     with pytest.raises(RuntimeError):
         MongoCollection("fake", StructureResource, mapper, database="fake")
 
@@ -27,7 +27,7 @@ def test_property_aliases(mapper):
         LENGTH_ALIASES = (("_exmpl_test_field", "test_field_len"),)
         ALIASES = (("field", "completely_different_field"),)
 
-    mapper = MyMapper()
+    mapper = MyMapper
     assert mapper.get_backend_field("_exmpl_dft_parameters") == "dft_parameters"
     assert mapper.get_backend_field("_exmpl_test_field") == "test_field"
     assert mapper.get_backend_field("field") == "completely_different_field"
@@ -62,3 +62,33 @@ def test_property_aliases(mapper):
         mapper.get_backend_field("_exmpl_dft_parameters_dft_parameters.nested.property")
         == "_exmpl_dft_parameters_dft_parameters.nested.property"
     )
+
+
+def test_cached_mapper_properties(mapper):
+    """Tests that alias caching both occurs, and is not effected
+    by the presence of other mapper caches.
+    """
+
+    class MyMapper(mapper(MAPPER)):
+        ALIASES = (("field", "completely_different_field"),)
+
+    class MyOtherMapper(mapper(MAPPER)):
+        ALIASES = (
+            ("field", "completely_different_field2"),
+            ("a", "b"),
+        )
+
+    assert MyMapper.get_backend_field("field") == "completely_different_field"
+    hits = MyMapper.get_backend_field.cache_info().hits
+    assert MyMapper.get_backend_field("field") == "completely_different_field"
+    assert MyMapper.get_backend_field.cache_info().hits == hits + 1
+    assert MyOtherMapper.get_backend_field("field") == "completely_different_field2"
+    assert MyOtherMapper.get_backend_field.cache_info().hits == hits + 1
+    assert MyOtherMapper.get_backend_field("field") == "completely_different_field2"
+    assert MyOtherMapper.get_backend_field.cache_info().hits == hits + 2
+
+    assert MyOtherMapper.get_backend_field("a") == "b"
+    assert MyOtherMapper.get_backend_field.cache_info().hits == hits + 2
+    assert MyOtherMapper.get_backend_field("a") == "b"
+    assert MyOtherMapper.get_backend_field.cache_info().hits == hits + 3
+    assert MyMapper.get_backend_field("a") == "a"


### PR DESCRIPTION
Closes #1434  by increasing the cache sizes to allow multiple mapper classes to be cached simultaneously.

Cache size is now controlled by module level constant; could also generate it programmatically but not necessarily worth the effort.