### PR TITLE
Add pip caches to CI and tidy old flake8 job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,29 +17,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v3
-
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.10'
-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -U setuptools wheel
-        pip install flake8
-
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --statistics
 
   pre-commit:
     runs-on: ubuntu-latest
@@ -53,6 +30,10 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: '3.8'
+        cache: 'pip'
+        cache-dependency-path: |
+          requirements*.txt
+
 
     - name: Install dependencies
       run: |
@@ -79,6 +60,9 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: '3.10'
+        cache: 'pip'
+        cache-dependency-path: |
+          requirements*.txt
 
     - name: Install tools
       run: |
@@ -186,6 +170,9 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+        cache-dependency-path: |
+          requirements*.txt
 
     - name: Install latest compatible versions of immediate dependencies
       run: |
@@ -304,6 +291,9 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.10'
+        cache: 'pip'
+        cache-dependency-path: |
+          requirements*.txt
 
     - name: Install dependencies
       run: |
@@ -334,6 +324,9 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: '3.10'
+        cache: 'pip'
+        cache-dependency-path: |
+          requirements*.txt
 
     - name: Install Python dependencies
       run: |


### PR DESCRIPTION
This PR removes a now defunct flake8 job in the CI (called already be pre-commit) and adds pip caches to every stage of the CI which should give a bit of a speed boost.