### PR TITLE
Include path if the base url is generated from the request URL.

### DIFF
--- a/optimade/server/routers/utils.py
+++ b/optimade/server/routers/utils.py
@@ -235,8 +235,6 @@ def get_base_url(
     if CONFIG.base_url:
         return CONFIG.base_url.rstrip("/")
 
-    from optimade.server.schemas import ENTRY_INFO_SCHEMAS
-
     parsed_url_request = (
         urllib.parse.urlparse(parsed_url_request)
         if isinstance(parsed_url_request, str)
@@ -246,6 +244,8 @@ def get_base_url(
     if parsed_url_request.path:
         split_path = re.split(r"/v[0-9]+(\.[0-9]+){0,2}", parsed_url_request.path, 1)
         if len(split_path) == 1:
+            from optimade.server.schemas import ENTRY_INFO_SCHEMAS
+
             available_endpoints = ["info", "links"] + list(ENTRY_INFO_SCHEMAS)
             for endpoint in available_endpoints:
                 split_path = parsed_url_request.path.split("/" + endpoint)

--- a/optimade/server/routers/utils.py
+++ b/optimade/server/routers/utils.py
@@ -246,14 +246,11 @@ def get_base_url(
         if len(split_path) == 1:
             from optimade.server.schemas import ENTRY_INFO_SCHEMAS
 
-            available_endpoints = ["info", "links"] + list(ENTRY_INFO_SCHEMAS)
-            for endpoint in available_endpoints:
+            for endpoint in ["info", "links"] + list(ENTRY_INFO_SCHEMAS):
                 split_path = parsed_url_request.path.split("/" + endpoint)
                 if len(split_path) > 1:
                     break
-            else:
-                split_path[0] = split_path[0].rstrip("/")
-        base_url = base_url + split_path[0]
+        base_url = base_url + split_path[0].rstrip("/")
 
     return base_url
 

--- a/optimade/server/routers/utils.py
+++ b/optimade/server/routers/utils.py
@@ -241,16 +241,8 @@ def get_base_url(
         else parsed_url_request
     )
     base_url = f"{parsed_url_request.scheme}://{parsed_url_request.netloc}"
-    if parsed_url_request.path:
-        split_path = re.split(r"/v[0-9]+(\.[0-9]+){0,2}", parsed_url_request.path, 1)
-        if len(split_path) == 1:
-            from optimade.server.schemas import ENTRY_INFO_SCHEMAS
-
-            for endpoint in ["info", "links"] + list(ENTRY_INFO_SCHEMAS):
-                split_path = parsed_url_request.path.split("/" + endpoint)
-                if len(split_path) > 1:
-                    break
-        base_url = base_url + split_path[0].rstrip("/")
+    if CONFIG.root_path:
+        base_url = base_url + CONFIG.root_path.rstrip("/")
 
     return base_url
 

--- a/tests/server/routers/test_utils.py
+++ b/tests/server/routers/test_utils.py
@@ -111,3 +111,36 @@ def test_get_providers_warning(caplog, top_dir):
             from optimade.server.data import providers
 
             assert providers == providers_cache
+
+
+def test_get_base_url():
+    """
+    This tests whether the base_url is correctly extracted from the request.
+    """
+    from optimade.server.routers.utils import get_base_url
+    from optimade.server.config import CONFIG
+
+    base_url_org = CONFIG.base_url
+    CONFIG.base_url = None
+    request_urls = (
+        "http://www.example.com",
+        "http://www.example.com/",
+        "http://www.example.com/optimade/v1/links",
+        "http://www.structures.com/links",
+        "https://www.links.org/optimade/structures/123456",
+    )
+    base_urls = (
+        "http://www.example.com",
+        "http://www.example.com",
+        "http://www.example.com/optimade",
+        "http://www.structures.com",
+        "https://www.links.org/optimade",
+    )
+    results = []
+    for request_url in request_urls:
+        results.append(get_base_url(request_url))
+
+    CONFIG.base_url = base_url_org
+
+    for i in range(len(base_urls)):
+        assert results[i] == base_urls[i]

--- a/tests/server/routers/test_utils.py
+++ b/tests/server/routers/test_utils.py
@@ -117,8 +117,8 @@ def test_get_base_url():
     """
     This tests whether the base_url is correctly extracted from the request.
     """
-    from optimade.server.routers.utils import get_base_url
     from optimade.server.config import CONFIG
+    from optimade.server.routers.utils import get_base_url
 
     base_url_org = CONFIG.base_url
     root_path_org = CONFIG.root_path

--- a/tests/server/routers/test_utils.py
+++ b/tests/server/routers/test_utils.py
@@ -121,7 +121,9 @@ def test_get_base_url():
     from optimade.server.config import CONFIG
 
     base_url_org = CONFIG.base_url
+    root_path_org = CONFIG.root_path
     CONFIG.base_url = None
+    CONFIG.root_path = "/optimade"
     request_urls = (
         "http://www.example.com",
         "http://www.example.com/",
@@ -130,10 +132,10 @@ def test_get_base_url():
         "https://www.links.org/optimade/structures/123456",
     )
     base_urls = (
-        "http://www.example.com",
-        "http://www.example.com",
         "http://www.example.com/optimade",
-        "http://www.structures.com",
+        "http://www.example.com/optimade",
+        "http://www.example.com/optimade",
+        "http://www.structures.com/optimade",
         "https://www.links.org/optimade",
     )
     results = []
@@ -141,6 +143,6 @@ def test_get_base_url():
         results.append(get_base_url(request_url))
 
     CONFIG.base_url = base_url_org
-
+    CONFIG.root_path = root_path_org
     for i in range(len(base_urls)):
         assert results[i] == base_urls[i]


### PR DESCRIPTION
This PR fixes a bug in get_base_url.
If the base URL is not specified in the config file, the function get_base_url extracts the base URL from the request URL.
The current function, however, only returns the scheme (e.g. https) and netloc(e.g. www.example.com) part of the base URL. 
A base URL may however also contain a root path (e.g. /optimade). 
This patch adds the root path to the base URL.