### PR TITLE
Replace httpx usage in synchronous `OptimadeClient` with requests 

### DIFF
--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -247,9 +247,9 @@ def check_error_response(client, index_client):
 
 @pytest.fixture(scope="session")
 def http_client():
-    from .utils import HttpxTestClient
+    from .utils import RequestsTestClient
 
-    return HttpxTestClient
+    return RequestsTestClient
 
 
 @pytest.fixture(scope="session")

--- a/tests/server/utils.py
+++ b/tests/server/utils.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse
 
 import httpx
 import pytest
+import requests
 from fastapi.testclient import TestClient
 from starlette import testclient
 
@@ -251,6 +252,21 @@ class HttpxTestClient(httpx.Client):
         url: httpx._types.URLTypes,
         **kwargs,
     ) -> httpx.Response:
+        return self.client.request(method, url)
+
+
+class RequestsTestClient(requests.Session):
+    """An HTTP client wrapper that calls the regular test server."""
+
+    client = client_factory()(server="regular")
+
+    def request(  # pylint: disable=too-many-locals
+        self,
+        method,
+        url,
+        *args,
+        **kwargs,
+    ) -> requests.Response:
         return self.client.request(method, url)
 
 


### PR DESCRIPTION
Bit of a last minute patch before the tutorials... it seems like we don't handle the case of getting IP banned from an API (which may well happen!) when the client is in non-async mode --- fix this for now by adding a very general exception handler to the request.

ALSO: client hangs even in sync mode within Jupyter notebooks.

The cause of this is that at some point httpx removed support for non-async code altogether, even in the sync client. The fix is to just defer to `requests` at this point. That is what is implemented in this PR, which now allows the client to be properly used within Jupyter/Colab.

Unfortunately I am going to have to merge and release without a review, given that the tutorial is in about 12 hours... I'm pretty confident that this is working well though and I was able to update the testing harness with only a couple of lines.

Closes #1527 and closes #1195 (for now -- async still doesn't work inside a jupyter notebook but at least it now runs).