### PR TITLE
Validate list `LENGTH` queries with validator

### DIFF
--- a/optimade/validator/config.py
+++ b/optimade/validator/config.py
@@ -108,6 +108,9 @@ _FIELD_SPECIFIC_OVERRIDES = {
             if op != "="
         ],
     },
+    "structure_features": {
+        SupportLevel.OPTIONAL: "LENGTH",
+    },
 }
 
 

--- a/optimade/validator/config.py
+++ b/optimade/validator/config.py
@@ -79,7 +79,7 @@ _INCLUSIVE_OPERATORS = {
     ),
     DataType.INTEGER: inclusive_ops,
     DataType.FLOAT: (),
-    DataType.LIST: ("HAS", "HAS ALL", "HAS ANY"),
+    DataType.LIST: ("HAS", "HAS ALL", "HAS ANY", "LENGTH"),
 }
 
 exclusive_ops = ("!=", "<", ">")

--- a/optimade/validator/validator.py
+++ b/optimade/validator/validator.py
@@ -682,6 +682,8 @@ class ImplementationValidator:
                 else:
                     _vals = [f"{val}" for val in _vals]
                 _test_value = ",".join(_vals)
+            elif operator == "LENGTH":
+                _test_value = f"{len(test_value)}"
             else:
                 if isinstance(test_value[0], str):
                     _test_value = f'"{test_value[0]}"'

--- a/optimade/validator/validator.py
+++ b/optimade/validator/validator.py
@@ -1240,7 +1240,7 @@ class ImplementationValidator:
             expected_status_code = [404, 400]
 
         self._get_endpoint(
-            "v123123", expected_status_code=expected_status_code, optional=True
+            "v123123/info", expected_status_code=expected_status_code, optional=True
         )
 
     @test_case


### PR DESCRIPTION
As above.

Also tweaks the test for bad versions by hitting `/v1234/info` instead of a landing page.