### PR TITLE
Fixed bug in LENGTH_ALIASES StructureMapper

### DIFF
--- a/optimade/server/mappers/structures.py
+++ b/optimade/server/mappers/structures.py
@@ -7,7 +7,7 @@ __all__ = ("StructureMapper",)
 class StructureMapper(BaseResourceMapper):
     LENGTH_ALIASES = (
         ("elements", "nelements"),
-        ("element_ratios", "nelements"),
+        ("elements_ratios", "nelements"),
         ("cartesian_site_positions", "nsites"),
         ("species_at_sites", "nsites"),
     )

--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -2,4 +2,4 @@ aiida-core==2.4.0
 ase==3.22.1
 jarvis-tools==2023.5.26
 numpy>=1.20
-pymatgen==2023.6.28
+pymatgen==2023.7.17


### PR DESCRIPTION
The name for the variable holding the fractions of each element in the structure is "elements_ratios" yet here it was spelled as "element_ratios".