### PR TITLE
Validate that available_api_version contains `base_url`

### DIFF
--- a/optimade/validator/validator.py
+++ b/optimade/validator/validator.py
@@ -955,7 +955,9 @@ class ImplementationValidator:
         return True, f"{prop} passed filter tests"
 
     @test_case
-    def _test_available_api_versions(self, base_info: dict) -> bool:
+    def _test_available_api_versions(
+        self, base_info: dict
+    ) -> Tuple[Optional[bool], str]:
         """Take the base info response from `/info` and check that
         `available_api_versions` points to valid OPTIMADE APIs.
 
@@ -969,7 +971,10 @@ class ImplementationValidator:
                     f"Invalid `available_api_versions` (expected URL to contain base URL {self.base_url!r}): {version=}"
                 )
 
-        return True
+        return (
+            True,
+            "`available_api_versions` urls look correct",
+        )
 
     def _test_info_or_links_endpoint(self, request_str: str) -> Union[bool, dict]:
         """Requests an info or links endpoint and attempts to deserialize

--- a/optimade/validator/validator.py
+++ b/optimade/validator/validator.py
@@ -294,6 +294,7 @@ class ImplementationValidator:
             self.valid = False
             self.print_summary()
             return
+        self._test_available_api_versions(base_info.get("data"))
 
         # Grab the provider prefix from base info and use it when looking for provider fields
         self.provider_prefix = None
@@ -952,6 +953,23 @@ class ImplementationValidator:
                     )
 
         return True, f"{prop} passed filter tests"
+
+    @test_case
+    def _test_available_api_versions(self, base_info: dict) -> bool:
+        """Take the base info response from `/info` and check that
+        `available_api_versions` points to valid OPTIMADE APIs.
+
+        """
+        for version in base_info.get("attributes", {}).get(
+            "available_api_versions", {}
+        ):
+            url = version.get("url")
+            if self.base_url not in url:
+                raise ResponseError(
+                    f"Invalid `available_api_versions` (expected URL to contain base URL {self.base_url!r}): {version=}"
+                )
+
+        return True
 
     def _test_info_or_links_endpoint(self, request_str: str) -> Union[bool, dict]:
         """Requests an info or links endpoint and attempts to deserialize


### PR DESCRIPTION
Closes #1672.

This works for now but raises the question of whether an API can link to an entirely different `base_url` in its `available_api_versions` section...