### PR TITLE
Extract next link query param creation into EntriesCollection method.

### DIFF
--- a/optimade/server/entry_collections/entry_collections.py
+++ b/optimade/server/entry_collections/entry_collections.py
@@ -434,3 +434,27 @@ class EntryCollection(ABC):
         ]
 
         return sort_spec
+
+    def get_next_query_params(
+        self,
+        params: EntryListingQueryParams,
+        results: Union[None, List[EntryResource], EntryResource, List[Dict]],
+    ) -> Dict[str, List[str]]:
+        """Provides url query pagination parameters that will be used in the next
+        link.
+
+        Arguments:
+            results: The results produced by find.
+            params: The parsed request params produced by handle_query_params.
+
+        Returns:
+            A dictionary with the necessary query parameters.
+
+        """
+        query: Dict[str, List[str]] = dict()
+        if isinstance(results, list):
+            query["page_offset"] = [
+                str(getattr(params, "page_offset", 0) + len(results))
+            ]
+
+        return query

--- a/optimade/server/routers/utils.py
+++ b/optimade/server/routers/utils.py
@@ -273,8 +273,8 @@ def get_entries(
     if more_data_available:
         # Deduce the `next` link from the current request
         query = urllib.parse.parse_qs(request.url.query)
-        if isinstance(results, list):
-            query["page_offset"] = int(query.get("page_offset", [0])[0]) + len(results)  # type: ignore[assignment,list-item]
+        query.update(collection.get_next_query_params(params, results))
+
         urlencoded = urllib.parse.urlencode(query, doseq=True)
         base_url = get_base_url(request.url)
 


### PR DESCRIPTION
This would allow different `EntriesCollection` implementations to alter how the URL query parameters for the next links are produced. How request params are handled is already part of `EntriesCollection`, it would be logical to also have the request params for the "next" request handled here.

The value-based pagination can depend on back-end implementation details. For example, in elasticsearch you would combine the sort-by property values with ids to create a value with tie-breaker.