### PR TITLE
Loosen version requirement email_validator

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ setup(
     install_requires=[
         "lark~=1.1",
         "pydantic~=1.10,>=1.10.2,!=1.10.7",
-        "email_validator~=1.2",
+        "email_validator>=1.2",
         "requests~=2.28",
     ],
     extras_require={


### PR DESCRIPTION
In setup.py, we state that only version 1.* of email_validator is acceptable. Yet in requirements.txt we state that the required version is 2.0.0.post2 Therefore, I have made the version requirement in setup.py more flexible.