### PR TITLE
Add ability to save client results directly from Python

### DIFF
--- a/optimade/client/client.py
+++ b/optimade/client/client.py
@@ -388,6 +388,7 @@ class OptimadeClient:
         if self.use_async:
             # Check for a pre-existing event loop (e.g. within a Jupyter notebook)
             # and use it if present
+            event_loop: Optional[asyncio.AbstractEventLoop]
             try:
                 event_loop = asyncio.get_running_loop()
                 if event_loop:
@@ -916,8 +917,6 @@ class OptimadeClient:
             except Exception:
                 existing_data = {}
 
-            breakpoint()
-
             results_to_write = self._merge_results(
                 existing_data, dict(self.all_results)
             )
@@ -944,7 +943,6 @@ class OptimadeClient:
         endpoints = set(old.keys()).union(new.keys())
 
         for endpoint in endpoints:
-
             output[endpoint] = {}
             filters = set(old.get(endpoint, {}).keys()).union(
                 new.get(endpoint, {}).keys()

--- a/optimade/client/client.py
+++ b/optimade/client/client.py
@@ -902,6 +902,60 @@ class OptimadeClient:
 
         return results, next_url
 
+    def save(self, filename: Union[str, Path]) -> None:
+        """Saves all results from this client in the specified JSON file,
+        combining it with any existing results in that file.
+
+        Parameters:
+            filename: The filename to save to.
+
+        """
+        with open(Path(filename), "w") as f:
+            try:
+                existing_data = json.load(f) or {}
+            except Exception:
+                existing_data = {}
+
+            breakpoint()
+
+            results_to_write = self._merge_results(
+                existing_data, dict(self.all_results)
+            )
+
+            json.dump(results_to_write, f, indent=2)
+
+    def _merge_results(
+        self,
+        old: Dict[str, Dict[str, Dict[str, Any]]],
+        new: Dict[str, Dict[str, Dict[str, Any]]],
+    ):
+        """Merges two sets of results from the same endpoints.
+
+        Parameters:
+            old: The old results.
+            new: The new results.
+
+        Returns:
+            The merged results.
+
+        """
+        output: Dict = {}
+
+        endpoints = set(old.keys()).union(new.keys())
+
+        for endpoint in endpoints:
+
+            output[endpoint] = {}
+            filters = set(old.get(endpoint, {}).keys()).union(
+                new.get(endpoint, {}).keys()
+            )
+            for filter in filters:
+                output[endpoint][filter] = {}
+                output[endpoint][filter].update(old.get(endpoint, {}).get(filter, {}))
+                output[endpoint][filter].update(new.get(endpoint, {}).get(filter, {}))
+
+        return output
+
     def _teardown(self, _task: TaskID, num_results: int) -> None:
         """Update the finished status of the progress bar depending on the number of results.
 

--- a/tests/server/test_client.py
+++ b/tests/server/test_client.py
@@ -98,8 +98,10 @@ def test_client_response_fields(http_client, use_async):
 
 
 @pytest.mark.parametrize("use_async", [False])
-def test_client_save_results(httpx_mocked_response, use_async, tmp_path_factory):
-    cli = OptimadeClient(base_urls=[TEST_URL], use_async=use_async)
+def test_client_save_results(http_client, use_async, tmp_path_factory):
+    cli = OptimadeClient(
+        base_urls=[TEST_URL], use_async=use_async, http_client=http_client
+    )
     tmp_path = tmp_path_factory.mktemp("data") / "results.json"
     results = cli.get(
         response_fields=["chemical_formula_reduced"],
@@ -145,8 +147,10 @@ def test_client_save_results(httpx_mocked_response, use_async, tmp_path_factory)
 
 
 @pytest.mark.parametrize("use_async", [False])
-def test_multiple_base_urls(httpx_mocked_response, use_async):
-    cli = OptimadeClient(base_urls=TEST_URLS, use_async=use_async)
+def test_multiple_base_urls(http_client, use_async):
+    cli = OptimadeClient(
+        base_urls=TEST_URLS, use_async=use_async, http_client=http_client
+    )
     results = cli.get()
     count_results = cli.count()
     for url in TEST_URLS:

--- a/tests/server/test_client.py
+++ b/tests/server/test_client.py
@@ -116,6 +116,27 @@ def test_client_save_results(httpx_mocked_response, use_async, tmp_path_factory)
         results["structures"][""][TEST_URL]
     )
 
+    tmp_path = tmp_path_factory.mktemp("data") / "all_results.json"
+    cli.save(tmp_path)
+    breakpoint()
+
+    # Fake another query
+    import copy
+
+    cli.all_results["structures"][""]["https://test_url.org"] = copy.deepcopy(
+        cli.all_results["structures"][""][TEST_URL]
+    )
+
+    del cli.all_results["structures"][""][TEST_URL]
+
+    cli.save(tmp_path)
+
+    with open(tmp_path) as f:
+        saved_data = json.load(f)
+
+    assert "https://test_url.org" in saved_data["structures"][""]
+    assert TEST_URL in saved_data["structures"][""]
+
     with pytest.raises(RuntimeError, match="already exists, will not overwrite."):
         cli.get(
             response_fields=["chemical_formula_reduced"],


### PR DESCRIPTION
This PR adds a `save_as` argument to `get()` which will save the results of a single query to a JSON file.

It also adds the `.save()` method which will save all results from the current client, making efforts to aggregate any existing results in that file.

This could begin the preliminary work for persistent local caching of OPTIMADE results. Caveats: what to do if not all responses fields are requested the first time around --- probably need to hash the precise query URLs and use those in the cache.