### PR TITLE
Assorted server optimizations

### DIFF
--- a/optimade/server/entry_collections/entry_collections.py
+++ b/optimade/server/entry_collections/entry_collections.py
@@ -137,13 +137,7 @@ class EntryCollection(ABC):
 
     def find(
         self, params: Union[EntryListingQueryParams, SingleEntryQueryParams]
-    ) -> Tuple[
-        Union[None, List[EntryResource], EntryResource, List[Dict]],
-        int,
-        bool,
-        Set[str],
-        Set[str],
-    ]:
+    ) -> Tuple[Union[None, Dict, List[Dict]], int, bool, Set[str], Set[str],]:
         """
         Fetches results and indicates if more data is available.
 
@@ -151,8 +145,7 @@ class EntryCollection(ABC):
         See [`EntryListingQueryParams`][optimade.server.query_params.EntryListingQueryParams]
         for more information.
 
-        Returns either the list of validated pydantic models matching the query, or simply the
-        mapped database reponse, depending on the value of `CONFIG.validate_api_response`.
+        Returns a list of the mapped database reponse.
 
         If no results match the query, then `results` is set to `None`.
 
@@ -202,13 +195,10 @@ class EntryCollection(ABC):
                 detail=f"Unrecognised OPTIMADE field(s) in requested `response_fields`: {bad_optimade_fields}."
             )
 
-        results: Union[None, List[EntryResource], EntryResource, List[Dict]] = None
+        results: Union[None, List[Dict], Dict] = None
 
         if raw_results:
-            if CONFIG.validate_api_response:
-                results = self.resource_mapper.deserialize(raw_results)
-            else:
-                results = [self.resource_mapper.map_back(doc) for doc in raw_results]
+            results = [self.resource_mapper.map_back(doc) for doc in raw_results]
 
             if single_entry:
                 results = results[0]  # type: ignore[assignment]
@@ -468,7 +458,7 @@ class EntryCollection(ABC):
     def get_next_query_params(
         self,
         params: EntryListingQueryParams,
-        results: Union[None, List[EntryResource], EntryResource, List[Dict]],
+        results: Union[None, Dict, List[Dict]],
     ) -> Dict[str, List[str]]:
         """Provides url query pagination parameters that will be used in the next
         link.

--- a/optimade/server/routers/links.py
+++ b/optimade/server/routers/links.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Dict
 
 from fastapi import APIRouter, Depends, Request
 
@@ -21,7 +21,7 @@ links_coll = create_collection(
 
 @router.get(
     "/links",
-    response_model=LinksResponse,
+    response_model=LinksResponse if CONFIG.validate_api_response else Dict,
     response_model_exclude_unset=True,
     tags=["Links"],
     responses=ERROR_RESPONSES,

--- a/optimade/server/routers/links.py
+++ b/optimade/server/routers/links.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from fastapi import APIRouter, Depends, Request
 
 from optimade.models import LinksResource, LinksResponse
@@ -24,9 +26,7 @@ links_coll = create_collection(
     tags=["Links"],
     responses=ERROR_RESPONSES,
 )
-def get_links(
-    request: Request, params: EntryListingQueryParams = Depends()
-) -> LinksResponse:
+def get_links(request: Request, params: EntryListingQueryParams = Depends()) -> Any:
     return get_entries(
         collection=links_coll, response=LinksResponse, request=request, params=params
     )

--- a/optimade/server/routers/references.py
+++ b/optimade/server/routers/references.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from fastapi import APIRouter, Depends, Request
 
 from optimade.models import (
@@ -30,7 +32,7 @@ references_coll = create_collection(
 )
 def get_references(
     request: Request, params: EntryListingQueryParams = Depends()
-) -> ReferenceResponseMany:
+) -> Any:
     return get_entries(
         collection=references_coll,
         response=ReferenceResponseMany,
@@ -48,7 +50,7 @@ def get_references(
 )
 def get_single_reference(
     request: Request, entry_id: str, params: SingleEntryQueryParams = Depends()
-) -> ReferenceResponseOne:
+) -> Any:
     return get_single_entry(
         collection=references_coll,
         entry_id=entry_id,

--- a/optimade/server/routers/references.py
+++ b/optimade/server/routers/references.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Dict
 
 from fastapi import APIRouter, Depends, Request
 
@@ -25,7 +25,7 @@ references_coll = create_collection(
 
 @router.get(
     "/references",
-    response_model=ReferenceResponseMany,
+    response_model=ReferenceResponseMany if CONFIG.validate_api_response else Dict,
     response_model_exclude_unset=True,
     tags=["References"],
     responses=ERROR_RESPONSES,
@@ -43,7 +43,7 @@ def get_references(
 
 @router.get(
     "/references/{entry_id:path}",
-    response_model=ReferenceResponseOne,
+    response_model=ReferenceResponseOne if CONFIG.validate_api_response else Dict,
     response_model_exclude_unset=True,
     tags=["References"],
     responses=ERROR_RESPONSES,

--- a/optimade/server/routers/structures.py
+++ b/optimade/server/routers/structures.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from fastapi import APIRouter, Depends, Request
 
 from optimade.models import (
@@ -30,7 +32,7 @@ structures_coll = create_collection(
 )
 def get_structures(
     request: Request, params: EntryListingQueryParams = Depends()
-) -> StructureResponseMany:
+) -> Any:
     return get_entries(
         collection=structures_coll,
         response=StructureResponseMany,
@@ -48,7 +50,7 @@ def get_structures(
 )
 def get_single_structure(
     request: Request, entry_id: str, params: SingleEntryQueryParams = Depends()
-) -> StructureResponseOne:
+) -> Any:
     return get_single_entry(
         collection=structures_coll,
         entry_id=entry_id,

--- a/optimade/server/routers/structures.py
+++ b/optimade/server/routers/structures.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Dict
 
 from fastapi import APIRouter, Depends, Request
 
@@ -25,7 +25,7 @@ structures_coll = create_collection(
 
 @router.get(
     "/structures",
-    response_model=StructureResponseMany,
+    response_model=StructureResponseMany if CONFIG.validate_api_response else Dict,
     response_model_exclude_unset=True,
     tags=["Structures"],
     responses=ERROR_RESPONSES,
@@ -43,7 +43,7 @@ def get_structures(
 
 @router.get(
     "/structures/{entry_id:path}",
-    response_model=StructureResponseOne,
+    response_model=StructureResponseOne if CONFIG.validate_api_response else Dict,
     response_model_exclude_unset=True,
     tags=["Structures"],
     responses=ERROR_RESPONSES,

--- a/optimade/server/routers/utils.py
+++ b/optimade/server/routers/utils.py
@@ -246,7 +246,7 @@ def get_base_url(
 
 def get_entries(
     collection: EntryCollection,
-    response: Type[EntryResponseMany],
+    response: Type[EntryResponseMany],  # noqa
     request: Request,
     params: EntryListingQueryParams,
 ) -> Dict:

--- a/optimade/server/routers/utils.py
+++ b/optimade/server/routers/utils.py
@@ -249,7 +249,7 @@ def get_entries(
     response: Type[EntryResponseMany],
     request: Request,
     params: EntryListingQueryParams,
-) -> EntryResponseMany:
+) -> Dict:
     """Generalized /{entry} endpoint getter"""
     from optimade.server.routers import ENTRY_COLLECTIONS
 
@@ -285,7 +285,7 @@ def get_entries(
     if results is not None and (fields or include_fields):
         results = handle_response_fields(results, fields, include_fields)  # type: ignore[assignment]
 
-    return response(
+    return dict(
         links=links,
         data=results if results else [],
         meta=meta_values(
@@ -307,7 +307,7 @@ def get_single_entry(
     response: Type[EntryResponseOne],
     request: Request,
     params: SingleEntryQueryParams,
-) -> EntryResponseOne:
+) -> Dict:
     from optimade.server.routers import ENTRY_COLLECTIONS
 
     params.check_params(request.query_params)
@@ -338,7 +338,7 @@ def get_single_entry(
     if results is not None and (fields or include_fields):
         results = handle_response_fields(results, fields, include_fields)[0]  # type: ignore[assignment]
 
-    return response(
+    return dict(
         links=links,
         data=results if results else None,
         meta=meta_values(

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,11 @@ with open(module_dir.joinpath("optimade/__init__.py")) as version_file:
 # Server minded
 elastic_deps = ["elasticsearch-dsl~=7.4,<8.0", "elasticsearch~=7.17"]
 mongo_deps = ["pymongo>=3.12.1,<5", "mongomock~=4.1"]
-server_deps = ["uvicorn~=0.19", "fastapi~=0.86,<0.99", "pyyaml~=6.0"] + mongo_deps
+server_deps = [
+    "uvicorn[standard]~=0.19",
+    "fastapi~=0.86,<0.99",
+    "pyyaml~=6.0",
+] + mongo_deps
 
 
 # Client minded

--- a/tests/server/test_client.py
+++ b/tests/server/test_client.py
@@ -12,7 +12,6 @@ import pytest
 
 from optimade.client.cli import _get
 from optimade.server.config import CONFIG, SupportedBackend
-from optimade.warnings import MissingExpectedField
 
 try:
     from optimade.client import OptimadeClient as OptimadeTestClient
@@ -115,24 +114,23 @@ def test_filter_validation(async_http_client, http_client, use_async):
 
 @pytest.mark.parametrize("use_async", [True, False])
 def test_client_response_fields(async_http_client, http_client, use_async):
-    with pytest.warns(MissingExpectedField):
-        cli = OptimadeClient(
-            base_urls=[TEST_URL],
-            use_async=use_async,
-            http_client=async_http_client if use_async else http_client,
-        )
-        results = cli.get(response_fields=["chemical_formula_reduced"])
-        for d in results["structures"][""][TEST_URL]["data"]:
-            assert "chemical_formula_reduced" in d["attributes"]
-            assert len(d["attributes"]) == 1
+    cli = OptimadeClient(
+        base_urls=[TEST_URL],
+        use_async=use_async,
+        http_client=async_http_client if use_async else http_client,
+    )
+    results = cli.get(response_fields=["chemical_formula_reduced"])
+    for d in results["structures"][""][TEST_URL]["data"]:
+        assert "chemical_formula_reduced" in d["attributes"]
+        assert len(d["attributes"]) == 1
 
-        results = cli.get(
-            response_fields=["chemical_formula_reduced", "cartesian_site_positions"]
-        )
-        for d in results["structures"][""][TEST_URL]["data"]:
-            assert "chemical_formula_reduced" in d["attributes"]
-            assert "cartesian_site_positions" in d["attributes"]
-            assert len(d["attributes"]) == 2
+    results = cli.get(
+        response_fields=["chemical_formula_reduced", "cartesian_site_positions"]
+    )
+    for d in results["structures"][""][TEST_URL]["data"]:
+        assert "chemical_formula_reduced" in d["attributes"]
+        assert "cartesian_site_positions" in d["attributes"]
+        assert len(d["attributes"]) == 2
 
 
 @pytest.mark.parametrize("use_async", [True, False])


### PR DESCRIPTION
This PR adds three optimisations, arising from the (ongoing) talk about optimizing FastAPI/pydantic at EuroPython2023 by Marcelo Tryle.

- Make sure `uvloop` and `httptools` are installed alongside `uvicorn`
- Avoid validating data twice in both the `get_entries` function and the routes
- Actually fix the `validate_api_response` option, now that I realise the FastAPI type hints were also validating...

Perf with mongomock:

Old version (current state of master):
```
$ ./wrk -t12 -c400 -d30s http://localhost:5000/v1/structures
Running 30s test @ http://localhost:5000/v1/structures
  12 threads and 400 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     0.00us    0.00us   0.00us    -nan%
    Req/Sec    10.73     15.34   121.00     91.48%
  368 requests in 30.08s, 14.28MB read
  Socket errors: connect 0, read 264, write 0, timeout 368
Requests/sec:     12.23
Transfer/sec:    486.22KB
```

New version with `VALIDATE_API_RESPONSE=true`:

```shell
$ ./wrk -t12 -c400 -d30s http://localhost:5000/v1/structures

Running 30s test @ http://localhost:5000/v1/structures
  12 threads and 400 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     0.00us    0.00us   0.00us    -nan%
    Req/Sec     9.88     12.00    80.00     90.49%
  701 requests in 30.10s, 27.22MB read
  Socket errors: connect 0, read 281, write 0, timeout 701
Requests/sec:     23.29
Transfer/sec:      0.90MB
```

New version with `VALIDATE_API_RESPONSE=false`:

```shell
$ ./wrk -t12 -c400 -d30s http://localhost:5000/v1/structures

Running 30s test @ http://localhost:5000/v1/structures
  12 threads and 400 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     0.00us    0.00us   0.00us    -nan%
    Req/Sec    10.14     11.96   171.00     91.84%
  1451 requests in 30.10s, 56.21MB read
  Socket errors: connect 0, read 113, write 0, timeout 1451
Requests/sec:     48.21
Transfer/sec:      1.87MB
```