### PR TITLE
Trim CHANGELOG whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 This release adds the ability to include or exclude particular providers from queries with the `OptimadeClient` class and `optimade-get` CLI, via the provider's registered prefix (#1412)
 
-For example: 
+For example:
 
 ```shell
 # Only query databases served by the example providers
@@ -31,7 +31,7 @@ The release also includes some server enhancements and fixes:
 
 This release adds the ability to include or exclude particular providers from queries with the `OptimadeClient` class and `optimade-get` CLI, via the provider's registered prefix (#1412)
 
-For example: 
+For example:
 
 ```shell
 # Only query databases served by the example providers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,30 +1,5 @@
 # Changelog
 
-## [Unreleased](https://github.com/Materials-Consortia/optimade-python-tools/tree/HEAD)
-
-[Full Changelog](https://github.com/Materials-Consortia/optimade-python-tools/compare/v0.20.2...HEAD)
-
-This release adds the ability to include or exclude particular providers from queries with the `OptimadeClient` class and `optimade-get` CLI, via the provider's registered prefix (#1412)
-
-For example:
-
-```shell
-# Only query databases served by the example providers
-optimade-get --include-providers exmpl,optimade
-# Exclude example providers from global list
-optimade-get --exclude-providers exmpl,optimade
-```
-
-You can also now exclude particular databases by their URLs:
-```shell
-# Exclude specific example databases
-optimade-get --exclude-databases https://example.org/optimade,https://optimade.org/example
-```
-
-The release also includes some server enhancements and fixes:
-- Caching of `/info/` and `/info/<entry>` endpoint responses (#1433)
-- A bugfix for the entry mapper classes, which were sharing cache resources globally leading to poor utilization (#1435)
-
 ## [v0.20.2](https://github.com/Materials-Consortia/optimade-python-tools/tree/v0.20.2) (2022-12-21)
 
 [Full Changelog](https://github.com/Materials-Consortia/optimade-python-tools/compare/v0.20.1...v0.20.2)

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ OPTIMADE Python tools
     <a href="https://github.com/Materials-Consortia/OPTIMADE"><img alt="OPTIMADE version" src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Materials-Consortia/optimade-python-tools/master/optimade-version.json"></a>
   </td>
   <td align="center">
-    <a href="https://github.com/Materials-Consortia/optimade-python-tools/actions?query=branch%3Amaster+"><img alt="Build Status" src="https://img.shields.io/github/workflow/status/Materials-Consortia/optimade-python-tools/CI%20tests?logo=github"></a><br>
+    <a href="https://github.com/Materials-Consortia/optimade-python-tools/actions?query=branch%3Amaster+"><img alt="Build Status" src="https://img.shields.io/github/actions/workflow/status/Materials-Consortia/optimade-python-tools/ci.yml?logo=github"></a><br>
     <a href="https://codecov.io/gh/Materials-Consortia/optimade-python-tools"><img alt="Codecov" src="https://img.shields.io/codecov/c/github/Materials-Consortia/optimade-python-tools?logo=codecov&logoColor=white&token=UJAtmqkZZO"></a><br>
   </td>
   <td align="center">


### PR DESCRIPTION
Annoyingly the CHANGELOG generated from my release notes had some trailing whitespace, which will cause the CI to fail until it is fixed.

This PR fixes it.