### PR TITLE
Add compatibility for `httpx`-based `TestClient` for latest FastAPI version

### DIFF
--- a/optimade/client/cli.py
+++ b/optimade/client/cli.py
@@ -119,6 +119,7 @@ def _get(
     include_providers,
     exclude_providers,
     exclude_databases,
+    **kwargs,
 ):
 
     if output_file:
@@ -143,6 +144,7 @@ def _get(
         exclude_databases=set(_.strip() for _ in exclude_databases.split(","))
         if exclude_databases
         else None,
+        **kwargs,
     )
     if response_fields:
         response_fields = response_fields.split(",")

--- a/optimade/validator/validator.py
+++ b/optimade/validator/validator.py
@@ -166,10 +166,13 @@ class ImplementationValidator:
         )
 
         # some simple checks on base_url
+        self.base_url = str(self.base_url)
         self.base_url_parsed = urllib.parse.urlparse(self.base_url)
         # only allow filters/endpoints if we are working in "as_type" mode
         if self.as_type_cls is None and self.base_url_parsed.query:
-            raise SystemExit("Base URL not appropriate: should not contain a filter.")
+            raise SystemExit(
+                f"Base URL {self.base_url} not appropriate: should not contain a filter."
+            )
 
         self.valid = None
 
@@ -805,7 +808,7 @@ class ImplementationValidator:
                 expected_status_code=(200, 501),
             )
 
-            if not response:
+            if response.status_code != 200:
                 if query_optional:
                     return (
                         None,
@@ -822,7 +825,7 @@ class ImplementationValidator:
                     f"Required field `meta->more_data_available` missing from response for {request}."
                 )
 
-            if not response["meta"]["more_data_available"]:
+            if not response["meta"]["more_data_available"] and "data" in response:
                 num_data_returned[operator] = len(response["data"])
             else:
                 num_data_returned[operator] = response["meta"].get("data_returned")

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,5 +10,4 @@ pre-commit==2.21.0
 pylint==2.15.9
 pytest==7.2.0
 pytest-cov==4.0.0
-pytest-httpx==0.21.2
 types-all==1.0.0

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -1,5 +1,5 @@
 elasticsearch==7.17.7
 elasticsearch-dsl==7.4.0
-fastapi==0.86.0
+fastapi==0.88.0
 mongomock==4.1.2
 pymongo==4.3.3

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ testing_deps = [
     "jsondiff~=2.0",
     "pytest~=7.2",
     "pytest-cov~=4.0",
-    "pytest-httpx~=0.21",
 ] + server_deps
 dev_deps = (
     [

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -243,3 +243,10 @@ def check_error_response(client, index_client):
             raise
 
     return inner
+
+
+@pytest.fixture(scope="session")
+def http_client():
+    from .utils import HttpxTestClient
+
+    return HttpxTestClient

--- a/tests/server/middleware/test_api_hint.py
+++ b/tests/server/middleware/test_api_hint.py
@@ -59,7 +59,7 @@ def test_url_changes(both_clients, get_good_response):
     response = get_good_response(query_url, server=both_clients, return_json=False)
 
     assert (
-        unquote(response.url)
+        unquote(str(response.url))
         == f"{both_clients.base_url}{BASE_URL_PREFIXES['major']}{query_url.split('&')[0]}"
     )
 
@@ -68,7 +68,7 @@ def test_url_changes(both_clients, get_good_response):
 
     response = get_good_response(query_url, server=both_clients, return_json=False)
 
-    assert unquote(response.url) == f"{both_clients.base_url}{query_url}"
+    assert unquote(str(response.url)) == f"{both_clients.base_url}{query_url}"
 
 
 def test_is_versioned_base_url(both_clients):

--- a/tests/server/utils.py
+++ b/tests/server/utils.py
@@ -4,9 +4,9 @@ import warnings
 from typing import Iterable, Optional, Type, Union
 from urllib.parse import urlparse
 
+import httpx
 import pytest
 from fastapi.testclient import TestClient
-from requests import Response
 from starlette import testclient
 
 import optimade.models.jsonapi as jsonapi
@@ -52,9 +52,11 @@ class OptimadeTestClient(TestClient):
     def request(  # pylint: disable=too-many-locals
         self,
         method: str,
-        url: str,
+        url: httpx._types.URLTypes,
         **kwargs,
-    ) -> Response:
+    ) -> httpx.Response:
+
+        url = str(url)
         if (
             re.match(r"/?v[0-9](.[0-9]){0,2}/", url) is None
             and not urlparse(url).scheme
@@ -75,7 +77,7 @@ class BaseEndpointTests:
     request_str: Optional[str] = None
     response_cls: Optional[Type[jsonapi.Response]] = None
 
-    response: Optional[Response] = None
+    response: Optional[httpx.Response] = None
     json_response: Optional[dict] = None
 
     @staticmethod
@@ -224,7 +226,7 @@ class NoJsonEndpointTests:
     request_str: Optional[str] = None
     response_cls: Optional[Type] = None
 
-    response: Optional[Response] = None
+    response: Optional[httpx.Response] = None
 
     @pytest.fixture(autouse=True)
     def get_response(self, both_clients):

--- a/tests/server/utils.py
+++ b/tests/server/utils.py
@@ -240,3 +240,17 @@ class NoJsonEndpointTests:
         assert (
             self.response.status_code == 200
         ), f"Request to {self.request_str} failed: {self.response.content}"
+
+
+class HttpxTestClient(httpx.Client):
+    """An HTTP client wrapper that calls the regular test server."""
+
+    client = client_factory()(server="regular")
+
+    def request(  # pylint: disable=too-many-locals
+        self,
+        method: str,
+        url: httpx._types.URLTypes,
+        **kwargs,
+    ) -> httpx.Response:
+        return self.client.request(method, url, **kwargs)


### PR DESCRIPTION
This PR updates tests, validator and client usage of requests/httpx to add compatibility for the new `httpx`-based `TestClient` required by the latest FastAPI version (whilst also maintaining compatibility with older versions).

To do this, I had to:

- drop `pytest-httpx` as it caused infinite recursion between the mocked test client and the mocked requests themselves, with no clean workaround
- some fixes to get string URLs back from the internal `httpx.URL` now used within the test client
- added ability to specify a custom HTTP client to the `OptimadeClient`, so a patched test client can be specified directly
- some tweaks associated with differences of truthiness of non-200 responses between `httpx` and `requests`

We can probably now begin the process of using httpx in the validator too, though a naive switch out lead to some errors that I don't want to fix in this PR.