### PR TITLE
Minor test compatibility patch for FastAPI 0.86

### DIFF
--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -1,5 +1,5 @@
 elasticsearch==7.17.7
 elasticsearch-dsl==7.4.0
-fastapi==0.86.0
+fastapi==0.88.0
 mongomock==4.1.2
 pymongo==4.3.3

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -1,5 +1,5 @@
 elasticsearch==7.17.7
 elasticsearch-dsl==7.4.0
-fastapi==0.88.0
+fastapi==0.86.0
 mongomock==4.1.2
 pymongo==4.3.3

--- a/tests/server/utils.py
+++ b/tests/server/utils.py
@@ -253,4 +253,4 @@ class HttpxTestClient(httpx.Client):
         url: httpx._types.URLTypes,
         **kwargs,
     ) -> httpx.Response:
-        return self.client.request(method, url, **kwargs)
+        return self.client.request(method, url)


### PR DESCRIPTION
This PR patches the test client to enable its continued use with `httpx` OR `requests`, which was the intention from #1460.

First I will push the rollback of FastAPI, let the tests finish (and fail), apply the patch, let the tests finish (and pass 🤞) then update FastAPI again.

Very minor issue only affecting people who want to use our repo's test set up with an older FastAPI version... (probably no-one)