### PR TITLE
Upgrade Fly deployment to Python 3.10

### DIFF
--- a/.github/fly.toml
+++ b/.github/fly.toml
@@ -36,3 +36,9 @@ processes = []
     interval = "15s"
     restart_limit = 0
     timeout = "2s"
+
+[build]
+  builtin = "python"
+
+[build.settings]
+  pythonbase = "3.10-slim-buster"


### PR DESCRIPTION
Using https://community.fly.io/t/building-with-python-3-9-vs-default-3-8/2215