### PR TITLE
Do not raise local OPTIMADE warnings at server level

### DIFF
--- a/optimade/server/middleware.py
+++ b/optimade/server/middleware.py
@@ -22,6 +22,7 @@ from optimade.server.config import CONFIG
 from optimade.server.routers.utils import BASE_URL_PREFIXES, get_base_url
 from optimade.warnings import (
     FieldValueNotRecognized,
+    LocalOptimadeWarning,
     OptimadeWarning,
     QueryParamNotUsed,
     TooManyValues,
@@ -359,6 +360,9 @@ class AddWarnings(BaseHTTPMiddleware):
             # If the Warning is not an OptimadeWarning or subclass thereof,
             # use the regular 'showwarning' function.
             warnings._showwarning_orig(message, category, filename, lineno, file, line)  # type: ignore[attr-defined]
+            return
+
+        if isinstance(message, LocalOptimadeWarning):
             return
 
         # Format warning

--- a/optimade/warnings.py
+++ b/optimade/warnings.py
@@ -45,6 +45,12 @@ class OptimadeWarning(Warning):
         return self.detail if self.detail is not None else ""
 
 
+class LocalOptimadeWarning(OptimadeWarning):
+    """A warning that is specific to a local implementation of the OPTIMADE API
+    and should not appear in the server log or response.
+    """
+
+
 class FieldValueNotRecognized(OptimadeWarning):
     """A field or value used in the request is not recognised by this implementation."""
 
@@ -57,7 +63,7 @@ class QueryParamNotUsed(OptimadeWarning):
     """A query parameter is not used in this request."""
 
 
-class MissingExpectedField(OptimadeWarning):
+class MissingExpectedField(LocalOptimadeWarning):
     """A field was provided with a null value when a related field was provided
     with a value."""
 


### PR DESCRIPTION
This PR removes the annoying feature that `MissingExpectedField` warnings pollute the server logs when a partial model is constructed. 