### PR TITLE
Removing Codecov from dependencies because it is no longer on pypi.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,5 @@
 black==23.1.0
 build==0.10.0
-codecov==2.1.12
 flake8==6.0.0
 invoke==2.0.0
 isort==5.12.0

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ docs_deps = [
 ]
 testing_deps = [
     "build~=0.9.0",
-    "codecov~=2.1",
     "jsondiff~=2.0",
     "pytest~=7.2",
     "pytest-cov~=4.0",


### PR DESCRIPTION
I have removed codecov from our requirements as it is no longer on PyPI.