### PR TITLE
Allow already prefixed fields to be configured as provider fields

### DIFF
--- a/optimade/server/data/test_structures.json
+++ b/optimade/server/data/test_structures.json
@@ -73,7 +73,8 @@
           }
         ]
       }
-    }
+    },
+    "_exmpl_this_provider_field": "test"
   },
   {
     "_id": {
@@ -189,7 +190,8 @@
           }
         ]
       }
-    }
+    },
+    "_exmpl_this_provider_field": "test"
   },
   {
     "_id": {
@@ -314,7 +316,8 @@
           }
         ]
       }
-    }
+    },
+    "_exmpl_this_provider_field": "test"
   },
   {
     "_id": {
@@ -403,7 +406,8 @@
       "Mg"
     ],
     "structure_features": [],
-    "task_id": "mpf_23"
+    "task_id": "mpf_23",
+    "_exmpl_this_provider_field": "test"
   },
   {
     "_id": {
@@ -504,7 +508,8 @@
       "O"
     ],
     "structure_features": [],
-    "task_id": "mpf_30"
+    "task_id": "mpf_30",
+    "_exmpl_this_provider_field": "test"
   },
   {
     "_id": {
@@ -627,7 +632,8 @@
       "O"
     ],
     "structure_features": [],
-    "task_id": "mpf_110"
+    "task_id": "mpf_110",
+    "_exmpl_this_provider_field": "test"
   },
   {
     "_id": {
@@ -693,7 +699,8 @@
       "Ag"
     ],
     "structure_features": [],
-    "task_id": "mpf_200"
+    "task_id": "mpf_200",
+    "_exmpl_this_provider_field": "test"
   },
   {
     "_id": {
@@ -882,7 +889,8 @@
       "Te"
     ],
     "structure_features": [],
-    "task_id": "mpf_220"
+    "task_id": "mpf_220",
+    "_exmpl_this_provider_field": "test"
   },
   {
     "_id": {
@@ -1057,7 +1065,8 @@
       "S"
     ],
     "structure_features": [],
-    "task_id": "mpf_259"
+    "task_id": "mpf_259",
+    "_exmpl_this_provider_field": "test"
   },
   {
     "_id": {
@@ -1305,7 +1314,8 @@
       "N"
     ],
     "structure_features": [],
-    "task_id": "mpf_272"
+    "task_id": "mpf_272",
+    "_exmpl_this_provider_field": "test"
   },
   {
     "_id": {
@@ -1559,7 +1569,8 @@
       "O"
     ],
     "structure_features": [],
-    "task_id": "mpf_276"
+    "task_id": "mpf_276",
+    "_exmpl_this_provider_field": "test"
   },
   {
     "_id": {
@@ -1823,7 +1834,8 @@
       "S"
     ],
     "structure_features": [],
-    "task_id": "mpf_281"
+    "task_id": "mpf_281",
+    "_exmpl_this_provider_field": "test"
   },
   {
     "_id": {
@@ -2046,7 +2058,8 @@
       "S"
     ],
     "structure_features": [],
-    "task_id": "mpf_446"
+    "task_id": "mpf_446",
+    "_exmpl_this_provider_field": "test"
   },
   {
     "_id": {
@@ -2627,7 +2640,8 @@
       "P"
     ],
     "structure_features": [],
-    "task_id": "mpf_551"
+    "task_id": "mpf_551",
+    "_exmpl_this_provider_field": "test"
   },
   {
     "_id": {
@@ -2927,7 +2941,8 @@
       "S"
     ],
     "structure_features": [],
-    "task_id": "mpf_632"
+    "task_id": "mpf_632",
+    "_exmpl_this_provider_field": "test"
   },
   {
     "_id": {
@@ -3328,7 +3343,8 @@
       "Ti"
     ],
     "structure_features": [],
-    "task_id": "mpf_3803"
+    "task_id": "mpf_3803",
+    "_exmpl_this_provider_field": "test"
   },
   {
     "_id": {

--- a/optimade/server/entry_collections/entry_collections.py
+++ b/optimade/server/entry_collections/entry_collections.py
@@ -255,6 +255,8 @@ class EntryCollection(ABC):
             # All provider-specific fields
             self._all_fields |= {
                 f"_{self.provider_prefix}_{field_name}"
+                if not field_name.startswith("_")
+                else field_name
                 for field_name in self.provider_fields
             }
 

--- a/optimade/server/mappers/entries.py
+++ b/optimade/server/mappers/entries.py
@@ -92,16 +92,22 @@ class BaseResourceMapper:
         return (
             tuple(
                 (f"_{CONFIG.provider.prefix}_{field}", field)
+                if not field.startswith("_")
+                else (field, field)
                 for field in CONFIG.provider_fields.get(cls.ENDPOINT, [])
                 if isinstance(field, str)
             )
             + tuple(
                 (f"_{CONFIG.provider.prefix}_{field['name']}", field["name"])
+                if not field["name"].startswith("_")
+                else (field["name"], field["name"])
                 for field in CONFIG.provider_fields.get(cls.ENDPOINT, [])
                 if isinstance(field, dict)
             )
             + tuple(
                 (f"_{CONFIG.provider.prefix}_{field}", field)
+                if not field.startswith("_")
+                else (field, field)
                 for field in cls.PROVIDER_FIELDS
             )
             + tuple(CONFIG.aliases.get(cls.ENDPOINT, {}).items())

--- a/optimade/server/schemas.py
+++ b/optimade/server/schemas.py
@@ -94,7 +94,11 @@ def retrieve_queryable_properties(
             if isinstance(field, dict)
         ]
         for field in described_provider_fields:
-            name = f"_{CONFIG.provider.prefix}_{field['name']}"
+            name = (
+                f"_{CONFIG.provider.prefix}_{field['name']}"
+                if not field["name"].startswith("_")
+                else field["name"]
+            )
             properties[name] = {k: field[k] for k in field if k != "name"}
             properties[name]["sortable"] = field.get("sortable", True)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ filterwarnings = [
     "ignore:.*the imp module is deprecated in favour of importlib.*:DeprecationWarning",
     "ignore:.*has an unrecognised prefix.*:",
     "ignore:.*pkg_resources is deprecated as an API*:DeprecationWarning",
+    "ignore:.*Deprecated call to `pkg_resources.declare_namespace*:DeprecationWarning",
 ]
 testpaths = "tests"
 addopts = "-rs"

--- a/tests/server/test_client.py
+++ b/tests/server/test_client.py
@@ -480,7 +480,7 @@ def test_list_properties(
 
     results = cli.list_properties("structures")
     for database in results:
-        assert len(results[database]) == 21
+        assert len(results[database]) == 22
 
     results = cli.search_property("structures", "site")
     for database in results:

--- a/tests/test_config.json
+++ b/tests/test_config.json
@@ -18,7 +18,8 @@
     "provider_fields": {
         "structures": [
             "band_gap",
-            {"name": "chemsys", "type": "string", "description": "A string representing the chemical system in an ordered fashion"}
+            {"name": "chemsys", "type": "string", "description": "A string representing the chemical system in an ordered fashion"},
+            {"name": "_exmpl_this_provider_field", "type": "string", "description": "A field defined by this provider, added to this config to check whether the server will pass it through without adding two prefixes."}
         ]
     },
     "aliases": {


### PR DESCRIPTION
This PR allows provider fields to be put into the config that already contain the prefix. This can eventually be extended to cover definition providers too.

This is useful for the case where a local database has already been prepared with OPTIMADE in mind, and thus database fields already contain the relevant prefix, to avoid adding the prefix twice.