### PR TITLE
Add server config option to disable validation of outgoing data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,6 +194,12 @@ jobs:
       env:
         OPTIMADE_DATABASE_BACKEND: 'mongomock'
 
+    - name: Run server tests with no API validation (using `mongomock`)
+      run: pytest -rs -vvv --cov=./optimade/ --cov-report=xml --cov-append tests/server tests/filtertransformers
+      env:
+        OPTIMADE_DATABASE_BACKEND: 'mongomock'
+        OPTIMADE_VALIDATE_API_RESPONSE: false
+
     - name: Run server tests (using a real MongoDB)
       run: pytest -rs -vvv --cov=./optimade/ --cov-report=xml --cov-append tests/server tests/filtertransformers
       env:

--- a/optimade/server/config.py
+++ b/optimade/server/config.py
@@ -293,7 +293,7 @@ class ServerConfig(BaseSettings):
     )
 
     validate_api_response: Optional[bool] = Field(
-        False,
+        True,
         description="""If False, data from the database will not undergo validation before being emitted by the API, and
         only the mapping of aliases will occur.""",
     )

--- a/optimade/server/config.py
+++ b/optimade/server/config.py
@@ -292,6 +292,12 @@ class ServerConfig(BaseSettings):
         description="If True, the server will check whether the query parameters given in the request are correct.",
     )
 
+    validate_api_response: Optional[bool] = Field(
+        False,
+        description="""If False, data from the database will not undergo validation before being emitted by the API, and
+        only the mapping of aliases will occur.""",
+    )
+
     @validator("implementation", pre=True)
     def set_implementation_version(cls, v):
         """Set defaults and modify bypassed value(s)"""

--- a/optimade/server/entry_collections/entry_collections.py
+++ b/optimade/server/entry_collections/entry_collections.py
@@ -188,7 +188,7 @@ class EntryCollection(ABC):
 
         results: Union[None, List[EntryResource], EntryResource, List[Dict]] = None
 
-        if raw_results is not None:
+        if raw_results:
             if CONFIG.validate_api_response:
                 results = self.resource_mapper.deserialize(raw_results)
             else:
@@ -197,10 +197,12 @@ class EntryCollection(ABC):
             if single_entry:
                 results = results[0]  # type: ignore[assignment]
 
-                if data_returned > 1:
+                if CONFIG.validate_api_response and data_returned > 1:
                     raise NotFound(
                         detail=f"Instead of a single entry, {data_returned} entries were found",
                     )
+                else:
+                    data_returned = 1
 
         return (
             results,

--- a/optimade/server/mappers/entries.py
+++ b/optimade/server/mappers/entries.py
@@ -363,6 +363,10 @@ class BaseResourceMapper:
     def deserialize(
         cls, results: Union[dict, Iterable[dict]]
     ) -> Union[List[EntryResource], EntryResource]:
+        """Converts the raw database entries for this class into serialized models,
+        mapping the data along the way.
+
+        """
         if isinstance(results, dict):
             return cls.ENTRY_RESOURCE_CLASS(**cls.map_back(results))
 

--- a/optimade/server/routers/utils.py
+++ b/optimade/server/routers/utils.py
@@ -283,7 +283,7 @@ def get_entries(
 
     return response(
         links=links,
-        data=results,
+        data=results if results else [],
         meta=meta_values(
             url=request.url,
             data_returned=data_returned,
@@ -336,7 +336,7 @@ def get_single_entry(
 
     return response(
         links=links,
-        data=results,
+        data=results if results else None,
         meta=meta_values(
             url=request.url,
             data_returned=data_returned,


### PR DESCRIPTION
This PR adds the config option `validate_api_response` to the reference server, which is enabled by default. Disabling this will short-circuit the pydantic validation of outgoing data, which can be used to allow things like "X" in chemical formulae through the API. Currently there are no associated warnings raised in this case, but an intermediate setting could be added to do this (would still have the performance hit of validation, but this does not seem to be sizable).

The server tests are now run in the CI in both modes, but there are currently no tests that the lack of validation does indeed allow negative data through --- it does, and setting up tests for this negative case would be more effort than I can afford atm.

