### PR TITLE
Tweak pymatgen pin in `setup.py` to allow for calver

### DIFF
--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -1,5 +1,5 @@
 aiida-core==2.2.1
 ase==3.22.1
 jarvis-tools==2023.1.8
-pymatgen==2022.7.25
 numpy>=1.20
+pymatgen==2022.7.25

--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -1,5 +1,5 @@
 aiida-core==2.2.1
 ase==3.22.1
 jarvis-tools==2023.1.8
-numpy==1.24.1
 pymatgen==2022.7.25
+numpy>=1.20

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ http_client_deps = [
 ase_deps = ["ase~=3.22"]
 cif_deps = ["numpy>=1.20"]
 pdb_deps = cif_deps
-pymatgen_deps = ["pymatgen~=2022.7"]
+pymatgen_deps = ["pymatgen>=2022"]
 jarvis_deps = ["jarvis-tools==2023.1.8"]
 client_deps = cif_deps
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ http_client_deps = [
     "click~=8.1",
 ]
 ase_deps = ["ase~=3.22"]
-cif_deps = ["numpy>=1.23"]
+cif_deps = ["numpy>=1.20"]
 pdb_deps = cif_deps
 pymatgen_deps = ["pymatgen~=2022.7"]
 jarvis_deps = ["jarvis-tools==2023.1.8"]


### PR DESCRIPTION
This PR tweaks the pymatgen `setup.py` version to allow `2023` to be installed.

Also relaxed the numpy requirement which was causing many build issues.