### PR TITLE
Allow client callbacks to overwrite the next URL

### DIFF
--- a/docs/getting_started/client.md
+++ b/docs/getting_started/client.md
@@ -14,7 +14,7 @@ This list outlines the current and planned features for the client:
 - [x] Validate filters against the OPTIMADE grammar before they are sent to each database.
 - [x] Count the number of results for a query without downloading them all.
 - [x] Cache the results for queries to disk, and use them in future sessions without making new requests (achieved via callbacks).
-- [ ] Valiate the results against the optimade-python-tools models and export into other supported formats (ASE, pymatgen, CIF, AiiDA).
+- [ ] Validate the results against the optimade-python-tools models and export into other supported formats (ASE, pymatgen, CIF, AiiDA).
 - [ ] Enable asynchronous use in cases where there is already a running event loop (e.g., inside a Jupyter notebook).
 - [ ] Support for querying databases indirectly via an [OPTIMADE gateway server](https://github.com/Materials-Consortia/optimade-gateway).
 
@@ -163,7 +163,7 @@ has the following (truncated) output:
 {
   // The endpoint that was queried
   "structures": {
-    // The filter applied to that endpointk
+    // The filter applied to that endpoint
     "nsites = 1": {
       // The base URL of the OPTIMADE API
       "https://optimade.fly.dev": {
@@ -444,9 +444,12 @@ Care should be taken if combining an asynchronous client with callbacks, as the 
     print(db.find_one())
     ```
 
-Callbacks can also optionally return a URL which will be used instead of the `next` link
-returned by the API.
-This can be used to dynamically change queries based on the results, or to skip
-pages that have already been queried previously.
+Callbacks can also optionally return a dictionary of data that can be used by the client.
+
+Currently the supported keys are:
+
+- `next` (string): To override the next URL returned by the API. This can be used to dynamically change queries based on the results, or to skip pages that have already been queried previously.
+- `advance_results` (integer): To skip the progress bar forward by the set amount.
+
 When multiple callbacks are provided, only the final callback will have its
 result captured.

--- a/docs/getting_started/client.md
+++ b/docs/getting_started/client.md
@@ -443,3 +443,10 @@ Care should be taken if combining an asynchronous client with callbacks, as the 
 
     print(db.find_one())
     ```
+
+Callbacks can also optionally return a URL which will be used instead of the `next` link
+returned by the API.
+This can be used to dynamically change queries based on the results, or to skip
+pages that have already been queried previously.
+When multiple callbacks are provided, only the final callback will have its
+result captured.

--- a/optimade/client/client.py
+++ b/optimade/client/client.py
@@ -102,7 +102,7 @@ class OptimadeClient:
     use_async: bool
     """Whether or not to make all requests asynchronously using asyncio."""
 
-    callbacks: Optional[List[Callable[[str, Dict], Union[None, str]]]] = None
+    callbacks: Optional[List[Callable[[str, Dict], Union[None, Dict]]]] = None
     """A list of callbacks to execute after each successful request, used
     to e.g., write to a file, add results to a database or perform additional
     filtering.
@@ -111,8 +111,8 @@ class OptimadeClient:
     from the JSON response, with keys 'data', 'meta', 'links', 'errors'
     and 'included'.
 
-    Each callback can return a string that will be used to replace the `next_url`
-    queried by the client.
+    Each callback can return a dictionary that can modify the `next_url` with the
+    key `next` and the progress bar with the key `advance_results`.
     In the case of multiple provided callbacks, only the value returned by the final
     callback in the stack will be used.
 
@@ -159,7 +159,7 @@ class OptimadeClient:
         http_client: Optional[
             Union[Type[httpx.AsyncClient], Type[requests.Session]]
         ] = None,
-        callbacks: Optional[List[Callable[[str, Dict], Union[None, str]]]] = None,
+        callbacks: Optional[List[Callable[[str, Dict], Union[None, Dict]]]] = None,
     ):
         """Create the OPTIMADE client object.
 
@@ -1002,18 +1002,19 @@ class OptimadeClient:
             "errors": r.get("errors", []),
         }
 
+        callback_response = None
+        if self.callbacks:
+            callback_response = self._execute_callbacks(results, response)
+        callback_response = callback_response or {}
+
         # Advance the progress bar for this provider
         self._progress.update(
             _task,
-            advance=len(results["data"]),
+            advance=callback_response.get("advance_results", len(results["data"])),
             total=results["meta"].get("data_returned", None),
         )
 
-        callback_url = None
-        if self.callbacks:
-            callback_url = self._execute_callbacks(results, response)
-
-        next_url = callback_url or results["links"].get("next", None)
+        next_url = callback_response.get("next") or results["links"].get("next", None)
         if isinstance(next_url, dict):
             next_url = next_url.pop("href")
 
@@ -1036,7 +1037,7 @@ class OptimadeClient:
 
     def _execute_callbacks(
         self, results: Dict, response: Union[httpx.Response, requests.Response]
-    ) -> Union[None, str]:
+    ) -> Union[None, Dict]:
         """Execute any callbacks registered with the client.
 
         Parameters:

--- a/tests/server/test_client.py
+++ b/tests/server/test_client.py
@@ -386,10 +386,10 @@ def test_client_global_data_callback(async_http_client, http_client, use_async):
 
 @pytest.mark.parametrize("use_async", [True, False])
 def test_client_page_skip_callback(async_http_client, http_client, use_async):
-    def page_skip_callback(_: str, results: Dict) -> Optional[str]:
+    def page_skip_callback(_: str, results: Dict) -> Optional[Dict]:
         """A test callback that skips to the final page of results."""
         if len(results["data"]) > 16:
-            return f"{TEST_URL}/structures?page_offset=16"
+            return {"next": f"{TEST_URL}/structures?page_offset=16"}
         return None
 
     cli = OptimadeClient(

--- a/tests/server/test_client.py
+++ b/tests/server/test_client.py
@@ -385,6 +385,27 @@ def test_client_global_data_callback(async_http_client, http_client, use_async):
 
 
 @pytest.mark.parametrize("use_async", [True, False])
+def test_client_page_skip_callback(async_http_client, http_client, use_async):
+    def page_skip_callback(_: str, results: Dict) -> Optional[str]:
+        """A test callback that skips to the final page of results."""
+        if len(results["data"]) > 16:
+            return f"{TEST_URL}/structures?page_offset=16"
+        return None
+
+    cli = OptimadeClient(
+        base_urls=[TEST_URL],
+        use_async=use_async,
+        http_client=async_http_client if use_async else http_client,
+        callbacks=[page_skip_callback],
+    )
+
+    results = cli.get(response_fields=["chemical_formula_reduced"])
+
+    # callback will skip to final page after first query and add duplicate of final result
+    assert len(results["structures"][""][TEST_URL]["data"]) == 18
+
+
+@pytest.mark.parametrize("use_async", [True, False])
 def test_client_mutable_data_callback(async_http_client, http_client, use_async):
     container: Dict[str, str] = {}
 


### PR DESCRIPTION
This is useful for dynamic querying, e.g., changing a filter based on the number of results, or skipping forward to later pages.