### PR TITLE
Tweak client timeouts and `response_fields` behaviour

### DIFF
--- a/optimade/client/cli.py
+++ b/optimade/client/cli.py
@@ -73,6 +73,11 @@ __all__ = ("_get",)
     default=None,
     nargs=-1,
 )
+@click.option(
+    "--http-timeout",
+    type=float,
+    help="The timeout to use for each HTTP request.",
+)
 def get(
     use_async,
     filter,
@@ -87,6 +92,7 @@ def get(
     include_providers,
     exclude_providers,
     exclude_databases,
+    http_timeout,
 ):
     return _get(
         use_async,
@@ -102,6 +108,7 @@ def get(
         include_providers,
         exclude_providers,
         exclude_databases,
+        http_timeout,
     )
 
 
@@ -119,6 +126,7 @@ def _get(
     include_providers,
     exclude_providers,
     exclude_databases,
+    http_timeout,
     **kwargs,
 ):
     if output_file:
@@ -130,7 +138,7 @@ def _get(
                 f"Desired output file {output_file} already exists, not overwriting."
             )
 
-    client = OptimadeClient(
+    args = dict(
         base_urls=base_url,
         use_async=use_async,
         max_results_per_provider=max_results_per_provider,
@@ -143,6 +151,15 @@ def _get(
         exclude_databases=set(_.strip() for _ in exclude_databases.split(","))
         if exclude_databases
         else None,
+    )
+
+    # Only set http timeout if its not null to avoid overwriting or duplicating the
+    # default value set on the OptimadeClient class
+    if http_timeout:
+        args["http_timeout"] = http_timeout
+
+    client = OptimadeClient(
+        **args,
         **kwargs,
     )
     if response_fields:

--- a/optimade/client/client.py
+++ b/optimade/client/client.py
@@ -316,7 +316,7 @@ class OptimadeClient:
                 endpoint,
                 page_limit=1,
                 paginate=False,
-                response_fields=None,
+                response_fields=[],
                 sort=None,
             )
             count_results = {}
@@ -776,8 +776,12 @@ class OptimadeClient:
 
         if filter:
             _filter = f"filter={filter}"
-        if response_fields:
-            _response_fields = f'response_fields={",".join(response_fields)}'
+        if response_fields is not None:
+            # If we have requested no response fields (e.g., in the case of --count) then just ask for IDs
+            if len(response_fields) == 0:
+                _response_fields = "response_fields=id"
+            else:
+                _response_fields = f'response_fields={",".join(response_fields)}'
         if page_limit:
             _page_limit = f"page_limit={page_limit}"
         if sort:

--- a/optimade/client/client.py
+++ b/optimade/client/client.py
@@ -122,7 +122,7 @@ class OptimadeClient:
                 from each provider.
             headers: Any additional HTTP headers to use for the queries.
             http_timeout: The timeout to use per request. Defaults to 10
-                seconds with 60 seconds for reads specifically. Overriding this value
+                seconds with 1000 seconds for reads specifically. Overriding this value
                 will replace all timeouts (connect, read, write and pool) with this value.
             max_attempts: The maximum number of times to repeat a failing query.
             use_async: Whether or not to make all requests asynchronously.

--- a/tests/server/test_client.py
+++ b/tests/server/test_client.py
@@ -157,6 +157,8 @@ def test_client_sort(http_client, use_async):
 
 @pytest.mark.parametrize("use_async", [False])
 def test_command_line_client(http_client, use_async, capsys):
+    import httpx
+
     from optimade.client.cli import _get
 
     args = dict(
@@ -174,6 +176,7 @@ def test_command_line_client(http_client, use_async, capsys):
         exclude_providers=None,
         exclude_databases=None,
         http_client=http_client,
+        http_timeout=httpx.Timeout(2.0),
     )
 
     # Test multi-provider query


### PR DESCRIPTION
This PR increases the default HTTP read timeout and makes it configurable via a parameter.

Also reduces the response fields to just "id" when a count query is being performed.