### PR TITLE
Element symbols are now used when generating an ase atom.

### DIFF
--- a/optimade/adapters/structures/ase.py
+++ b/optimade/adapters/structures/ase.py
@@ -87,7 +87,9 @@ def get_ase_atoms(optimade_structure: OptimadeStructure) -> Atoms:
         if current_species.mass:
             mass = current_species.mass[0]
 
-        atoms.append(Atom(symbol=species_name, position=site, mass=mass))
+        atoms.append(
+            Atom(symbol=current_species.chemical_symbols[0], position=site, mass=mass)
+        )
 
     info = {}
     for key in attributes.dict().keys():

--- a/optimade/server/data/test_structures.json
+++ b/optimade/server/data/test_structures.json
@@ -267,7 +267,16 @@
         "concentration": [
           1.0
         ],
-        "name": "Ac"
+        "name": "Ac1"
+      },
+      {
+        "chemical_symbols": [
+          "Ac"
+        ],
+        "concentration": [
+          1.0
+        ],
+        "name": "Ac2"
       },
       {
         "chemical_symbols": [
@@ -289,8 +298,8 @@
       }
     ],
     "species_at_sites": [
-      "Ac",
-      "Ac",
+      "Ac1",
+      "Ac2",
       "Ag",
       "Pb"
     ],


### PR DESCRIPTION
A quick fix for the issue brought up in PR#1570
Previously, the species name was used for the element symbol when generating ase atoms. Now element symbols are used correctly.