### PR TITLE
Add `--list-properties` and `--search-property` functionality to client

### DIFF
--- a/docs/getting_started/client.md
+++ b/docs/getting_started/client.md
@@ -263,6 +263,37 @@ In the Python interface, the different endpoints can be queried as attributes of
     client.get(endpoint="extensions/properties")
     ```
 
+### Listing the properties served by a database
+
+You can also retrieve the list of properties served by a database using the
+`--list-properties` flag:
+
+=== "Command line"
+    ```
+    optimade-get --list-properties structures --include-providers odbx
+    ```
+
+=== "Python"
+    ```
+    from optimade.client import OptimadeClient
+    client = OptimadeClient(include_providers={"odbx"})
+    client.list_properties("structures")
+    ```
+
+and do simple string matching filtering of the response:
+
+=== "Command line"
+    ```
+    optimade-get --list-properties structures --search-property gap
+    ```
+
+=== "Python"
+    ```
+    from optimade.client import OptimadeClient
+    client = OptimadeClient()
+    client.list_properties("structures")
+    ```
+
 ### Limiting the number of responses
 
 Querying all OPTIMADE APIs without limiting the number of entries can result in a lot of data.

--- a/optimade/client/cli.py
+++ b/optimade/client/cli.py
@@ -34,6 +34,16 @@ __all__ = ("_get",)
     help="Count the results of the filter rather than downloading them.",
 )
 @click.option(
+    "--list-properties",
+    default=None,
+    help="An entry type to list the properties of.",
+)
+@click.option(
+    "--search-property",
+    default=None,
+    help="An search string for finding a particular proprety.",
+)
+@click.option(
     "--endpoint",
     default="structures",
     help="The endpoint to query.",
@@ -90,6 +100,8 @@ def get(
     max_results_per_provider,
     output_file,
     count,
+    list_properties,
+    search_property,
     response_fields,
     sort,
     endpoint,
@@ -107,6 +119,8 @@ def get(
         max_results_per_provider,
         output_file,
         count,
+        list_properties,
+        search_property,
         response_fields,
         sort,
         endpoint,
@@ -126,6 +140,8 @@ def _get(
     max_results_per_provider,
     output_file,
     count,
+    list_properties,
+    search_property,
     response_fields,
     sort,
     endpoint,
@@ -178,6 +194,12 @@ def _get(
             for f in filter:
                 client.count(f, endpoint=endpoint)
                 results = client.count_results
+        elif list_properties:
+            results = client.list_properties(entry_type=list_properties)
+            if search_property:
+                results = client.search_property(
+                    entry_type=list_properties, query=search_property
+                )
         else:
             for f in filter:
                 client.get(

--- a/tests/server/test_client.py
+++ b/tests/server/test_client.py
@@ -197,6 +197,8 @@ def test_command_line_client(async_http_client, http_client, use_async, capsys):
         endpoint="structures",
         pretty_print=False,
         include_providers=None,
+        list_properties=None,
+        search_property=None,
         exclude_providers=None,
         exclude_databases=None,
         http_client=async_http_client if use_async else http_client,
@@ -230,6 +232,8 @@ def test_command_line_client_silent(async_http_client, http_client, use_async, c
         silent=True,
         endpoint="structures",
         pretty_print=False,
+        list_properties=None,
+        search_property=None,
         include_providers=None,
         exclude_providers=None,
         exclude_databases=None,
@@ -267,6 +271,8 @@ def test_command_line_client_multi_provider(
         silent=False,
         endpoint="structures",
         pretty_print=False,
+        list_properties=None,
+        search_property=None,
         include_providers=None,
         exclude_providers=None,
         exclude_databases=None,
@@ -298,6 +304,8 @@ def test_command_line_client_write_to_file(
         sort=None,
         silent=False,
         endpoint="structures",
+        list_properties=None,
+        search_property=None,
         pretty_print=False,
         include_providers=None,
         exclude_providers=None,
@@ -418,3 +426,26 @@ def test_client_asynchronous_write_callback(
         lines = f.readlines()
 
     assert len(lines) == 17 * len(TEST_URLS) + 1
+
+
+@pytest.mark.parametrize("use_async", [True, False])
+def test_list_properties(
+    async_http_client,
+    http_client,
+    use_async,
+):
+    cli = OptimadeClient(
+        base_urls=TEST_URLS,
+        use_async=use_async,
+        http_client=async_http_client if use_async else http_client,
+    )
+
+    cli.__strict_async = True
+
+    results = cli.list_properties("structures")
+    for database in results:
+        assert len(results[database]) == 21
+
+    results = cli.search_property("structures", "site")
+    for database in results:
+        assert results[database] == ["nsites", "cartesian_site_positions"]


### PR DESCRIPTION
This PR adds the ability to query multiple databases for the properties that they report in their info endpoints, e.g.,

```shell
$ optimade-get --list-properties structures --include-providers odbx
{
  "structures": {
    "https://optimade.odbx.science": [
      "_odbx_lattice_abc",
      "_odbx_fractional_site_positions",
      "_odbx_cell_volume",
      "_odbx_dft_parameters",
      "_odbx_thermodynamics",
      "_odbx_calculator",
      "_odbx_space_group",
      "_odbx_submitter",
      "_odbx_stress",
      "_odbx_stress_tensor",
      "_odbx_forces",
      "_odbx_max_force_on_atom",
      "_odbx_tags",
      "_odbx_calculation_date"
    ],
    "https://optimade-misc.odbx.science": [
      "_odbx_hull_distance",
      "_odbx_formation_energy"
    ]
  }
}
```

or

```python
>> from optimade.client import OptimadeClient
>> client = OptimadeClient(include_providers={"odbx"})
>> client.list_properties("structures")
{
  "structures": {
    "https://optimade.odbx.science": [
      "_odbx_lattice_abc",
      "_odbx_fractional_site_positions",
      "_odbx_cell_volume",
      "_odbx_dft_parameters",
      "_odbx_thermodynamics",
      "_odbx_calculator",
      "_odbx_space_group",
      "_odbx_submitter",
      "_odbx_stress",
      "_odbx_stress_tensor",
      "_odbx_forces",
      "_odbx_max_force_on_atom",
      "_odbx_tags",
      "_odbx_calculation_date"
    ],
    "https://optimade-misc.odbx.science": [
      "_odbx_hull_distance",
      "_odbx_formation_energy"
    ]
  }
}
```