### PR TITLE
Migration to pydantic v2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,4 +56,4 @@ repos:
     hooks:
       - id: mypy
         name: "MyPy"
-        additional_dependencies: ["types-all", "pydantic~=1.10"]
+        additional_dependencies: ["types-all", "pydantic~=2.0"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,3 +57,5 @@ repos:
       - id: mypy
         name: "MyPy"
         additional_dependencies: ["types-all", "pydantic~=2.0"]
+        exclude: ^tests/.*$
+        args: [--check-untyped-defs]

--- a/docs/all_models.md
+++ b/docs/all_models.md
@@ -11,3 +11,6 @@ For example, the three OPTIMADE entry types, `structures`, `references` and `lin
 As well as validating data types when creating instances of these models, this package defines several OPTIMADE-specific validators that ensure consistency between fields (e.g., the value of `nsites` matches the number of positions provided in `cartesian_site_positions`).
 
 ::: optimade.models
+    options:
+      show_submodules: true
+      show_if_no_docstring: true

--- a/docs/api_reference/models/types.md
+++ b/docs/api_reference/models/types.md
@@ -1,0 +1,5 @@
+# types
+
+::: optimade.models.types
+    options:
+      show_if_no_docstring: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,29 +70,38 @@ plugins:
       lang: en
   - mkdocstrings:
       default_handler: python
+      enable_inventory: true
       handlers:
         python:
           options:
+            # General options
+            show_source: true
+            show_bases: true
+
+            # Heading options
+            heading_level: 2
             show_root_heading: false
             show_root_toc_entry: true
             show_root_full_path: true
             show_object_full_path: false
             show_category_heading: false
-            show_if_no_docstring: false
-            show_source: true
-            show_bases: true
-            group_by_category: true
-            heading_level: 2
+
+            # Members options
+            inherited_members: true
+            members: true
             filters:
               - "!^_[^_]"
               - "!__json_encoder__$"
               - "!__all__$"
               - "!__config__$"
               - "!ValidatorResults$"
-            members: true
-            inherited_members: true
+            group_by_category: true
+
+            # Docstring options
             docstring_style: google
-            enable_inventory: true
+            docstring_options:
+              replace_admonitions: true
+            show_if_no_docstring: false
   - awesome-pages
   - autorefs
 

--- a/openapi/index_openapi.json
+++ b/openapi/index_openapi.json
@@ -106,164 +106,164 @@
         "operationId": "get_links_links_get",
         "parameters": [
           {
-            "description": "A filter string, in the format described in section API Filtering Format Specification of the specification.",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "title": "Filter",
-              "description": "A filter string, in the format described in section API Filtering Format Specification of the specification.",
-              "default": ""
-            },
             "name": "filter",
-            "in": "query"
-          },
-          {
-            "description": "The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`",
+            "in": "query",
             "required": false,
             "schema": {
               "type": "string",
-              "title": "Response Format",
-              "description": "The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`",
-              "default": "json"
+              "description": "A filter string, in the format described in section API Filtering Format Specification of the specification.",
+              "default": "",
+              "title": "Filter"
             },
-            "name": "response_format",
-            "in": "query"
+            "description": "A filter string, in the format described in section API Filtering Format Specification of the specification."
           },
           {
-            "description": "An email address of the user making the request.\nThe email SHOULD be that of a person and not an automatic system.\nExample: `http://example.com/v1/structures?email_address=user@example.com`",
+            "name": "response_format",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`",
+              "default": "json",
+              "title": "Response Format"
+            },
+            "description": "The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`"
+          },
+          {
+            "name": "email_address",
+            "in": "query",
             "required": false,
             "schema": {
               "type": "string",
               "format": "email",
-              "title": "Email Address",
               "description": "An email address of the user making the request.\nThe email SHOULD be that of a person and not an automatic system.\nExample: `http://example.com/v1/structures?email_address=user@example.com`",
-              "default": ""
+              "default": "",
+              "title": "Email Address"
             },
-            "name": "email_address",
-            "in": "query"
+            "description": "An email address of the user making the request.\nThe email SHOULD be that of a person and not an automatic system.\nExample: `http://example.com/v1/structures?email_address=user@example.com`"
           },
           {
-            "description": "A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "pattern": "([a-z_][a-z_0-9]*(,[a-z_][a-z_0-9]*)*)?",
-              "title": "Response Fields",
-              "description": "A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`",
-              "default": ""
-            },
             "name": "response_fields",
-            "in": "query"
-          },
-          {
-            "description": "If supporting sortable queries, an implementation MUST use the `sort` query parameter with format as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-sorting).\n\nAn implementation MAY support multiple sort fields for a single query.\nIf it does, it again MUST conform to the JSON API 1.0 specification.\n\nIf an implementation supports sorting for an entry listing endpoint, then the `/info/<entries>` endpoint MUST include, for each field name `<fieldname>` in its `data.properties.<fieldname>` response value that can be used for sorting, the key `sortable` with value `true`.\nIf a field name under an entry listing endpoint supporting sorting cannot be used for sorting, the server MUST either leave out the `sortable` key or set it equal to `false` for the specific field name.\nThe set of field names, with `sortable` equal to `true` are allowed to be used in the \"sort fields\" list according to its definition in the JSON API 1.0 specification.\nThe field `sortable` is in addition to each property description and other OPTIONAL fields.\nAn example is shown in the section Entry Listing Info Endpoints.",
+            "in": "query",
             "required": false,
             "schema": {
               "type": "string",
               "pattern": "([a-z_][a-z_0-9]*(,[a-z_][a-z_0-9]*)*)?",
-              "title": "Sort",
-              "description": "If supporting sortable queries, an implementation MUST use the `sort` query parameter with format as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-sorting).\n\nAn implementation MAY support multiple sort fields for a single query.\nIf it does, it again MUST conform to the JSON API 1.0 specification.\n\nIf an implementation supports sorting for an entry listing endpoint, then the `/info/<entries>` endpoint MUST include, for each field name `<fieldname>` in its `data.properties.<fieldname>` response value that can be used for sorting, the key `sortable` with value `true`.\nIf a field name under an entry listing endpoint supporting sorting cannot be used for sorting, the server MUST either leave out the `sortable` key or set it equal to `false` for the specific field name.\nThe set of field names, with `sortable` equal to `true` are allowed to be used in the \"sort fields\" list according to its definition in the JSON API 1.0 specification.\nThe field `sortable` is in addition to each property description and other OPTIONAL fields.\nAn example is shown in the section Entry Listing Info Endpoints.",
-              "default": ""
+              "description": "A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`",
+              "default": "",
+              "title": "Response Fields"
             },
+            "description": "A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`"
+          },
+          {
             "name": "sort",
-            "in": "query"
-          },
-          {
-            "description": "Sets a numerical limit on the number of entries returned.\nSee [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-pagination).\nThe API implementation MUST return no more than the number specified.\nIt MAY return fewer.\nThe database MAY have a maximum limit and not accept larger numbers (in which case an error code -- 403 Forbidden -- MUST be returned).\nThe default limit value is up to the API implementation to decide.\nExample: `http://example.com/optimade/v1/structures?page_limit=100`",
+            "in": "query",
             "required": false,
             "schema": {
-              "type": "integer",
-              "minimum": 0.0,
-              "title": "Page Limit",
-              "description": "Sets a numerical limit on the number of entries returned.\nSee [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-pagination).\nThe API implementation MUST return no more than the number specified.\nIt MAY return fewer.\nThe database MAY have a maximum limit and not accept larger numbers (in which case an error code -- 403 Forbidden -- MUST be returned).\nThe default limit value is up to the API implementation to decide.\nExample: `http://example.com/optimade/v1/structures?page_limit=100`",
-              "default": 20
+              "type": "string",
+              "pattern": "([a-z_][a-z_0-9]*(,[a-z_][a-z_0-9]*)*)?",
+              "description": "If supporting sortable queries, an implementation MUST use the `sort` query parameter with format as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-sorting).\n\nAn implementation MAY support multiple sort fields for a single query.\nIf it does, it again MUST conform to the JSON API 1.0 specification.\n\nIf an implementation supports sorting for an entry listing endpoint, then the `/info/<entries>` endpoint MUST include, for each field name `<fieldname>` in its `data.properties.<fieldname>` response value that can be used for sorting, the key `sortable` with value `true`.\nIf a field name under an entry listing endpoint supporting sorting cannot be used for sorting, the server MUST either leave out the `sortable` key or set it equal to `false` for the specific field name.\nThe set of field names, with `sortable` equal to `true` are allowed to be used in the \"sort fields\" list according to its definition in the JSON API 1.0 specification.\nThe field `sortable` is in addition to each property description and other OPTIONAL fields.\nAn example is shown in the section Entry Listing Info Endpoints.",
+              "default": "",
+              "title": "Sort"
             },
+            "description": "If supporting sortable queries, an implementation MUST use the `sort` query parameter with format as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-sorting).\n\nAn implementation MAY support multiple sort fields for a single query.\nIf it does, it again MUST conform to the JSON API 1.0 specification.\n\nIf an implementation supports sorting for an entry listing endpoint, then the `/info/<entries>` endpoint MUST include, for each field name `<fieldname>` in its `data.properties.<fieldname>` response value that can be used for sorting, the key `sortable` with value `true`.\nIf a field name under an entry listing endpoint supporting sorting cannot be used for sorting, the server MUST either leave out the `sortable` key or set it equal to `false` for the specific field name.\nThe set of field names, with `sortable` equal to `true` are allowed to be used in the \"sort fields\" list according to its definition in the JSON API 1.0 specification.\nThe field `sortable` is in addition to each property description and other OPTIONAL fields.\nAn example is shown in the section Entry Listing Info Endpoints."
+          },
+          {
             "name": "page_limit",
-            "in": "query"
-          },
-          {
-            "description": "RECOMMENDED for use with _offset-based_ pagination: using `page_offset` and `page_limit` is RECOMMENDED.\nExample: Skip 50 structures and fetch up to 100: `/structures?page_offset=50&page_limit=100`.",
+            "in": "query",
             "required": false,
             "schema": {
               "type": "integer",
-              "minimum": 0.0,
-              "title": "Page Offset",
-              "description": "RECOMMENDED for use with _offset-based_ pagination: using `page_offset` and `page_limit` is RECOMMENDED.\nExample: Skip 50 structures and fetch up to 100: `/structures?page_offset=50&page_limit=100`.",
-              "default": 0
+              "minimum": 0,
+              "description": "Sets a numerical limit on the number of entries returned.\nSee [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-pagination).\nThe API implementation MUST return no more than the number specified.\nIt MAY return fewer.\nThe database MAY have a maximum limit and not accept larger numbers (in which case an error code -- 403 Forbidden -- MUST be returned).\nThe default limit value is up to the API implementation to decide.\nExample: `http://example.com/optimade/v1/structures?page_limit=100`",
+              "default": 20,
+              "title": "Page Limit"
             },
+            "description": "Sets a numerical limit on the number of entries returned.\nSee [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-pagination).\nThe API implementation MUST return no more than the number specified.\nIt MAY return fewer.\nThe database MAY have a maximum limit and not accept larger numbers (in which case an error code -- 403 Forbidden -- MUST be returned).\nThe default limit value is up to the API implementation to decide.\nExample: `http://example.com/optimade/v1/structures?page_limit=100`"
+          },
+          {
             "name": "page_offset",
-            "in": "query"
-          },
-          {
-            "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`.",
+            "in": "query",
             "required": false,
             "schema": {
               "type": "integer",
-              "title": "Page Number",
-              "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`."
+              "minimum": 0,
+              "description": "RECOMMENDED for use with _offset-based_ pagination: using `page_offset` and `page_limit` is RECOMMENDED.\nExample: Skip 50 structures and fetch up to 100: `/structures?page_offset=50&page_limit=100`.",
+              "default": 0,
+              "title": "Page Offset"
             },
+            "description": "RECOMMENDED for use with _offset-based_ pagination: using `page_offset` and `page_limit` is RECOMMENDED.\nExample: Skip 50 structures and fetch up to 100: `/structures?page_offset=50&page_limit=100`."
+          },
+          {
             "name": "page_number",
-            "in": "query"
-          },
-          {
-            "description": "RECOMMENDED for use with _cursor-based_ pagination: using `page_cursor` and `page_limit` is RECOMMENDED.",
+            "in": "query",
             "required": false,
             "schema": {
               "type": "integer",
-              "minimum": 0.0,
-              "title": "Page Cursor",
-              "description": "RECOMMENDED for use with _cursor-based_ pagination: using `page_cursor` and `page_limit` is RECOMMENDED.",
-              "default": 0
+              "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`.",
+              "title": "Page Number"
             },
+            "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`."
+          },
+          {
             "name": "page_cursor",
-            "in": "query"
-          },
-          {
-            "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.\nExample: Fetch up to 100 structures above sort-field value 4000 (in this example, server chooses to fetch results sorted by increasing `id`, so `page_above` value refers to an `id` value): `/structures?page_above=4000&page_limit=100`.",
+            "in": "query",
             "required": false,
             "schema": {
-              "type": "string",
-              "title": "Page Above",
-              "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.\nExample: Fetch up to 100 structures above sort-field value 4000 (in this example, server chooses to fetch results sorted by increasing `id`, so `page_above` value refers to an `id` value): `/structures?page_above=4000&page_limit=100`."
+              "type": "integer",
+              "minimum": 0,
+              "description": "RECOMMENDED for use with _cursor-based_ pagination: using `page_cursor` and `page_limit` is RECOMMENDED.",
+              "default": 0,
+              "title": "Page Cursor"
             },
+            "description": "RECOMMENDED for use with _cursor-based_ pagination: using `page_cursor` and `page_limit` is RECOMMENDED."
+          },
+          {
             "name": "page_above",
-            "in": "query"
-          },
-          {
-            "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.",
+            "in": "query",
             "required": false,
             "schema": {
               "type": "string",
-              "title": "Page Below",
-              "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED."
+              "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.\nExample: Fetch up to 100 structures above sort-field value 4000 (in this example, server chooses to fetch results sorted by increasing `id`, so `page_above` value refers to an `id` value): `/structures?page_above=4000&page_limit=100`.",
+              "title": "Page Above"
             },
+            "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.\nExample: Fetch up to 100 structures above sort-field value 4000 (in this example, server chooses to fetch results sorted by increasing `id`, so `page_above` value refers to an `id` value): `/structures?page_above=4000&page_limit=100`."
+          },
+          {
             "name": "page_below",
-            "in": "query"
-          },
-          {
-            "description": "A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of \"relationship paths\", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`.",
+            "in": "query",
             "required": false,
             "schema": {
               "type": "string",
-              "title": "Include",
-              "description": "A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of \"relationship paths\", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`.",
-              "default": "references"
+              "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.",
+              "title": "Page Below"
             },
-            "name": "include",
-            "in": "query"
+            "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED."
           },
           {
-            "description": "If the client provides the parameter, the value SHOULD have the format `vMAJOR` or `vMAJOR.MINOR`, where MAJOR is a major version and MINOR is a minor version of the API. For example, if a client appends `api_hint=v1.0` to the query string, the hint provided is for major version 1 and minor version 0.",
+            "name": "include",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of \"relationship paths\", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`.",
+              "default": "references",
+              "title": "Include"
+            },
+            "description": "A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of \"relationship paths\", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`."
+          },
+          {
+            "name": "api_hint",
+            "in": "query",
             "required": false,
             "schema": {
               "type": "string",
               "pattern": "(v[0-9]+(\\.[0-9]+)?)?",
-              "title": "Api Hint",
               "description": "If the client provides the parameter, the value SHOULD have the format `vMAJOR` or `vMAJOR.MINOR`, where MAJOR is a major version and MINOR is a minor version of the API. For example, if a client appends `api_hint=v1.0` to the query string, the hint provided is for major version 1 and minor version 0.",
-              "default": ""
+              "default": "",
+              "title": "Api Hint"
             },
-            "name": "api_hint",
-            "in": "query"
+            "description": "If the client provides the parameter, the value SHOULD have the format `vMAJOR` or `vMAJOR.MINOR`, where MAJOR is a major version and MINOR is a minor version of the API. For example, if a client appends `api_hint=v1.0` to the query string, the hint provided is for major version 1 and minor version 0."
           }
         ],
         "responses": {
@@ -376,6 +376,7 @@
   "components": {
     "schemas": {
       "Aggregate": {
+        "type": "string",
         "enum": [
           "ok",
           "test",
@@ -387,6 +388,7 @@
       },
       "Attributes": {
         "properties": {},
+        "additionalProperties": true,
         "type": "object",
         "title": "Attributes",
         "description": "Members of the attributes object (\"attributes\") represent information about the resource object in which it's defined.\nThe keys for Attributes MUST NOT be:\n    relationships\n    links\n    id\n    type"
@@ -395,9 +397,8 @@
         "properties": {
           "url": {
             "type": "string",
-            "maxLength": 65536,
             "minLength": 1,
-            "pattern": ".+/v[0-1](\\.[0-9]+)*/?$",
+            "pattern": "^.+/v[0-1](\\.[0-9]+)*/?$",
             "format": "uri",
             "title": "Url",
             "description": "A string specifying a versioned base URL that MUST adhere to the rules in section Base URL"
@@ -407,7 +408,7 @@
             "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "title": "Version",
             "description": "A string containing the full version number of the API served at that versioned base URL.\nThe version number string MUST NOT be prefixed by, e.g., 'v'.\nExamples: `1.0.0`, `1.0.0-rc.2`.",
-            "example": [
+            "examples": [
               "0.10.1",
               "1.0.0-rc.2",
               "1.2.3-rc.5+develop"
@@ -430,6 +431,7 @@
             "description": "OPTIONAL human-readable description of the relationship."
           }
         },
+        "additionalProperties": true,
         "type": "object",
         "required": [
           "description"
@@ -450,12 +452,14 @@
             "description": "Resource type"
           },
           "meta": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/BaseRelationshipMeta"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Meta",
             "description": "Relationship meta field. MUST contain 'description' if supplied."
           }
         },
@@ -470,21 +474,25 @@
       "EntryRelationships": {
         "properties": {
           "references": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/ReferenceRelationship"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "References",
             "description": "Object containing links to relationships with entries of the `references` type."
           },
           "structures": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/StructureRelationship"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Structures",
             "description": "Object containing links to relationships with entries of the `structures` type."
           }
         },
@@ -498,32 +506,36 @@
             "type": "string",
             "title": "Id",
             "description": "An entry's ID as defined in section Definition of Terms.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n\n- **Examples**:\n    - `\"db/1234567\"`\n    - `\"cod/2000000\"`\n    - `\"cod/2000000@1234567\"`\n    - `\"nomad/L1234567890\"`\n    - `\"42\"`",
-            "x-optimade-support": "must",
-            "x-optimade-queryable": "must"
+            "x-optimade-queryable": "must",
+            "x-optimade-support": "must"
           },
           "type": {
             "type": "string",
             "title": "Type",
             "description": "The name of the type of an entry.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n    - MUST be an existing entry type.\n    - The entry of type `<type>` and ID `<id>` MUST be returned in response to a request for `/<type>/<id>` under the versioned base URL.\n\n- **Example**: `\"structures\"`",
-            "x-optimade-support": "must",
-            "x-optimade-queryable": "must"
+            "x-optimade-queryable": "must",
+            "x-optimade-support": "must"
           },
           "links": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/ResourceLinks"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Links",
             "description": "a links object containing links related to the resource."
           },
           "meta": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/Meta"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Meta",
             "description": "a meta object containing non-standard meta-information about a resource that can not be represented as an attribute or relationship."
           },
           "attributes": {
@@ -532,16 +544,17 @@
                 "$ref": "#/components/schemas/EntryResourceAttributes"
               }
             ],
-            "title": "Attributes",
             "description": "A dictionary, containing key-value pairs representing the entry's properties, except for `type` and `id`.\nDatabase-provider-specific properties need to include the database-provider-specific prefix (see section on Database-Provider-Specific Namespace Prefixes)."
           },
           "relationships": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/EntryRelationships"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Relationships",
             "description": "A dictionary containing references to other entries according to the description in section Relationships encoded as [JSON API Relationships](https://jsonapi.org/format/1.0/#document-resource-object-relationships).\nThe OPTIONAL human-readable description of the relationship MAY be provided in the `description` field inside the `meta` dictionary of the JSON API resource identifier object."
           }
         },
@@ -557,21 +570,36 @@
       "EntryResourceAttributes": {
         "properties": {
           "immutable_id": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Immutable Id",
             "description": "The entry's immutable ID (e.g., an UUID). This is important for databases having preferred IDs that point to \"the latest version\" of a record, but still offer access to older variants. This ID maps to the version-specific record, in case it changes in the future.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n\n- **Examples**:\n    - `\"8bd3e750-b477-41a0-9b11-3a799f21b44f\"`\n    - `\"fjeiwoj,54;@=%<>#32\"` (Strings that are not URL-safe are allowed.)",
-            "x-optimade-support": "optional",
-            "x-optimade-queryable": "must"
+            "x-optimade-queryable": "must",
+            "x-optimade-support": "optional"
           },
           "last_modified": {
-            "type": "string",
-            "format": "date-time",
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Last Modified",
             "description": "Date and time representing when the entry was last modified.\n\n- **Type**: timestamp.\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response unless the query parameter `response_fields` is present and does not include this property.\n\n- **Example**:\n    - As part of JSON response format: `\"2007-04-05T14:30:20Z\"` (i.e., encoded as an [RFC 3339 Internet Date/Time Format](https://tools.ietf.org/html/rfc3339#section-5.6) string.)",
-            "x-optimade-support": "should",
-            "x-optimade-queryable": "must"
+            "x-optimade-queryable": "must",
+            "x-optimade-support": "should"
           }
         },
+        "additionalProperties": true,
         "type": "object",
         "required": [
           "last_modified"
@@ -582,55 +610,96 @@
       "Error": {
         "properties": {
           "id": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Id",
             "description": "A unique identifier for this particular occurrence of the problem."
           },
           "links": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/ErrorLinks"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Links",
             "description": "A links object storing about"
           },
           "status": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Status",
             "description": "the HTTP status code applicable to this problem, expressed as a string value."
           },
           "code": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Code",
             "description": "an application-specific error code, expressed as a string value."
           },
           "title": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Title",
             "description": "A short, human-readable summary of the problem. It **SHOULD NOT** change from occurrence to occurrence of the problem, except for purposes of localization."
           },
           "detail": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Detail",
             "description": "A human-readable explanation specific to this occurrence of the problem."
           },
           "source": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/ErrorSource"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Source",
             "description": "An object containing references to the source of the error"
           },
           "meta": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/Meta"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Meta",
             "description": "a meta object containing non-standard meta-information about the error."
           }
         },
@@ -644,12 +713,14 @@
             "anyOf": [
               {
                 "type": "string",
-                "maxLength": 65536,
                 "minLength": 1,
                 "format": "uri"
               },
               {
                 "$ref": "#/components/schemas/Link"
+              },
+              {
+                "type": "null"
               }
             ],
             "title": "About",
@@ -672,6 +743,9 @@
                   "$ref": "#/components/schemas/Resource"
                 },
                 "type": "array"
+              },
+              {
+                "type": "null"
               }
             ],
             "uniqueItems": true,
@@ -684,7 +758,6 @@
                 "$ref": "#/components/schemas/ResponseMeta"
               }
             ],
-            "title": "Meta",
             "description": "A meta object containing non-standard information."
           },
           "errors": {
@@ -697,30 +770,41 @@
             "description": "A list of OPTIMADE-specific JSON API error objects, where the field detail MUST be present."
           },
           "included": {
-            "items": {
-              "$ref": "#/components/schemas/Resource"
-            },
-            "type": "array",
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/Resource"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "uniqueItems": true,
             "title": "Included",
             "description": "A list of unique included resources"
           },
           "links": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/ToplevelLinks"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Links",
             "description": "Links associated with the primary data or errors"
           },
           "jsonapi": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/JsonApi"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Jsonapi",
             "description": "Information about the JSON API used"
           }
         },
@@ -735,12 +819,26 @@
       "ErrorSource": {
         "properties": {
           "pointer": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Pointer",
             "description": "a JSON Pointer [RFC6901] to the associated entity in the request document [e.g. \"/data\" for a primary data object, or \"/data/attributes/title\" for a specific attribute]."
           },
           "parameter": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Parameter",
             "description": "a string indicating which URI query parameter caused the error."
           }
@@ -752,12 +850,26 @@
       "Implementation": {
         "properties": {
           "name": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Name",
             "description": "name of the implementation"
           },
           "version": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Version",
             "description": "version string of the current implementation"
           },
@@ -765,12 +877,14 @@
             "anyOf": [
               {
                 "type": "string",
-                "maxLength": 65536,
                 "minLength": 1,
                 "format": "uri"
               },
               {
                 "$ref": "#/components/schemas/Link"
+              },
+              {
+                "type": "null"
               }
             ],
             "title": "Homepage",
@@ -780,36 +894,42 @@
             "anyOf": [
               {
                 "type": "string",
-                "maxLength": 65536,
                 "minLength": 1,
                 "format": "uri"
               },
               {
                 "$ref": "#/components/schemas/Link"
+              },
+              {
+                "type": "null"
               }
             ],
             "title": "Source Url",
             "description": "A [JSON API links object](http://jsonapi.org/format/1.0/#document-links) pointing to the implementation source, either downloadable archive or version control system."
           },
           "maintainer": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/ImplementationMaintainer"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Maintainer",
             "description": "A dictionary providing details about the maintainer of the implementation."
           },
           "issue_tracker": {
             "anyOf": [
               {
                 "type": "string",
-                "maxLength": 65536,
                 "minLength": 1,
                 "format": "uri"
               },
               {
                 "$ref": "#/components/schemas/Link"
+              },
+              {
+                "type": "null"
               }
             ],
             "title": "Issue Tracker",
@@ -843,7 +963,7 @@
             "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "title": "Api Version",
             "description": "Presently used full version of the OPTIMADE API.\nThe version number string MUST NOT be prefixed by, e.g., \"v\".\nExamples: `1.0.0`, `1.0.0-rc.2`.",
-            "example": [
+            "examples": [
               "0.10.1",
               "1.0.0-rc.2",
               "1.2.3-rc.5+develop"
@@ -907,43 +1027,52 @@
       "IndexInfoResource": {
         "properties": {
           "id": {
-            "type": "string",
-            "pattern": "^/$",
+            "const": "/",
             "title": "Id",
             "default": "/"
           },
           "type": {
-            "type": "string",
-            "pattern": "^info$",
+            "const": "info",
             "title": "Type",
             "default": "info"
           },
           "links": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/ResourceLinks"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Links",
             "description": "a links object containing links related to the resource."
           },
           "meta": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/Meta"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Meta",
             "description": "a meta object containing non-standard meta-information about a resource that can not be represented as an attribute or relationship."
           },
           "attributes": {
             "$ref": "#/components/schemas/IndexInfoAttributes"
           },
           "relationships": {
-            "additionalProperties": {
-              "$ref": "#/components/schemas/IndexRelationship"
-            },
-            "type": "object",
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "$ref": "#/components/schemas/IndexRelationship"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Relationships",
             "description": "Reference to the Links identifier object under the `links` endpoint that the provider has chosen as their 'default' OPTIMADE API database.\nA client SHOULD present this database as the first choice when an end-user chooses this provider."
           }
@@ -966,7 +1095,6 @@
                 "$ref": "#/components/schemas/IndexInfoResource"
               }
             ],
-            "title": "Data",
             "description": "Index meta-database /info data."
           },
           "meta": {
@@ -975,43 +1103,60 @@
                 "$ref": "#/components/schemas/ResponseMeta"
               }
             ],
-            "title": "Meta",
             "description": "A meta object containing non-standard information"
           },
           "errors": {
-            "items": {
-              "$ref": "#/components/schemas/Error"
-            },
-            "type": "array",
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "uniqueItems": true,
             "title": "Errors",
             "description": "A list of unique errors"
           },
           "included": {
-            "items": {
-              "$ref": "#/components/schemas/Resource"
-            },
-            "type": "array",
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/Resource"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "uniqueItems": true,
             "title": "Included",
             "description": "A list of unique included resources"
           },
           "links": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/ToplevelLinks"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Links",
             "description": "Links associated with the primary data or errors"
           },
           "jsonapi": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/JsonApi"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Jsonapi",
             "description": "Information about the JSON API used"
           }
         },
@@ -1020,18 +1165,19 @@
           "data",
           "meta"
         ],
-        "title": "IndexInfoResponse",
-        "description": "errors are not allowed"
+        "title": "IndexInfoResponse"
       },
       "IndexRelationship": {
         "properties": {
           "data": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/RelatedLinksResource"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Data",
             "description": "[JSON API resource linkage](http://jsonapi.org/format/1.0/#document-links).\nIt MUST be either `null` or contain a single Links identifier object with the fields `id` and `type`"
           }
         },
@@ -1051,12 +1197,14 @@
             "default": "1.0"
           },
           "meta": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/Meta"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Meta",
             "description": "Non-standard meta information"
           }
         },
@@ -1068,19 +1216,20 @@
         "properties": {
           "href": {
             "type": "string",
-            "maxLength": 65536,
             "minLength": 1,
             "format": "uri",
             "title": "Href",
-            "description": "a string containing the link\u2019s URL."
+            "description": "a string containing the link's URL."
           },
           "meta": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/Meta"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Meta",
             "description": "a meta object containing non-standard meta-information about the link."
           }
         },
@@ -1092,6 +1241,7 @@
         "description": "A link **MUST** be represented as either: a string containing the link's URL or a link object."
       },
       "LinkType": {
+        "type": "string",
         "enum": [
           "child",
           "root",
@@ -1107,32 +1257,36 @@
             "type": "string",
             "title": "Id",
             "description": "An entry's ID as defined in section Definition of Terms.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n\n- **Examples**:\n    - `\"db/1234567\"`\n    - `\"cod/2000000\"`\n    - `\"cod/2000000@1234567\"`\n    - `\"nomad/L1234567890\"`\n    - `\"42\"`",
-            "x-optimade-support": "must",
-            "x-optimade-queryable": "must"
+            "x-optimade-queryable": "must",
+            "x-optimade-support": "must"
           },
           "type": {
-            "type": "string",
+            "const": "links",
             "pattern": "^links$",
             "title": "Type",
             "description": "These objects are described in detail in the section Links Endpoint",
             "default": "links"
           },
           "links": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/ResourceLinks"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Links",
             "description": "a links object containing links related to the resource."
           },
           "meta": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/Meta"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Meta",
             "description": "a meta object containing non-standard meta-information about a resource that can not be represented as an attribute or relationship."
           },
           "attributes": {
@@ -1141,16 +1295,17 @@
                 "$ref": "#/components/schemas/LinksResourceAttributes"
               }
             ],
-            "title": "Attributes",
             "description": "A dictionary containing key-value pairs representing the Links resource's properties."
           },
           "relationships": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/EntryRelationships"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Relationships",
             "description": "A dictionary containing references to other entries according to the description in section Relationships encoded as [JSON API Relationships](https://jsonapi.org/format/1.0/#document-resource-object-relationships).\nThe OPTIONAL human-readable description of the relationship MAY be provided in the `description` field inside the `meta` dictionary of the JSON API resource identifier object."
           }
         },
@@ -1179,12 +1334,14 @@
             "anyOf": [
               {
                 "type": "string",
-                "maxLength": 65536,
                 "minLength": 1,
                 "format": "uri"
               },
               {
                 "$ref": "#/components/schemas/Link"
+              },
+              {
+                "type": "null"
               }
             ],
             "title": "Base Url",
@@ -1194,12 +1351,14 @@
             "anyOf": [
               {
                 "type": "string",
-                "maxLength": 65536,
                 "minLength": 1,
                 "format": "uri"
               },
               {
                 "$ref": "#/components/schemas/Link"
+              },
+              {
+                "type": "null"
               }
             ],
             "title": "Homepage",
@@ -1215,9 +1374,12 @@
             "description": "The type of the linked relation.\nMUST be one of these values: 'child', 'root', 'external', 'providers'."
           },
           "aggregate": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/Aggregate"
+              },
+              {
+                "type": "null"
               }
             ],
             "title": "Aggregate",
@@ -1225,11 +1387,19 @@
             "default": "ok"
           },
           "no_aggregate_reason": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "No Aggregate Reason",
             "description": "An OPTIONAL human-readable string indicating the reason for suggesting not to aggregate results following the link.\nIt SHOULD NOT be present if `aggregate`=`ok`."
           }
         },
+        "additionalProperties": true,
         "type": "object",
         "required": [
           "name",
@@ -1268,14 +1438,20 @@
                 "$ref": "#/components/schemas/ResponseMeta"
               }
             ],
-            "title": "Meta",
             "description": "A meta object containing non-standard information"
           },
           "errors": {
-            "items": {
-              "$ref": "#/components/schemas/Error"
-            },
-            "type": "array",
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "uniqueItems": true,
             "title": "Errors",
             "description": "A list of unique errors"
@@ -1293,27 +1469,35 @@
                   "type": "object"
                 },
                 "type": "array"
+              },
+              {
+                "type": "null"
               }
             ],
             "uniqueItems": true,
-            "title": "Included"
+            "title": "Included",
+            "description": "A list of unique included OPTIMADE entry resources."
           },
           "links": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/ToplevelLinks"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Links",
             "description": "Links associated with the primary data or errors"
           },
           "jsonapi": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/JsonApi"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Jsonapi",
             "description": "Information about the JSON API used"
           }
         },
@@ -1322,11 +1506,11 @@
           "data",
           "meta"
         ],
-        "title": "LinksResponse",
-        "description": "errors are not allowed"
+        "title": "LinksResponse"
       },
       "Meta": {
         "properties": {},
+        "additionalProperties": true,
         "type": "object",
         "title": "Meta",
         "description": "Non-standard meta-information that can not be represented as an attribute or relationship."
@@ -1334,31 +1518,61 @@
       "OptimadeError": {
         "properties": {
           "id": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Id",
             "description": "A unique identifier for this particular occurrence of the problem."
           },
           "links": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/ErrorLinks"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Links",
             "description": "A links object storing about"
           },
           "status": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Status",
             "description": "the HTTP status code applicable to this problem, expressed as a string value."
           },
           "code": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Code",
             "description": "an application-specific error code, expressed as a string value."
           },
           "title": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Title",
             "description": "A short, human-readable summary of the problem. It **SHOULD NOT** change from occurrence to occurrence of the problem, except for purposes of localization."
           },
@@ -1368,21 +1582,25 @@
             "description": "A human-readable explanation specific to this occurrence of the problem."
           },
           "source": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/ErrorSource"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Source",
             "description": "An object containing references to the source of the error"
           },
           "meta": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/Meta"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Meta",
             "description": "a meta object containing non-standard meta-information about the error."
           }
         },
@@ -1415,12 +1633,14 @@
             "anyOf": [
               {
                 "type": "string",
-                "maxLength": 65536,
                 "minLength": 1,
                 "format": "uri"
               },
               {
                 "$ref": "#/components/schemas/Link"
+              },
+              {
+                "type": "null"
               }
             ],
             "title": "Homepage",
@@ -1439,12 +1659,14 @@
       "ReferenceRelationship": {
         "properties": {
           "links": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/RelationshipLinks"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Links",
             "description": "a links object containing at least one of the following: self, related"
           },
           "data": {
@@ -1457,6 +1679,9 @@
                   "$ref": "#/components/schemas/BaseRelationshipResource"
                 },
                 "type": "array"
+              },
+              {
+                "type": "null"
               }
             ],
             "uniqueItems": true,
@@ -1464,18 +1689,19 @@
             "description": "Resource linkage"
           },
           "meta": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/Meta"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Meta",
             "description": "a meta object that contains non-standard meta-information about the relationship."
           }
         },
         "type": "object",
-        "title": "ReferenceRelationship",
-        "description": "Similar to normal JSON API relationship, but with addition of OPTIONAL meta field for a resource."
+        "title": "ReferenceRelationship"
       },
       "RelatedLinksResource": {
         "properties": {
@@ -1485,8 +1711,7 @@
             "description": "Resource ID"
           },
           "type": {
-            "type": "string",
-            "pattern": "^links$",
+            "const": "links",
             "title": "Type",
             "default": "links"
           }
@@ -1505,12 +1730,14 @@
             "anyOf": [
               {
                 "type": "string",
-                "maxLength": 65536,
                 "minLength": 1,
                 "format": "uri"
               },
               {
                 "$ref": "#/components/schemas/Link"
+              },
+              {
+                "type": "null"
               }
             ],
             "title": "Self",
@@ -1520,12 +1747,14 @@
             "anyOf": [
               {
                 "type": "string",
-                "maxLength": 65536,
                 "minLength": 1,
                 "format": "uri"
               },
               {
                 "$ref": "#/components/schemas/Link"
+              },
+              {
+                "type": "null"
               }
             ],
             "title": "Related",
@@ -1555,39 +1784,47 @@
             "description": "Resource type"
           },
           "links": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/ResourceLinks"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Links",
             "description": "a links object containing links related to the resource."
           },
           "meta": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/Meta"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Meta",
             "description": "a meta object containing non-standard meta-information about a resource that can not be represented as an attribute or relationship."
           },
           "attributes": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/Attributes"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Attributes",
             "description": "an attributes object representing some of the resource\u2019s data."
           },
           "relationships": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/Relationships"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Relationships",
             "description": "[Relationships object](https://jsonapi.org/format/1.0/#document-resource-object-relationships)\ndescribing relationships between the resource and other JSON API resources."
           }
         },
@@ -1605,12 +1842,14 @@
             "anyOf": [
               {
                 "type": "string",
-                "maxLength": 65536,
                 "minLength": 1,
                 "format": "uri"
               },
               {
                 "$ref": "#/components/schemas/Link"
+              },
+              {
+                "type": "null"
               }
             ],
             "title": "Self",
@@ -1629,7 +1868,6 @@
                 "$ref": "#/components/schemas/ResponseMetaQuery"
               }
             ],
-            "title": "Query",
             "description": "Information on the Query that was requested"
           },
           "api_version": {
@@ -1637,7 +1875,7 @@
             "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "title": "Api Version",
             "description": "Presently used full version of the OPTIMADE API.\nThe version number string MUST NOT be prefixed by, e.g., \"v\".\nExamples: `1.0.0`, `1.0.0-rc.2`.",
-            "example": [
+            "examples": [
               "0.10.1",
               "1.0.0-rc.2",
               "1.2.3-rc.5+develop"
@@ -1652,72 +1890,121 @@
             "anyOf": [
               {
                 "type": "string",
-                "maxLength": 65536,
                 "minLength": 1,
                 "format": "uri"
               },
               {
                 "$ref": "#/components/schemas/Link"
+              },
+              {
+                "type": "null"
               }
             ],
             "title": "Schema",
             "description": "A [JSON API links object](http://jsonapi.org/format/1.0/#document-links) that points to a schema for the response.\nIf it is a string, or a dictionary containing no `meta` field, the provided URL MUST point at an [OpenAPI](https://swagger.io/specification/) schema.\nIt is possible that future versions of this specification allows for alternative schema types.\nHence, if the `meta` field of the JSON API links object is provided and contains a field `schema_type` that is not equal to the string `OpenAPI` the client MUST not handle failures to parse the schema or to validate the response against the schema as errors."
           },
           "time_stamp": {
-            "type": "string",
-            "format": "date-time",
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Time Stamp",
             "description": "A timestamp containing the date and time at which the query was executed."
           },
           "data_returned": {
-            "type": "integer",
-            "minimum": 0.0,
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Data Returned",
             "description": "An integer containing the total number of data resource objects returned for the current `filter` query, independent of pagination."
           },
           "provider": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/Provider"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Provider",
             "description": "information on the database provider of the implementation."
           },
           "data_available": {
-            "type": "integer",
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Data Available",
             "description": "An integer containing the total number of data resource objects available in the database for the endpoint."
           },
           "last_id": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Last Id",
             "description": "a string containing the last ID returned"
           },
           "response_message": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Response Message",
             "description": "response string from the server"
           },
           "implementation": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/Implementation"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Implementation",
             "description": "a dictionary describing the server implementation"
           },
           "warnings": {
-            "items": {
-              "$ref": "#/components/schemas/Warnings"
-            },
-            "type": "array",
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/Warnings"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "uniqueItems": true,
             "title": "Warnings",
             "description": "A list of warning resource objects representing non-critical errors or warnings.\nA warning resource object is defined similarly to a [JSON API error object](http://jsonapi.org/format/1.0/#error-objects), but MUST also include the field `type`, which MUST have the value `\"warning\"`.\nThe field `detail` MUST be present and SHOULD contain a non-critical message, e.g., reporting unrecognized search attributes or deprecated features.\nThe field `status`, representing a HTTP response status code, MUST NOT be present for a warning resource object.\nThis is an exclusive field for error resource objects."
           }
         },
+        "additionalProperties": true,
         "type": "object",
         "required": [
           "query",
@@ -1745,12 +2032,14 @@
       "StructureRelationship": {
         "properties": {
           "links": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/RelationshipLinks"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Links",
             "description": "a links object containing at least one of the following: self, related"
           },
           "data": {
@@ -1763,6 +2052,9 @@
                   "$ref": "#/components/schemas/BaseRelationshipResource"
                 },
                 "type": "array"
+              },
+              {
+                "type": "null"
               }
             ],
             "uniqueItems": true,
@@ -1770,18 +2062,19 @@
             "description": "Resource linkage"
           },
           "meta": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/Meta"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Meta",
             "description": "a meta object that contains non-standard meta-information about the relationship."
           }
         },
         "type": "object",
-        "title": "StructureRelationship",
-        "description": "Similar to normal JSON API relationship, but with addition of OPTIONAL meta field for a resource."
+        "title": "StructureRelationship"
       },
       "ToplevelLinks": {
         "properties": {
@@ -1789,12 +2082,14 @@
             "anyOf": [
               {
                 "type": "string",
-                "maxLength": 65536,
                 "minLength": 1,
                 "format": "uri"
               },
               {
                 "$ref": "#/components/schemas/Link"
+              },
+              {
+                "type": "null"
               }
             ],
             "title": "Self",
@@ -1804,12 +2099,14 @@
             "anyOf": [
               {
                 "type": "string",
-                "maxLength": 65536,
                 "minLength": 1,
                 "format": "uri"
               },
               {
                 "$ref": "#/components/schemas/Link"
+              },
+              {
+                "type": "null"
               }
             ],
             "title": "Related",
@@ -1819,12 +2116,14 @@
             "anyOf": [
               {
                 "type": "string",
-                "maxLength": 65536,
                 "minLength": 1,
                 "format": "uri"
               },
               {
                 "$ref": "#/components/schemas/Link"
+              },
+              {
+                "type": "null"
               }
             ],
             "title": "First",
@@ -1834,12 +2133,14 @@
             "anyOf": [
               {
                 "type": "string",
-                "maxLength": 65536,
                 "minLength": 1,
                 "format": "uri"
               },
               {
                 "$ref": "#/components/schemas/Link"
+              },
+              {
+                "type": "null"
               }
             ],
             "title": "Last",
@@ -1849,12 +2150,14 @@
             "anyOf": [
               {
                 "type": "string",
-                "maxLength": 65536,
                 "minLength": 1,
                 "format": "uri"
               },
               {
                 "$ref": "#/components/schemas/Link"
+              },
+              {
+                "type": "null"
               }
             ],
             "title": "Prev",
@@ -1864,18 +2167,21 @@
             "anyOf": [
               {
                 "type": "string",
-                "maxLength": 65536,
                 "minLength": 1,
                 "format": "uri"
               },
               {
                 "$ref": "#/components/schemas/Link"
+              },
+              {
+                "type": "null"
               }
             ],
             "title": "Next",
             "description": "The next page of data"
           }
         },
+        "additionalProperties": true,
         "type": "object",
         "title": "ToplevelLinks",
         "description": "A set of Links objects, possibly including pagination"
@@ -1883,26 +2189,49 @@
       "Warnings": {
         "properties": {
           "id": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Id",
             "description": "A unique identifier for this particular occurrence of the problem."
           },
           "links": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/ErrorLinks"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Links",
             "description": "A links object storing about"
           },
           "code": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Code",
             "description": "an application-specific error code, expressed as a string value."
           },
           "title": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Title",
             "description": "A short, human-readable summary of the problem. It **SHOULD NOT** change from occurrence to occurrence of the problem, except for purposes of localization."
           },
@@ -1912,25 +2241,29 @@
             "description": "A human-readable explanation specific to this occurrence of the problem."
           },
           "source": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/ErrorSource"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Source",
             "description": "An object containing references to the source of the error"
           },
           "meta": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/Meta"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Meta",
             "description": "a meta object containing non-standard meta-information about the error."
           },
           "type": {
-            "type": "string",
+            "const": "warning",
             "pattern": "^warning$",
             "title": "Type",
             "description": "Warnings must be of type \"warning\"",

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -106,13 +106,13 @@
         "operationId": "get_entry_info_info__entry__get",
         "parameters": [
           {
+            "name": "entry",
+            "in": "path",
             "required": true,
             "schema": {
               "type": "string",
               "title": "Entry"
-            },
-            "name": "entry",
-            "in": "path"
+            }
           }
         ],
         "responses": {
@@ -208,164 +208,164 @@
         "operationId": "get_links_links_get",
         "parameters": [
           {
-            "description": "A filter string, in the format described in section API Filtering Format Specification of the specification.",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "title": "Filter",
-              "description": "A filter string, in the format described in section API Filtering Format Specification of the specification.",
-              "default": ""
-            },
             "name": "filter",
-            "in": "query"
-          },
-          {
-            "description": "The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`",
+            "in": "query",
             "required": false,
             "schema": {
               "type": "string",
-              "title": "Response Format",
-              "description": "The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`",
-              "default": "json"
+              "description": "A filter string, in the format described in section API Filtering Format Specification of the specification.",
+              "default": "",
+              "title": "Filter"
             },
-            "name": "response_format",
-            "in": "query"
+            "description": "A filter string, in the format described in section API Filtering Format Specification of the specification."
           },
           {
-            "description": "An email address of the user making the request.\nThe email SHOULD be that of a person and not an automatic system.\nExample: `http://example.com/v1/structures?email_address=user@example.com`",
+            "name": "response_format",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`",
+              "default": "json",
+              "title": "Response Format"
+            },
+            "description": "The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`"
+          },
+          {
+            "name": "email_address",
+            "in": "query",
             "required": false,
             "schema": {
               "type": "string",
               "format": "email",
-              "title": "Email Address",
               "description": "An email address of the user making the request.\nThe email SHOULD be that of a person and not an automatic system.\nExample: `http://example.com/v1/structures?email_address=user@example.com`",
-              "default": ""
+              "default": "",
+              "title": "Email Address"
             },
-            "name": "email_address",
-            "in": "query"
+            "description": "An email address of the user making the request.\nThe email SHOULD be that of a person and not an automatic system.\nExample: `http://example.com/v1/structures?email_address=user@example.com`"
           },
           {
-            "description": "A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "pattern": "([a-z_][a-z_0-9]*(,[a-z_][a-z_0-9]*)*)?",
-              "title": "Response Fields",
-              "description": "A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`",
-              "default": ""
-            },
             "name": "response_fields",
-            "in": "query"
-          },
-          {
-            "description": "If supporting sortable queries, an implementation MUST use the `sort` query parameter with format as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-sorting).\n\nAn implementation MAY support multiple sort fields for a single query.\nIf it does, it again MUST conform to the JSON API 1.0 specification.\n\nIf an implementation supports sorting for an entry listing endpoint, then the `/info/<entries>` endpoint MUST include, for each field name `<fieldname>` in its `data.properties.<fieldname>` response value that can be used for sorting, the key `sortable` with value `true`.\nIf a field name under an entry listing endpoint supporting sorting cannot be used for sorting, the server MUST either leave out the `sortable` key or set it equal to `false` for the specific field name.\nThe set of field names, with `sortable` equal to `true` are allowed to be used in the \"sort fields\" list according to its definition in the JSON API 1.0 specification.\nThe field `sortable` is in addition to each property description and other OPTIONAL fields.\nAn example is shown in the section Entry Listing Info Endpoints.",
+            "in": "query",
             "required": false,
             "schema": {
               "type": "string",
               "pattern": "([a-z_][a-z_0-9]*(,[a-z_][a-z_0-9]*)*)?",
-              "title": "Sort",
-              "description": "If supporting sortable queries, an implementation MUST use the `sort` query parameter with format as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-sorting).\n\nAn implementation MAY support multiple sort fields for a single query.\nIf it does, it again MUST conform to the JSON API 1.0 specification.\n\nIf an implementation supports sorting for an entry listing endpoint, then the `/info/<entries>` endpoint MUST include, for each field name `<fieldname>` in its `data.properties.<fieldname>` response value that can be used for sorting, the key `sortable` with value `true`.\nIf a field name under an entry listing endpoint supporting sorting cannot be used for sorting, the server MUST either leave out the `sortable` key or set it equal to `false` for the specific field name.\nThe set of field names, with `sortable` equal to `true` are allowed to be used in the \"sort fields\" list according to its definition in the JSON API 1.0 specification.\nThe field `sortable` is in addition to each property description and other OPTIONAL fields.\nAn example is shown in the section Entry Listing Info Endpoints.",
-              "default": ""
+              "description": "A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`",
+              "default": "",
+              "title": "Response Fields"
             },
+            "description": "A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`"
+          },
+          {
             "name": "sort",
-            "in": "query"
-          },
-          {
-            "description": "Sets a numerical limit on the number of entries returned.\nSee [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-pagination).\nThe API implementation MUST return no more than the number specified.\nIt MAY return fewer.\nThe database MAY have a maximum limit and not accept larger numbers (in which case an error code -- 403 Forbidden -- MUST be returned).\nThe default limit value is up to the API implementation to decide.\nExample: `http://example.com/optimade/v1/structures?page_limit=100`",
+            "in": "query",
             "required": false,
             "schema": {
-              "type": "integer",
-              "minimum": 0.0,
-              "title": "Page Limit",
-              "description": "Sets a numerical limit on the number of entries returned.\nSee [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-pagination).\nThe API implementation MUST return no more than the number specified.\nIt MAY return fewer.\nThe database MAY have a maximum limit and not accept larger numbers (in which case an error code -- 403 Forbidden -- MUST be returned).\nThe default limit value is up to the API implementation to decide.\nExample: `http://example.com/optimade/v1/structures?page_limit=100`",
-              "default": 20
+              "type": "string",
+              "pattern": "([a-z_][a-z_0-9]*(,[a-z_][a-z_0-9]*)*)?",
+              "description": "If supporting sortable queries, an implementation MUST use the `sort` query parameter with format as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-sorting).\n\nAn implementation MAY support multiple sort fields for a single query.\nIf it does, it again MUST conform to the JSON API 1.0 specification.\n\nIf an implementation supports sorting for an entry listing endpoint, then the `/info/<entries>` endpoint MUST include, for each field name `<fieldname>` in its `data.properties.<fieldname>` response value that can be used for sorting, the key `sortable` with value `true`.\nIf a field name under an entry listing endpoint supporting sorting cannot be used for sorting, the server MUST either leave out the `sortable` key or set it equal to `false` for the specific field name.\nThe set of field names, with `sortable` equal to `true` are allowed to be used in the \"sort fields\" list according to its definition in the JSON API 1.0 specification.\nThe field `sortable` is in addition to each property description and other OPTIONAL fields.\nAn example is shown in the section Entry Listing Info Endpoints.",
+              "default": "",
+              "title": "Sort"
             },
+            "description": "If supporting sortable queries, an implementation MUST use the `sort` query parameter with format as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-sorting).\n\nAn implementation MAY support multiple sort fields for a single query.\nIf it does, it again MUST conform to the JSON API 1.0 specification.\n\nIf an implementation supports sorting for an entry listing endpoint, then the `/info/<entries>` endpoint MUST include, for each field name `<fieldname>` in its `data.properties.<fieldname>` response value that can be used for sorting, the key `sortable` with value `true`.\nIf a field name under an entry listing endpoint supporting sorting cannot be used for sorting, the server MUST either leave out the `sortable` key or set it equal to `false` for the specific field name.\nThe set of field names, with `sortable` equal to `true` are allowed to be used in the \"sort fields\" list according to its definition in the JSON API 1.0 specification.\nThe field `sortable` is in addition to each property description and other OPTIONAL fields.\nAn example is shown in the section Entry Listing Info Endpoints."
+          },
+          {
             "name": "page_limit",
-            "in": "query"
-          },
-          {
-            "description": "RECOMMENDED for use with _offset-based_ pagination: using `page_offset` and `page_limit` is RECOMMENDED.\nExample: Skip 50 structures and fetch up to 100: `/structures?page_offset=50&page_limit=100`.",
+            "in": "query",
             "required": false,
             "schema": {
               "type": "integer",
-              "minimum": 0.0,
-              "title": "Page Offset",
-              "description": "RECOMMENDED for use with _offset-based_ pagination: using `page_offset` and `page_limit` is RECOMMENDED.\nExample: Skip 50 structures and fetch up to 100: `/structures?page_offset=50&page_limit=100`.",
-              "default": 0
+              "minimum": 0,
+              "description": "Sets a numerical limit on the number of entries returned.\nSee [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-pagination).\nThe API implementation MUST return no more than the number specified.\nIt MAY return fewer.\nThe database MAY have a maximum limit and not accept larger numbers (in which case an error code -- 403 Forbidden -- MUST be returned).\nThe default limit value is up to the API implementation to decide.\nExample: `http://example.com/optimade/v1/structures?page_limit=100`",
+              "default": 20,
+              "title": "Page Limit"
             },
+            "description": "Sets a numerical limit on the number of entries returned.\nSee [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-pagination).\nThe API implementation MUST return no more than the number specified.\nIt MAY return fewer.\nThe database MAY have a maximum limit and not accept larger numbers (in which case an error code -- 403 Forbidden -- MUST be returned).\nThe default limit value is up to the API implementation to decide.\nExample: `http://example.com/optimade/v1/structures?page_limit=100`"
+          },
+          {
             "name": "page_offset",
-            "in": "query"
-          },
-          {
-            "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`.",
+            "in": "query",
             "required": false,
             "schema": {
               "type": "integer",
-              "title": "Page Number",
-              "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`."
+              "minimum": 0,
+              "description": "RECOMMENDED for use with _offset-based_ pagination: using `page_offset` and `page_limit` is RECOMMENDED.\nExample: Skip 50 structures and fetch up to 100: `/structures?page_offset=50&page_limit=100`.",
+              "default": 0,
+              "title": "Page Offset"
             },
+            "description": "RECOMMENDED for use with _offset-based_ pagination: using `page_offset` and `page_limit` is RECOMMENDED.\nExample: Skip 50 structures and fetch up to 100: `/structures?page_offset=50&page_limit=100`."
+          },
+          {
             "name": "page_number",
-            "in": "query"
-          },
-          {
-            "description": "RECOMMENDED for use with _cursor-based_ pagination: using `page_cursor` and `page_limit` is RECOMMENDED.",
+            "in": "query",
             "required": false,
             "schema": {
               "type": "integer",
-              "minimum": 0.0,
-              "title": "Page Cursor",
-              "description": "RECOMMENDED for use with _cursor-based_ pagination: using `page_cursor` and `page_limit` is RECOMMENDED.",
-              "default": 0
+              "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`.",
+              "title": "Page Number"
             },
+            "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`."
+          },
+          {
             "name": "page_cursor",
-            "in": "query"
-          },
-          {
-            "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.\nExample: Fetch up to 100 structures above sort-field value 4000 (in this example, server chooses to fetch results sorted by increasing `id`, so `page_above` value refers to an `id` value): `/structures?page_above=4000&page_limit=100`.",
+            "in": "query",
             "required": false,
             "schema": {
-              "type": "string",
-              "title": "Page Above",
-              "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.\nExample: Fetch up to 100 structures above sort-field value 4000 (in this example, server chooses to fetch results sorted by increasing `id`, so `page_above` value refers to an `id` value): `/structures?page_above=4000&page_limit=100`."
+              "type": "integer",
+              "minimum": 0,
+              "description": "RECOMMENDED for use with _cursor-based_ pagination: using `page_cursor` and `page_limit` is RECOMMENDED.",
+              "default": 0,
+              "title": "Page Cursor"
             },
+            "description": "RECOMMENDED for use with _cursor-based_ pagination: using `page_cursor` and `page_limit` is RECOMMENDED."
+          },
+          {
             "name": "page_above",
-            "in": "query"
-          },
-          {
-            "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.",
+            "in": "query",
             "required": false,
             "schema": {
               "type": "string",
-              "title": "Page Below",
-              "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED."
+              "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.\nExample: Fetch up to 100 structures above sort-field value 4000 (in this example, server chooses to fetch results sorted by increasing `id`, so `page_above` value refers to an `id` value): `/structures?page_above=4000&page_limit=100`.",
+              "title": "Page Above"
             },
+            "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.\nExample: Fetch up to 100 structures above sort-field value 4000 (in this example, server chooses to fetch results sorted by increasing `id`, so `page_above` value refers to an `id` value): `/structures?page_above=4000&page_limit=100`."
+          },
+          {
             "name": "page_below",
-            "in": "query"
-          },
-          {
-            "description": "A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of \"relationship paths\", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`.",
+            "in": "query",
             "required": false,
             "schema": {
               "type": "string",
-              "title": "Include",
-              "description": "A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of \"relationship paths\", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`.",
-              "default": "references"
+              "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.",
+              "title": "Page Below"
             },
-            "name": "include",
-            "in": "query"
+            "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED."
           },
           {
-            "description": "If the client provides the parameter, the value SHOULD have the format `vMAJOR` or `vMAJOR.MINOR`, where MAJOR is a major version and MINOR is a minor version of the API. For example, if a client appends `api_hint=v1.0` to the query string, the hint provided is for major version 1 and minor version 0.",
+            "name": "include",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of \"relationship paths\", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`.",
+              "default": "references",
+              "title": "Include"
+            },
+            "description": "A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of \"relationship paths\", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`."
+          },
+          {
+            "name": "api_hint",
+            "in": "query",
             "required": false,
             "schema": {
               "type": "string",
               "pattern": "(v[0-9]+(\\.[0-9]+)?)?",
-              "title": "Api Hint",
               "description": "If the client provides the parameter, the value SHOULD have the format `vMAJOR` or `vMAJOR.MINOR`, where MAJOR is a major version and MINOR is a minor version of the API. For example, if a client appends `api_hint=v1.0` to the query string, the hint provided is for major version 1 and minor version 0.",
-              "default": ""
+              "default": "",
+              "title": "Api Hint"
             },
-            "name": "api_hint",
-            "in": "query"
+            "description": "If the client provides the parameter, the value SHOULD have the format `vMAJOR` or `vMAJOR.MINOR`, where MAJOR is a major version and MINOR is a minor version of the API. For example, if a client appends `api_hint=v1.0` to the query string, the hint provided is for major version 1 and minor version 0."
           }
         ],
         "responses": {
@@ -461,164 +461,164 @@
         "operationId": "get_references_references_get",
         "parameters": [
           {
-            "description": "A filter string, in the format described in section API Filtering Format Specification of the specification.",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "title": "Filter",
-              "description": "A filter string, in the format described in section API Filtering Format Specification of the specification.",
-              "default": ""
-            },
             "name": "filter",
-            "in": "query"
-          },
-          {
-            "description": "The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`",
+            "in": "query",
             "required": false,
             "schema": {
               "type": "string",
-              "title": "Response Format",
-              "description": "The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`",
-              "default": "json"
+              "description": "A filter string, in the format described in section API Filtering Format Specification of the specification.",
+              "default": "",
+              "title": "Filter"
             },
-            "name": "response_format",
-            "in": "query"
+            "description": "A filter string, in the format described in section API Filtering Format Specification of the specification."
           },
           {
-            "description": "An email address of the user making the request.\nThe email SHOULD be that of a person and not an automatic system.\nExample: `http://example.com/v1/structures?email_address=user@example.com`",
+            "name": "response_format",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`",
+              "default": "json",
+              "title": "Response Format"
+            },
+            "description": "The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`"
+          },
+          {
+            "name": "email_address",
+            "in": "query",
             "required": false,
             "schema": {
               "type": "string",
               "format": "email",
-              "title": "Email Address",
               "description": "An email address of the user making the request.\nThe email SHOULD be that of a person and not an automatic system.\nExample: `http://example.com/v1/structures?email_address=user@example.com`",
-              "default": ""
+              "default": "",
+              "title": "Email Address"
             },
-            "name": "email_address",
-            "in": "query"
+            "description": "An email address of the user making the request.\nThe email SHOULD be that of a person and not an automatic system.\nExample: `http://example.com/v1/structures?email_address=user@example.com`"
           },
           {
-            "description": "A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "pattern": "([a-z_][a-z_0-9]*(,[a-z_][a-z_0-9]*)*)?",
-              "title": "Response Fields",
-              "description": "A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`",
-              "default": ""
-            },
             "name": "response_fields",
-            "in": "query"
-          },
-          {
-            "description": "If supporting sortable queries, an implementation MUST use the `sort` query parameter with format as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-sorting).\n\nAn implementation MAY support multiple sort fields for a single query.\nIf it does, it again MUST conform to the JSON API 1.0 specification.\n\nIf an implementation supports sorting for an entry listing endpoint, then the `/info/<entries>` endpoint MUST include, for each field name `<fieldname>` in its `data.properties.<fieldname>` response value that can be used for sorting, the key `sortable` with value `true`.\nIf a field name under an entry listing endpoint supporting sorting cannot be used for sorting, the server MUST either leave out the `sortable` key or set it equal to `false` for the specific field name.\nThe set of field names, with `sortable` equal to `true` are allowed to be used in the \"sort fields\" list according to its definition in the JSON API 1.0 specification.\nThe field `sortable` is in addition to each property description and other OPTIONAL fields.\nAn example is shown in the section Entry Listing Info Endpoints.",
+            "in": "query",
             "required": false,
             "schema": {
               "type": "string",
               "pattern": "([a-z_][a-z_0-9]*(,[a-z_][a-z_0-9]*)*)?",
-              "title": "Sort",
-              "description": "If supporting sortable queries, an implementation MUST use the `sort` query parameter with format as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-sorting).\n\nAn implementation MAY support multiple sort fields for a single query.\nIf it does, it again MUST conform to the JSON API 1.0 specification.\n\nIf an implementation supports sorting for an entry listing endpoint, then the `/info/<entries>` endpoint MUST include, for each field name `<fieldname>` in its `data.properties.<fieldname>` response value that can be used for sorting, the key `sortable` with value `true`.\nIf a field name under an entry listing endpoint supporting sorting cannot be used for sorting, the server MUST either leave out the `sortable` key or set it equal to `false` for the specific field name.\nThe set of field names, with `sortable` equal to `true` are allowed to be used in the \"sort fields\" list according to its definition in the JSON API 1.0 specification.\nThe field `sortable` is in addition to each property description and other OPTIONAL fields.\nAn example is shown in the section Entry Listing Info Endpoints.",
-              "default": ""
+              "description": "A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`",
+              "default": "",
+              "title": "Response Fields"
             },
+            "description": "A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`"
+          },
+          {
             "name": "sort",
-            "in": "query"
-          },
-          {
-            "description": "Sets a numerical limit on the number of entries returned.\nSee [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-pagination).\nThe API implementation MUST return no more than the number specified.\nIt MAY return fewer.\nThe database MAY have a maximum limit and not accept larger numbers (in which case an error code -- 403 Forbidden -- MUST be returned).\nThe default limit value is up to the API implementation to decide.\nExample: `http://example.com/optimade/v1/structures?page_limit=100`",
+            "in": "query",
             "required": false,
             "schema": {
-              "type": "integer",
-              "minimum": 0.0,
-              "title": "Page Limit",
-              "description": "Sets a numerical limit on the number of entries returned.\nSee [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-pagination).\nThe API implementation MUST return no more than the number specified.\nIt MAY return fewer.\nThe database MAY have a maximum limit and not accept larger numbers (in which case an error code -- 403 Forbidden -- MUST be returned).\nThe default limit value is up to the API implementation to decide.\nExample: `http://example.com/optimade/v1/structures?page_limit=100`",
-              "default": 20
+              "type": "string",
+              "pattern": "([a-z_][a-z_0-9]*(,[a-z_][a-z_0-9]*)*)?",
+              "description": "If supporting sortable queries, an implementation MUST use the `sort` query parameter with format as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-sorting).\n\nAn implementation MAY support multiple sort fields for a single query.\nIf it does, it again MUST conform to the JSON API 1.0 specification.\n\nIf an implementation supports sorting for an entry listing endpoint, then the `/info/<entries>` endpoint MUST include, for each field name `<fieldname>` in its `data.properties.<fieldname>` response value that can be used for sorting, the key `sortable` with value `true`.\nIf a field name under an entry listing endpoint supporting sorting cannot be used for sorting, the server MUST either leave out the `sortable` key or set it equal to `false` for the specific field name.\nThe set of field names, with `sortable` equal to `true` are allowed to be used in the \"sort fields\" list according to its definition in the JSON API 1.0 specification.\nThe field `sortable` is in addition to each property description and other OPTIONAL fields.\nAn example is shown in the section Entry Listing Info Endpoints.",
+              "default": "",
+              "title": "Sort"
             },
+            "description": "If supporting sortable queries, an implementation MUST use the `sort` query parameter with format as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-sorting).\n\nAn implementation MAY support multiple sort fields for a single query.\nIf it does, it again MUST conform to the JSON API 1.0 specification.\n\nIf an implementation supports sorting for an entry listing endpoint, then the `/info/<entries>` endpoint MUST include, for each field name `<fieldname>` in its `data.properties.<fieldname>` response value that can be used for sorting, the key `sortable` with value `true`.\nIf a field name under an entry listing endpoint supporting sorting cannot be used for sorting, the server MUST either leave out the `sortable` key or set it equal to `false` for the specific field name.\nThe set of field names, with `sortable` equal to `true` are allowed to be used in the \"sort fields\" list according to its definition in the JSON API 1.0 specification.\nThe field `sortable` is in addition to each property description and other OPTIONAL fields.\nAn example is shown in the section Entry Listing Info Endpoints."
+          },
+          {
             "name": "page_limit",
-            "in": "query"
-          },
-          {
-            "description": "RECOMMENDED for use with _offset-based_ pagination: using `page_offset` and `page_limit` is RECOMMENDED.\nExample: Skip 50 structures and fetch up to 100: `/structures?page_offset=50&page_limit=100`.",
+            "in": "query",
             "required": false,
             "schema": {
               "type": "integer",
-              "minimum": 0.0,
-              "title": "Page Offset",
-              "description": "RECOMMENDED for use with _offset-based_ pagination: using `page_offset` and `page_limit` is RECOMMENDED.\nExample: Skip 50 structures and fetch up to 100: `/structures?page_offset=50&page_limit=100`.",
-              "default": 0
+              "minimum": 0,
+              "description": "Sets a numerical limit on the number of entries returned.\nSee [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-pagination).\nThe API implementation MUST return no more than the number specified.\nIt MAY return fewer.\nThe database MAY have a maximum limit and not accept larger numbers (in which case an error code -- 403 Forbidden -- MUST be returned).\nThe default limit value is up to the API implementation to decide.\nExample: `http://example.com/optimade/v1/structures?page_limit=100`",
+              "default": 20,
+              "title": "Page Limit"
             },
+            "description": "Sets a numerical limit on the number of entries returned.\nSee [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-pagination).\nThe API implementation MUST return no more than the number specified.\nIt MAY return fewer.\nThe database MAY have a maximum limit and not accept larger numbers (in which case an error code -- 403 Forbidden -- MUST be returned).\nThe default limit value is up to the API implementation to decide.\nExample: `http://example.com/optimade/v1/structures?page_limit=100`"
+          },
+          {
             "name": "page_offset",
-            "in": "query"
-          },
-          {
-            "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`.",
+            "in": "query",
             "required": false,
             "schema": {
               "type": "integer",
-              "title": "Page Number",
-              "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`."
+              "minimum": 0,
+              "description": "RECOMMENDED for use with _offset-based_ pagination: using `page_offset` and `page_limit` is RECOMMENDED.\nExample: Skip 50 structures and fetch up to 100: `/structures?page_offset=50&page_limit=100`.",
+              "default": 0,
+              "title": "Page Offset"
             },
+            "description": "RECOMMENDED for use with _offset-based_ pagination: using `page_offset` and `page_limit` is RECOMMENDED.\nExample: Skip 50 structures and fetch up to 100: `/structures?page_offset=50&page_limit=100`."
+          },
+          {
             "name": "page_number",
-            "in": "query"
-          },
-          {
-            "description": "RECOMMENDED for use with _cursor-based_ pagination: using `page_cursor` and `page_limit` is RECOMMENDED.",
+            "in": "query",
             "required": false,
             "schema": {
               "type": "integer",
-              "minimum": 0.0,
-              "title": "Page Cursor",
-              "description": "RECOMMENDED for use with _cursor-based_ pagination: using `page_cursor` and `page_limit` is RECOMMENDED.",
-              "default": 0
+              "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`.",
+              "title": "Page Number"
             },
+            "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`."
+          },
+          {
             "name": "page_cursor",
-            "in": "query"
-          },
-          {
-            "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.\nExample: Fetch up to 100 structures above sort-field value 4000 (in this example, server chooses to fetch results sorted by increasing `id`, so `page_above` value refers to an `id` value): `/structures?page_above=4000&page_limit=100`.",
+            "in": "query",
             "required": false,
             "schema": {
-              "type": "string",
-              "title": "Page Above",
-              "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.\nExample: Fetch up to 100 structures above sort-field value 4000 (in this example, server chooses to fetch results sorted by increasing `id`, so `page_above` value refers to an `id` value): `/structures?page_above=4000&page_limit=100`."
+              "type": "integer",
+              "minimum": 0,
+              "description": "RECOMMENDED for use with _cursor-based_ pagination: using `page_cursor` and `page_limit` is RECOMMENDED.",
+              "default": 0,
+              "title": "Page Cursor"
             },
+            "description": "RECOMMENDED for use with _cursor-based_ pagination: using `page_cursor` and `page_limit` is RECOMMENDED."
+          },
+          {
             "name": "page_above",
-            "in": "query"
-          },
-          {
-            "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.",
+            "in": "query",
             "required": false,
             "schema": {
               "type": "string",
-              "title": "Page Below",
-              "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED."
+              "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.\nExample: Fetch up to 100 structures above sort-field value 4000 (in this example, server chooses to fetch results sorted by increasing `id`, so `page_above` value refers to an `id` value): `/structures?page_above=4000&page_limit=100`.",
+              "title": "Page Above"
             },
+            "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.\nExample: Fetch up to 100 structures above sort-field value 4000 (in this example, server chooses to fetch results sorted by increasing `id`, so `page_above` value refers to an `id` value): `/structures?page_above=4000&page_limit=100`."
+          },
+          {
             "name": "page_below",
-            "in": "query"
-          },
-          {
-            "description": "A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of \"relationship paths\", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`.",
+            "in": "query",
             "required": false,
             "schema": {
               "type": "string",
-              "title": "Include",
-              "description": "A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of \"relationship paths\", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`.",
-              "default": "references"
+              "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.",
+              "title": "Page Below"
             },
-            "name": "include",
-            "in": "query"
+            "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED."
           },
           {
-            "description": "If the client provides the parameter, the value SHOULD have the format `vMAJOR` or `vMAJOR.MINOR`, where MAJOR is a major version and MINOR is a minor version of the API. For example, if a client appends `api_hint=v1.0` to the query string, the hint provided is for major version 1 and minor version 0.",
+            "name": "include",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of \"relationship paths\", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`.",
+              "default": "references",
+              "title": "Include"
+            },
+            "description": "A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of \"relationship paths\", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`."
+          },
+          {
+            "name": "api_hint",
+            "in": "query",
             "required": false,
             "schema": {
               "type": "string",
               "pattern": "(v[0-9]+(\\.[0-9]+)?)?",
-              "title": "Api Hint",
               "description": "If the client provides the parameter, the value SHOULD have the format `vMAJOR` or `vMAJOR.MINOR`, where MAJOR is a major version and MINOR is a minor version of the API. For example, if a client appends `api_hint=v1.0` to the query string, the hint provided is for major version 1 and minor version 0.",
-              "default": ""
+              "default": "",
+              "title": "Api Hint"
             },
-            "name": "api_hint",
-            "in": "query"
+            "description": "If the client provides the parameter, the value SHOULD have the format `vMAJOR` or `vMAJOR.MINOR`, where MAJOR is a major version and MINOR is a minor version of the API. For example, if a client appends `api_hint=v1.0` to the query string, the hint provided is for major version 1 and minor version 0."
           }
         ],
         "responses": {
@@ -714,76 +714,76 @@
         "operationId": "get_single_reference_references__entry_id__get",
         "parameters": [
           {
+            "name": "entry_id",
+            "in": "path",
             "required": true,
             "schema": {
               "type": "string",
               "title": "Entry Id"
-            },
-            "name": "entry_id",
-            "in": "path"
+            }
           },
           {
-            "description": "The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`",
+            "name": "response_format",
+            "in": "query",
             "required": false,
             "schema": {
               "type": "string",
-              "title": "Response Format",
               "description": "The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`",
-              "default": "json"
+              "default": "json",
+              "title": "Response Format"
             },
-            "name": "response_format",
-            "in": "query"
+            "description": "The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`"
           },
           {
-            "description": "An email address of the user making the request.\nThe email SHOULD be that of a person and not an automatic system.\nExample: `http://example.com/v1/structures?email_address=user@example.com`",
+            "name": "email_address",
+            "in": "query",
             "required": false,
             "schema": {
               "type": "string",
               "format": "email",
-              "title": "Email Address",
               "description": "An email address of the user making the request.\nThe email SHOULD be that of a person and not an automatic system.\nExample: `http://example.com/v1/structures?email_address=user@example.com`",
-              "default": ""
+              "default": "",
+              "title": "Email Address"
             },
-            "name": "email_address",
-            "in": "query"
+            "description": "An email address of the user making the request.\nThe email SHOULD be that of a person and not an automatic system.\nExample: `http://example.com/v1/structures?email_address=user@example.com`"
           },
           {
-            "description": "A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`",
+            "name": "response_fields",
+            "in": "query",
             "required": false,
             "schema": {
               "type": "string",
               "pattern": "([a-z_][a-z_0-9]*(,[a-z_][a-z_0-9]*)*)?",
-              "title": "Response Fields",
               "description": "A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`",
-              "default": ""
+              "default": "",
+              "title": "Response Fields"
             },
-            "name": "response_fields",
-            "in": "query"
+            "description": "A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`"
           },
           {
-            "description": "A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of \"relationship paths\", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`.",
+            "name": "include",
+            "in": "query",
             "required": false,
             "schema": {
               "type": "string",
-              "title": "Include",
               "description": "A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of \"relationship paths\", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`.",
-              "default": "references"
+              "default": "references",
+              "title": "Include"
             },
-            "name": "include",
-            "in": "query"
+            "description": "A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of \"relationship paths\", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`."
           },
           {
-            "description": "If the client provides the parameter, the value SHOULD have the format `vMAJOR` or `vMAJOR.MINOR`, where MAJOR is a major version and MINOR is a minor version of the API. For example, if a client appends `api_hint=v1.0` to the query string, the hint provided is for major version 1 and minor version 0.",
+            "name": "api_hint",
+            "in": "query",
             "required": false,
             "schema": {
               "type": "string",
               "pattern": "(v[0-9]+(\\.[0-9]+)?)?",
-              "title": "Api Hint",
               "description": "If the client provides the parameter, the value SHOULD have the format `vMAJOR` or `vMAJOR.MINOR`, where MAJOR is a major version and MINOR is a minor version of the API. For example, if a client appends `api_hint=v1.0` to the query string, the hint provided is for major version 1 and minor version 0.",
-              "default": ""
+              "default": "",
+              "title": "Api Hint"
             },
-            "name": "api_hint",
-            "in": "query"
+            "description": "If the client provides the parameter, the value SHOULD have the format `vMAJOR` or `vMAJOR.MINOR`, where MAJOR is a major version and MINOR is a minor version of the API. For example, if a client appends `api_hint=v1.0` to the query string, the hint provided is for major version 1 and minor version 0."
           }
         ],
         "responses": {
@@ -879,164 +879,164 @@
         "operationId": "get_structures_structures_get",
         "parameters": [
           {
-            "description": "A filter string, in the format described in section API Filtering Format Specification of the specification.",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "title": "Filter",
-              "description": "A filter string, in the format described in section API Filtering Format Specification of the specification.",
-              "default": ""
-            },
             "name": "filter",
-            "in": "query"
-          },
-          {
-            "description": "The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`",
+            "in": "query",
             "required": false,
             "schema": {
               "type": "string",
-              "title": "Response Format",
-              "description": "The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`",
-              "default": "json"
+              "description": "A filter string, in the format described in section API Filtering Format Specification of the specification.",
+              "default": "",
+              "title": "Filter"
             },
-            "name": "response_format",
-            "in": "query"
+            "description": "A filter string, in the format described in section API Filtering Format Specification of the specification."
           },
           {
-            "description": "An email address of the user making the request.\nThe email SHOULD be that of a person and not an automatic system.\nExample: `http://example.com/v1/structures?email_address=user@example.com`",
+            "name": "response_format",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`",
+              "default": "json",
+              "title": "Response Format"
+            },
+            "description": "The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`"
+          },
+          {
+            "name": "email_address",
+            "in": "query",
             "required": false,
             "schema": {
               "type": "string",
               "format": "email",
-              "title": "Email Address",
               "description": "An email address of the user making the request.\nThe email SHOULD be that of a person and not an automatic system.\nExample: `http://example.com/v1/structures?email_address=user@example.com`",
-              "default": ""
+              "default": "",
+              "title": "Email Address"
             },
-            "name": "email_address",
-            "in": "query"
+            "description": "An email address of the user making the request.\nThe email SHOULD be that of a person and not an automatic system.\nExample: `http://example.com/v1/structures?email_address=user@example.com`"
           },
           {
-            "description": "A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "pattern": "([a-z_][a-z_0-9]*(,[a-z_][a-z_0-9]*)*)?",
-              "title": "Response Fields",
-              "description": "A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`",
-              "default": ""
-            },
             "name": "response_fields",
-            "in": "query"
-          },
-          {
-            "description": "If supporting sortable queries, an implementation MUST use the `sort` query parameter with format as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-sorting).\n\nAn implementation MAY support multiple sort fields for a single query.\nIf it does, it again MUST conform to the JSON API 1.0 specification.\n\nIf an implementation supports sorting for an entry listing endpoint, then the `/info/<entries>` endpoint MUST include, for each field name `<fieldname>` in its `data.properties.<fieldname>` response value that can be used for sorting, the key `sortable` with value `true`.\nIf a field name under an entry listing endpoint supporting sorting cannot be used for sorting, the server MUST either leave out the `sortable` key or set it equal to `false` for the specific field name.\nThe set of field names, with `sortable` equal to `true` are allowed to be used in the \"sort fields\" list according to its definition in the JSON API 1.0 specification.\nThe field `sortable` is in addition to each property description and other OPTIONAL fields.\nAn example is shown in the section Entry Listing Info Endpoints.",
+            "in": "query",
             "required": false,
             "schema": {
               "type": "string",
               "pattern": "([a-z_][a-z_0-9]*(,[a-z_][a-z_0-9]*)*)?",
-              "title": "Sort",
-              "description": "If supporting sortable queries, an implementation MUST use the `sort` query parameter with format as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-sorting).\n\nAn implementation MAY support multiple sort fields for a single query.\nIf it does, it again MUST conform to the JSON API 1.0 specification.\n\nIf an implementation supports sorting for an entry listing endpoint, then the `/info/<entries>` endpoint MUST include, for each field name `<fieldname>` in its `data.properties.<fieldname>` response value that can be used for sorting, the key `sortable` with value `true`.\nIf a field name under an entry listing endpoint supporting sorting cannot be used for sorting, the server MUST either leave out the `sortable` key or set it equal to `false` for the specific field name.\nThe set of field names, with `sortable` equal to `true` are allowed to be used in the \"sort fields\" list according to its definition in the JSON API 1.0 specification.\nThe field `sortable` is in addition to each property description and other OPTIONAL fields.\nAn example is shown in the section Entry Listing Info Endpoints.",
-              "default": ""
+              "description": "A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`",
+              "default": "",
+              "title": "Response Fields"
             },
+            "description": "A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`"
+          },
+          {
             "name": "sort",
-            "in": "query"
-          },
-          {
-            "description": "Sets a numerical limit on the number of entries returned.\nSee [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-pagination).\nThe API implementation MUST return no more than the number specified.\nIt MAY return fewer.\nThe database MAY have a maximum limit and not accept larger numbers (in which case an error code -- 403 Forbidden -- MUST be returned).\nThe default limit value is up to the API implementation to decide.\nExample: `http://example.com/optimade/v1/structures?page_limit=100`",
+            "in": "query",
             "required": false,
             "schema": {
-              "type": "integer",
-              "minimum": 0.0,
-              "title": "Page Limit",
-              "description": "Sets a numerical limit on the number of entries returned.\nSee [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-pagination).\nThe API implementation MUST return no more than the number specified.\nIt MAY return fewer.\nThe database MAY have a maximum limit and not accept larger numbers (in which case an error code -- 403 Forbidden -- MUST be returned).\nThe default limit value is up to the API implementation to decide.\nExample: `http://example.com/optimade/v1/structures?page_limit=100`",
-              "default": 20
+              "type": "string",
+              "pattern": "([a-z_][a-z_0-9]*(,[a-z_][a-z_0-9]*)*)?",
+              "description": "If supporting sortable queries, an implementation MUST use the `sort` query parameter with format as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-sorting).\n\nAn implementation MAY support multiple sort fields for a single query.\nIf it does, it again MUST conform to the JSON API 1.0 specification.\n\nIf an implementation supports sorting for an entry listing endpoint, then the `/info/<entries>` endpoint MUST include, for each field name `<fieldname>` in its `data.properties.<fieldname>` response value that can be used for sorting, the key `sortable` with value `true`.\nIf a field name under an entry listing endpoint supporting sorting cannot be used for sorting, the server MUST either leave out the `sortable` key or set it equal to `false` for the specific field name.\nThe set of field names, with `sortable` equal to `true` are allowed to be used in the \"sort fields\" list according to its definition in the JSON API 1.0 specification.\nThe field `sortable` is in addition to each property description and other OPTIONAL fields.\nAn example is shown in the section Entry Listing Info Endpoints.",
+              "default": "",
+              "title": "Sort"
             },
+            "description": "If supporting sortable queries, an implementation MUST use the `sort` query parameter with format as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-sorting).\n\nAn implementation MAY support multiple sort fields for a single query.\nIf it does, it again MUST conform to the JSON API 1.0 specification.\n\nIf an implementation supports sorting for an entry listing endpoint, then the `/info/<entries>` endpoint MUST include, for each field name `<fieldname>` in its `data.properties.<fieldname>` response value that can be used for sorting, the key `sortable` with value `true`.\nIf a field name under an entry listing endpoint supporting sorting cannot be used for sorting, the server MUST either leave out the `sortable` key or set it equal to `false` for the specific field name.\nThe set of field names, with `sortable` equal to `true` are allowed to be used in the \"sort fields\" list according to its definition in the JSON API 1.0 specification.\nThe field `sortable` is in addition to each property description and other OPTIONAL fields.\nAn example is shown in the section Entry Listing Info Endpoints."
+          },
+          {
             "name": "page_limit",
-            "in": "query"
-          },
-          {
-            "description": "RECOMMENDED for use with _offset-based_ pagination: using `page_offset` and `page_limit` is RECOMMENDED.\nExample: Skip 50 structures and fetch up to 100: `/structures?page_offset=50&page_limit=100`.",
+            "in": "query",
             "required": false,
             "schema": {
               "type": "integer",
-              "minimum": 0.0,
-              "title": "Page Offset",
-              "description": "RECOMMENDED for use with _offset-based_ pagination: using `page_offset` and `page_limit` is RECOMMENDED.\nExample: Skip 50 structures and fetch up to 100: `/structures?page_offset=50&page_limit=100`.",
-              "default": 0
+              "minimum": 0,
+              "description": "Sets a numerical limit on the number of entries returned.\nSee [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-pagination).\nThe API implementation MUST return no more than the number specified.\nIt MAY return fewer.\nThe database MAY have a maximum limit and not accept larger numbers (in which case an error code -- 403 Forbidden -- MUST be returned).\nThe default limit value is up to the API implementation to decide.\nExample: `http://example.com/optimade/v1/structures?page_limit=100`",
+              "default": 20,
+              "title": "Page Limit"
             },
+            "description": "Sets a numerical limit on the number of entries returned.\nSee [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-pagination).\nThe API implementation MUST return no more than the number specified.\nIt MAY return fewer.\nThe database MAY have a maximum limit and not accept larger numbers (in which case an error code -- 403 Forbidden -- MUST be returned).\nThe default limit value is up to the API implementation to decide.\nExample: `http://example.com/optimade/v1/structures?page_limit=100`"
+          },
+          {
             "name": "page_offset",
-            "in": "query"
-          },
-          {
-            "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`.",
+            "in": "query",
             "required": false,
             "schema": {
               "type": "integer",
-              "title": "Page Number",
-              "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`."
+              "minimum": 0,
+              "description": "RECOMMENDED for use with _offset-based_ pagination: using `page_offset` and `page_limit` is RECOMMENDED.\nExample: Skip 50 structures and fetch up to 100: `/structures?page_offset=50&page_limit=100`.",
+              "default": 0,
+              "title": "Page Offset"
             },
+            "description": "RECOMMENDED for use with _offset-based_ pagination: using `page_offset` and `page_limit` is RECOMMENDED.\nExample: Skip 50 structures and fetch up to 100: `/structures?page_offset=50&page_limit=100`."
+          },
+          {
             "name": "page_number",
-            "in": "query"
-          },
-          {
-            "description": "RECOMMENDED for use with _cursor-based_ pagination: using `page_cursor` and `page_limit` is RECOMMENDED.",
+            "in": "query",
             "required": false,
             "schema": {
               "type": "integer",
-              "minimum": 0.0,
-              "title": "Page Cursor",
-              "description": "RECOMMENDED for use with _cursor-based_ pagination: using `page_cursor` and `page_limit` is RECOMMENDED.",
-              "default": 0
+              "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`.",
+              "title": "Page Number"
             },
+            "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`."
+          },
+          {
             "name": "page_cursor",
-            "in": "query"
-          },
-          {
-            "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.\nExample: Fetch up to 100 structures above sort-field value 4000 (in this example, server chooses to fetch results sorted by increasing `id`, so `page_above` value refers to an `id` value): `/structures?page_above=4000&page_limit=100`.",
+            "in": "query",
             "required": false,
             "schema": {
-              "type": "string",
-              "title": "Page Above",
-              "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.\nExample: Fetch up to 100 structures above sort-field value 4000 (in this example, server chooses to fetch results sorted by increasing `id`, so `page_above` value refers to an `id` value): `/structures?page_above=4000&page_limit=100`."
+              "type": "integer",
+              "minimum": 0,
+              "description": "RECOMMENDED for use with _cursor-based_ pagination: using `page_cursor` and `page_limit` is RECOMMENDED.",
+              "default": 0,
+              "title": "Page Cursor"
             },
+            "description": "RECOMMENDED for use with _cursor-based_ pagination: using `page_cursor` and `page_limit` is RECOMMENDED."
+          },
+          {
             "name": "page_above",
-            "in": "query"
-          },
-          {
-            "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.",
+            "in": "query",
             "required": false,
             "schema": {
               "type": "string",
-              "title": "Page Below",
-              "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED."
+              "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.\nExample: Fetch up to 100 structures above sort-field value 4000 (in this example, server chooses to fetch results sorted by increasing `id`, so `page_above` value refers to an `id` value): `/structures?page_above=4000&page_limit=100`.",
+              "title": "Page Above"
             },
+            "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.\nExample: Fetch up to 100 structures above sort-field value 4000 (in this example, server chooses to fetch results sorted by increasing `id`, so `page_above` value refers to an `id` value): `/structures?page_above=4000&page_limit=100`."
+          },
+          {
             "name": "page_below",
-            "in": "query"
-          },
-          {
-            "description": "A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of \"relationship paths\", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`.",
+            "in": "query",
             "required": false,
             "schema": {
               "type": "string",
-              "title": "Include",
-              "description": "A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of \"relationship paths\", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`.",
-              "default": "references"
+              "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.",
+              "title": "Page Below"
             },
-            "name": "include",
-            "in": "query"
+            "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED."
           },
           {
-            "description": "If the client provides the parameter, the value SHOULD have the format `vMAJOR` or `vMAJOR.MINOR`, where MAJOR is a major version and MINOR is a minor version of the API. For example, if a client appends `api_hint=v1.0` to the query string, the hint provided is for major version 1 and minor version 0.",
+            "name": "include",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of \"relationship paths\", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`.",
+              "default": "references",
+              "title": "Include"
+            },
+            "description": "A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of \"relationship paths\", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`."
+          },
+          {
+            "name": "api_hint",
+            "in": "query",
             "required": false,
             "schema": {
               "type": "string",
               "pattern": "(v[0-9]+(\\.[0-9]+)?)?",
-              "title": "Api Hint",
               "description": "If the client provides the parameter, the value SHOULD have the format `vMAJOR` or `vMAJOR.MINOR`, where MAJOR is a major version and MINOR is a minor version of the API. For example, if a client appends `api_hint=v1.0` to the query string, the hint provided is for major version 1 and minor version 0.",
-              "default": ""
+              "default": "",
+              "title": "Api Hint"
             },
-            "name": "api_hint",
-            "in": "query"
+            "description": "If the client provides the parameter, the value SHOULD have the format `vMAJOR` or `vMAJOR.MINOR`, where MAJOR is a major version and MINOR is a minor version of the API. For example, if a client appends `api_hint=v1.0` to the query string, the hint provided is for major version 1 and minor version 0."
           }
         ],
         "responses": {
@@ -1132,76 +1132,76 @@
         "operationId": "get_single_structure_structures__entry_id__get",
         "parameters": [
           {
+            "name": "entry_id",
+            "in": "path",
             "required": true,
             "schema": {
               "type": "string",
               "title": "Entry Id"
-            },
-            "name": "entry_id",
-            "in": "path"
+            }
           },
           {
-            "description": "The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`",
+            "name": "response_format",
+            "in": "query",
             "required": false,
             "schema": {
               "type": "string",
-              "title": "Response Format",
               "description": "The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`",
-              "default": "json"
+              "default": "json",
+              "title": "Response Format"
             },
-            "name": "response_format",
-            "in": "query"
+            "description": "The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`"
           },
           {
-            "description": "An email address of the user making the request.\nThe email SHOULD be that of a person and not an automatic system.\nExample: `http://example.com/v1/structures?email_address=user@example.com`",
+            "name": "email_address",
+            "in": "query",
             "required": false,
             "schema": {
               "type": "string",
               "format": "email",
-              "title": "Email Address",
               "description": "An email address of the user making the request.\nThe email SHOULD be that of a person and not an automatic system.\nExample: `http://example.com/v1/structures?email_address=user@example.com`",
-              "default": ""
+              "default": "",
+              "title": "Email Address"
             },
-            "name": "email_address",
-            "in": "query"
+            "description": "An email address of the user making the request.\nThe email SHOULD be that of a person and not an automatic system.\nExample: `http://example.com/v1/structures?email_address=user@example.com`"
           },
           {
-            "description": "A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`",
+            "name": "response_fields",
+            "in": "query",
             "required": false,
             "schema": {
               "type": "string",
               "pattern": "([a-z_][a-z_0-9]*(,[a-z_][a-z_0-9]*)*)?",
-              "title": "Response Fields",
               "description": "A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`",
-              "default": ""
+              "default": "",
+              "title": "Response Fields"
             },
-            "name": "response_fields",
-            "in": "query"
+            "description": "A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`"
           },
           {
-            "description": "A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of \"relationship paths\", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`.",
+            "name": "include",
+            "in": "query",
             "required": false,
             "schema": {
               "type": "string",
-              "title": "Include",
               "description": "A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of \"relationship paths\", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`.",
-              "default": "references"
+              "default": "references",
+              "title": "Include"
             },
-            "name": "include",
-            "in": "query"
+            "description": "A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of \"relationship paths\", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`."
           },
           {
-            "description": "If the client provides the parameter, the value SHOULD have the format `vMAJOR` or `vMAJOR.MINOR`, where MAJOR is a major version and MINOR is a minor version of the API. For example, if a client appends `api_hint=v1.0` to the query string, the hint provided is for major version 1 and minor version 0.",
+            "name": "api_hint",
+            "in": "query",
             "required": false,
             "schema": {
               "type": "string",
               "pattern": "(v[0-9]+(\\.[0-9]+)?)?",
-              "title": "Api Hint",
               "description": "If the client provides the parameter, the value SHOULD have the format `vMAJOR` or `vMAJOR.MINOR`, where MAJOR is a major version and MINOR is a minor version of the API. For example, if a client appends `api_hint=v1.0` to the query string, the hint provided is for major version 1 and minor version 0.",
-              "default": ""
+              "default": "",
+              "title": "Api Hint"
             },
-            "name": "api_hint",
-            "in": "query"
+            "description": "If the client provides the parameter, the value SHOULD have the format `vMAJOR` or `vMAJOR.MINOR`, where MAJOR is a major version and MINOR is a minor version of the API. For example, if a client appends `api_hint=v1.0` to the query string, the hint provided is for major version 1 and minor version 0."
           }
         ],
         "responses": {
@@ -1314,6 +1314,7 @@
   "components": {
     "schemas": {
       "Aggregate": {
+        "type": "string",
         "enum": [
           "ok",
           "test",
@@ -1335,8 +1336,8 @@
             "type": "array",
             "title": "Sites In Groups",
             "description": "Index of the sites (0-based) that belong to each group for each assembly.\n\n- **Examples**:\n    - `[[1], [2]]`: two groups, one with the second site, one with the third.\n    - `[[1,2], [3]]`: one group with the second and third site, one with the fourth.",
-            "x-optimade-support": "must",
-            "x-optimade-queryable": "optional"
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "must"
           },
           "group_probabilities": {
             "items": {
@@ -1345,8 +1346,8 @@
             "type": "array",
             "title": "Group Probabilities",
             "description": "Statistical probability of each group. It MUST have the same length as `sites_in_groups`.\nIt SHOULD sum to one.\nSee below for examples of how to specify the probability of the occurrence of a vacancy.\nThe possible reasons for the values not to sum to one are the same as already specified above for the `concentration` of each `species`.",
-            "x-optimade-support": "must",
-            "x-optimade-queryable": "optional"
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "must"
           }
         },
         "type": "object",
@@ -1359,6 +1360,7 @@
       },
       "Attributes": {
         "properties": {},
+        "additionalProperties": true,
         "type": "object",
         "title": "Attributes",
         "description": "Members of the attributes object (\"attributes\") represent information about the resource object in which it's defined.\nThe keys for Attributes MUST NOT be:\n    relationships\n    links\n    id\n    type"
@@ -1367,9 +1369,8 @@
         "properties": {
           "url": {
             "type": "string",
-            "maxLength": 65536,
             "minLength": 1,
-            "pattern": ".+/v[0-1](\\.[0-9]+)*/?$",
+            "pattern": "^.+/v[0-1](\\.[0-9]+)*/?$",
             "format": "uri",
             "title": "Url",
             "description": "A string specifying a versioned base URL that MUST adhere to the rules in section Base URL"
@@ -1379,7 +1380,7 @@
             "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "title": "Version",
             "description": "A string containing the full version number of the API served at that versioned base URL.\nThe version number string MUST NOT be prefixed by, e.g., 'v'.\nExamples: `1.0.0`, `1.0.0-rc.2`.",
-            "example": [
+            "examples": [
               "0.10.1",
               "1.0.0-rc.2",
               "1.2.3-rc.5+develop"
@@ -1401,7 +1402,7 @@
             "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "title": "Api Version",
             "description": "Presently used full version of the OPTIMADE API.\nThe version number string MUST NOT be prefixed by, e.g., \"v\".\nExamples: `1.0.0`, `1.0.0-rc.2`.",
-            "example": [
+            "examples": [
               "0.10.1",
               "1.0.0-rc.2",
               "1.2.3-rc.5+develop"
@@ -1446,7 +1447,14 @@
             "description": "Available entry endpoints as a function of output formats."
           },
           "is_index": {
-            "type": "boolean",
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Is Index",
             "description": "If true, this is an index meta-database base URL (see section Index Meta-Database). If this member is not provided, the client MUST assume this is not an index meta-database base URL (i.e., the default is for `is_index` to be `false`).",
             "default": false
@@ -1465,45 +1473,49 @@
       "BaseInfoResource": {
         "properties": {
           "id": {
-            "type": "string",
-            "pattern": "^/$",
+            "const": "/",
             "title": "Id",
             "default": "/"
           },
           "type": {
-            "type": "string",
-            "pattern": "^info$",
+            "const": "info",
             "title": "Type",
             "default": "info"
           },
           "links": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/ResourceLinks"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Links",
             "description": "a links object containing links related to the resource."
           },
           "meta": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/Meta"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Meta",
             "description": "a meta object containing non-standard meta-information about a resource that can not be represented as an attribute or relationship."
           },
           "attributes": {
             "$ref": "#/components/schemas/BaseInfoAttributes"
           },
           "relationships": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/Relationships"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Relationships",
             "description": "[Relationships object](https://jsonapi.org/format/1.0/#document-resource-object-relationships)\ndescribing relationships between the resource and other JSON API resources."
           }
         },
@@ -1513,8 +1525,7 @@
           "type",
           "attributes"
         ],
-        "title": "BaseInfoResource",
-        "description": "Resource objects appear in a JSON API document to represent resources."
+        "title": "BaseInfoResource"
       },
       "BaseRelationshipMeta": {
         "properties": {
@@ -1524,6 +1535,7 @@
             "description": "OPTIONAL human-readable description of the relationship."
           }
         },
+        "additionalProperties": true,
         "type": "object",
         "required": [
           "description"
@@ -1544,12 +1556,14 @@
             "description": "Resource type"
           },
           "meta": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/BaseRelationshipMeta"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Meta",
             "description": "Relationship meta field. MUST contain 'description' if supplied."
           }
         },
@@ -1562,6 +1576,7 @@
         "description": "Minimum requirements to represent a relationship resource"
       },
       "DataType": {
+        "type": "string",
         "enum": [
           "string",
           "integer",
@@ -1573,7 +1588,7 @@
           "unknown"
         ],
         "title": "DataType",
-        "description": "Optimade Data Types\n\nSee the section \"Data types\" in the OPTIMADE API specification for more information."
+        "description": "Optimade Data types\n\nSee the section \"Data types\" in the OPTIMADE API specification for more information."
       },
       "EntryInfoProperty": {
         "properties": {
@@ -1583,19 +1598,36 @@
             "description": "A human-readable description of the entry property"
           },
           "unit": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Unit",
             "description": "The physical unit of the entry property.\nThis MUST be a valid representation of units according to version 2.1 of [The Unified Code for Units of Measure](https://unitsofmeasure.org/ucum.html).\nIt is RECOMMENDED that non-standard (non-SI) units are described in the description for the property."
           },
           "sortable": {
-            "type": "boolean",
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Sortable",
             "description": "Defines whether the entry property can be used for sorting with the \"sort\" parameter.\nIf the entry listing endpoint supports sorting, this key MUST be present for sortable properties with value `true`."
           },
           "type": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/DataType"
+              },
+              {
+                "type": "null"
               }
             ],
             "title": "Type",
@@ -1660,7 +1692,6 @@
                 "$ref": "#/components/schemas/EntryInfoResource"
               }
             ],
-            "title": "Data",
             "description": "OPTIMADE information for an entry endpoint."
           },
           "meta": {
@@ -1669,43 +1700,60 @@
                 "$ref": "#/components/schemas/ResponseMeta"
               }
             ],
-            "title": "Meta",
             "description": "A meta object containing non-standard information"
           },
           "errors": {
-            "items": {
-              "$ref": "#/components/schemas/Error"
-            },
-            "type": "array",
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "uniqueItems": true,
             "title": "Errors",
             "description": "A list of unique errors"
           },
           "included": {
-            "items": {
-              "$ref": "#/components/schemas/Resource"
-            },
-            "type": "array",
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/Resource"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "uniqueItems": true,
             "title": "Included",
             "description": "A list of unique included resources"
           },
           "links": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/ToplevelLinks"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Links",
             "description": "Links associated with the primary data or errors"
           },
           "jsonapi": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/JsonApi"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Jsonapi",
             "description": "Information about the JSON API used"
           }
         },
@@ -1714,27 +1762,30 @@
           "data",
           "meta"
         ],
-        "title": "EntryInfoResponse",
-        "description": "errors are not allowed"
+        "title": "EntryInfoResponse"
       },
       "EntryRelationships": {
         "properties": {
           "references": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/ReferenceRelationship"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "References",
             "description": "Object containing links to relationships with entries of the `references` type."
           },
           "structures": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/StructureRelationship"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Structures",
             "description": "Object containing links to relationships with entries of the `structures` type."
           }
         },
@@ -1748,32 +1799,36 @@
             "type": "string",
             "title": "Id",
             "description": "An entry's ID as defined in section Definition of Terms.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n\n- **Examples**:\n    - `\"db/1234567\"`\n    - `\"cod/2000000\"`\n    - `\"cod/2000000@1234567\"`\n    - `\"nomad/L1234567890\"`\n    - `\"42\"`",
-            "x-optimade-support": "must",
-            "x-optimade-queryable": "must"
+            "x-optimade-queryable": "must",
+            "x-optimade-support": "must"
           },
           "type": {
             "type": "string",
             "title": "Type",
             "description": "The name of the type of an entry.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n    - MUST be an existing entry type.\n    - The entry of type `<type>` and ID `<id>` MUST be returned in response to a request for `/<type>/<id>` under the versioned base URL.\n\n- **Example**: `\"structures\"`",
-            "x-optimade-support": "must",
-            "x-optimade-queryable": "must"
+            "x-optimade-queryable": "must",
+            "x-optimade-support": "must"
           },
           "links": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/ResourceLinks"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Links",
             "description": "a links object containing links related to the resource."
           },
           "meta": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/Meta"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Meta",
             "description": "a meta object containing non-standard meta-information about a resource that can not be represented as an attribute or relationship."
           },
           "attributes": {
@@ -1782,16 +1837,17 @@
                 "$ref": "#/components/schemas/EntryResourceAttributes"
               }
             ],
-            "title": "Attributes",
             "description": "A dictionary, containing key-value pairs representing the entry's properties, except for `type` and `id`.\nDatabase-provider-specific properties need to include the database-provider-specific prefix (see section on Database-Provider-Specific Namespace Prefixes)."
           },
           "relationships": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/EntryRelationships"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Relationships",
             "description": "A dictionary containing references to other entries according to the description in section Relationships encoded as [JSON API Relationships](https://jsonapi.org/format/1.0/#document-resource-object-relationships).\nThe OPTIONAL human-readable description of the relationship MAY be provided in the `description` field inside the `meta` dictionary of the JSON API resource identifier object."
           }
         },
@@ -1807,21 +1863,36 @@
       "EntryResourceAttributes": {
         "properties": {
           "immutable_id": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Immutable Id",
             "description": "The entry's immutable ID (e.g., an UUID). This is important for databases having preferred IDs that point to \"the latest version\" of a record, but still offer access to older variants. This ID maps to the version-specific record, in case it changes in the future.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n\n- **Examples**:\n    - `\"8bd3e750-b477-41a0-9b11-3a799f21b44f\"`\n    - `\"fjeiwoj,54;@=%<>#32\"` (Strings that are not URL-safe are allowed.)",
-            "x-optimade-support": "optional",
-            "x-optimade-queryable": "must"
+            "x-optimade-queryable": "must",
+            "x-optimade-support": "optional"
           },
           "last_modified": {
-            "type": "string",
-            "format": "date-time",
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Last Modified",
             "description": "Date and time representing when the entry was last modified.\n\n- **Type**: timestamp.\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response unless the query parameter `response_fields` is present and does not include this property.\n\n- **Example**:\n    - As part of JSON response format: `\"2007-04-05T14:30:20Z\"` (i.e., encoded as an [RFC 3339 Internet Date/Time Format](https://tools.ietf.org/html/rfc3339#section-5.6) string.)",
-            "x-optimade-support": "should",
-            "x-optimade-queryable": "must"
+            "x-optimade-queryable": "must",
+            "x-optimade-support": "should"
           }
         },
+        "additionalProperties": true,
         "type": "object",
         "required": [
           "last_modified"
@@ -1832,55 +1903,96 @@
       "Error": {
         "properties": {
           "id": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Id",
             "description": "A unique identifier for this particular occurrence of the problem."
           },
           "links": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/ErrorLinks"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Links",
             "description": "A links object storing about"
           },
           "status": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Status",
             "description": "the HTTP status code applicable to this problem, expressed as a string value."
           },
           "code": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Code",
             "description": "an application-specific error code, expressed as a string value."
           },
           "title": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Title",
             "description": "A short, human-readable summary of the problem. It **SHOULD NOT** change from occurrence to occurrence of the problem, except for purposes of localization."
           },
           "detail": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Detail",
             "description": "A human-readable explanation specific to this occurrence of the problem."
           },
           "source": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/ErrorSource"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Source",
             "description": "An object containing references to the source of the error"
           },
           "meta": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/Meta"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Meta",
             "description": "a meta object containing non-standard meta-information about the error."
           }
         },
@@ -1894,12 +2006,14 @@
             "anyOf": [
               {
                 "type": "string",
-                "maxLength": 65536,
                 "minLength": 1,
                 "format": "uri"
               },
               {
                 "$ref": "#/components/schemas/Link"
+              },
+              {
+                "type": "null"
               }
             ],
             "title": "About",
@@ -1922,6 +2036,9 @@
                   "$ref": "#/components/schemas/Resource"
                 },
                 "type": "array"
+              },
+              {
+                "type": "null"
               }
             ],
             "uniqueItems": true,
@@ -1934,7 +2051,6 @@
                 "$ref": "#/components/schemas/ResponseMeta"
               }
             ],
-            "title": "Meta",
             "description": "A meta object containing non-standard information."
           },
           "errors": {
@@ -1947,30 +2063,41 @@
             "description": "A list of OPTIMADE-specific JSON API error objects, where the field detail MUST be present."
           },
           "included": {
-            "items": {
-              "$ref": "#/components/schemas/Resource"
-            },
-            "type": "array",
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/Resource"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "uniqueItems": true,
             "title": "Included",
             "description": "A list of unique included resources"
           },
           "links": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/ToplevelLinks"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Links",
             "description": "Links associated with the primary data or errors"
           },
           "jsonapi": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/JsonApi"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Jsonapi",
             "description": "Information about the JSON API used"
           }
         },
@@ -1985,12 +2112,26 @@
       "ErrorSource": {
         "properties": {
           "pointer": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Pointer",
             "description": "a JSON Pointer [RFC6901] to the associated entity in the request document [e.g. \"/data\" for a primary data object, or \"/data/attributes/title\" for a specific attribute]."
           },
           "parameter": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Parameter",
             "description": "a string indicating which URI query parameter caused the error."
           }
@@ -2002,12 +2143,26 @@
       "Implementation": {
         "properties": {
           "name": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Name",
             "description": "name of the implementation"
           },
           "version": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Version",
             "description": "version string of the current implementation"
           },
@@ -2015,12 +2170,14 @@
             "anyOf": [
               {
                 "type": "string",
-                "maxLength": 65536,
                 "minLength": 1,
                 "format": "uri"
               },
               {
                 "$ref": "#/components/schemas/Link"
+              },
+              {
+                "type": "null"
               }
             ],
             "title": "Homepage",
@@ -2030,36 +2187,42 @@
             "anyOf": [
               {
                 "type": "string",
-                "maxLength": 65536,
                 "minLength": 1,
                 "format": "uri"
               },
               {
                 "$ref": "#/components/schemas/Link"
+              },
+              {
+                "type": "null"
               }
             ],
             "title": "Source Url",
             "description": "A [JSON API links object](http://jsonapi.org/format/1.0/#document-links) pointing to the implementation source, either downloadable archive or version control system."
           },
           "maintainer": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/ImplementationMaintainer"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Maintainer",
             "description": "A dictionary providing details about the maintainer of the implementation."
           },
           "issue_tracker": {
             "anyOf": [
               {
                 "type": "string",
-                "maxLength": 65536,
                 "minLength": 1,
                 "format": "uri"
               },
               {
                 "$ref": "#/components/schemas/Link"
+              },
+              {
+                "type": "null"
               }
             ],
             "title": "Issue Tracker",
@@ -2094,7 +2257,6 @@
                 "$ref": "#/components/schemas/BaseInfoResource"
               }
             ],
-            "title": "Data",
             "description": "The implementations /info data."
           },
           "meta": {
@@ -2103,43 +2265,60 @@
                 "$ref": "#/components/schemas/ResponseMeta"
               }
             ],
-            "title": "Meta",
             "description": "A meta object containing non-standard information"
           },
           "errors": {
-            "items": {
-              "$ref": "#/components/schemas/Error"
-            },
-            "type": "array",
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "uniqueItems": true,
             "title": "Errors",
             "description": "A list of unique errors"
           },
           "included": {
-            "items": {
-              "$ref": "#/components/schemas/Resource"
-            },
-            "type": "array",
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/Resource"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "uniqueItems": true,
             "title": "Included",
             "description": "A list of unique included resources"
           },
           "links": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/ToplevelLinks"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Links",
             "description": "Links associated with the primary data or errors"
           },
           "jsonapi": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/JsonApi"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Jsonapi",
             "description": "Information about the JSON API used"
           }
         },
@@ -2148,8 +2327,7 @@
           "data",
           "meta"
         ],
-        "title": "InfoResponse",
-        "description": "errors are not allowed"
+        "title": "InfoResponse"
       },
       "JsonApi": {
         "properties": {
@@ -2160,12 +2338,14 @@
             "default": "1.0"
           },
           "meta": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/Meta"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Meta",
             "description": "Non-standard meta information"
           }
         },
@@ -2177,19 +2357,20 @@
         "properties": {
           "href": {
             "type": "string",
-            "maxLength": 65536,
             "minLength": 1,
             "format": "uri",
             "title": "Href",
-            "description": "a string containing the link\u2019s URL."
+            "description": "a string containing the link's URL."
           },
           "meta": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/Meta"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Meta",
             "description": "a meta object containing non-standard meta-information about the link."
           }
         },
@@ -2201,6 +2382,7 @@
         "description": "A link **MUST** be represented as either: a string containing the link's URL or a link object."
       },
       "LinkType": {
+        "type": "string",
         "enum": [
           "child",
           "root",
@@ -2216,32 +2398,36 @@
             "type": "string",
             "title": "Id",
             "description": "An entry's ID as defined in section Definition of Terms.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n\n- **Examples**:\n    - `\"db/1234567\"`\n    - `\"cod/2000000\"`\n    - `\"cod/2000000@1234567\"`\n    - `\"nomad/L1234567890\"`\n    - `\"42\"`",
-            "x-optimade-support": "must",
-            "x-optimade-queryable": "must"
+            "x-optimade-queryable": "must",
+            "x-optimade-support": "must"
           },
           "type": {
-            "type": "string",
+            "const": "links",
             "pattern": "^links$",
             "title": "Type",
             "description": "These objects are described in detail in the section Links Endpoint",
             "default": "links"
           },
           "links": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/ResourceLinks"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Links",
             "description": "a links object containing links related to the resource."
           },
           "meta": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/Meta"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Meta",
             "description": "a meta object containing non-standard meta-information about a resource that can not be represented as an attribute or relationship."
           },
           "attributes": {
@@ -2250,16 +2436,17 @@
                 "$ref": "#/components/schemas/LinksResourceAttributes"
               }
             ],
-            "title": "Attributes",
             "description": "A dictionary containing key-value pairs representing the Links resource's properties."
           },
           "relationships": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/EntryRelationships"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Relationships",
             "description": "A dictionary containing references to other entries according to the description in section Relationships encoded as [JSON API Relationships](https://jsonapi.org/format/1.0/#document-resource-object-relationships).\nThe OPTIONAL human-readable description of the relationship MAY be provided in the `description` field inside the `meta` dictionary of the JSON API resource identifier object."
           }
         },
@@ -2288,12 +2475,14 @@
             "anyOf": [
               {
                 "type": "string",
-                "maxLength": 65536,
                 "minLength": 1,
                 "format": "uri"
               },
               {
                 "$ref": "#/components/schemas/Link"
+              },
+              {
+                "type": "null"
               }
             ],
             "title": "Base Url",
@@ -2303,12 +2492,14 @@
             "anyOf": [
               {
                 "type": "string",
-                "maxLength": 65536,
                 "minLength": 1,
                 "format": "uri"
               },
               {
                 "$ref": "#/components/schemas/Link"
+              },
+              {
+                "type": "null"
               }
             ],
             "title": "Homepage",
@@ -2324,9 +2515,12 @@
             "description": "The type of the linked relation.\nMUST be one of these values: 'child', 'root', 'external', 'providers'."
           },
           "aggregate": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/Aggregate"
+              },
+              {
+                "type": "null"
               }
             ],
             "title": "Aggregate",
@@ -2334,11 +2528,19 @@
             "default": "ok"
           },
           "no_aggregate_reason": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "No Aggregate Reason",
             "description": "An OPTIONAL human-readable string indicating the reason for suggesting not to aggregate results following the link.\nIt SHOULD NOT be present if `aggregate`=`ok`."
           }
         },
+        "additionalProperties": true,
         "type": "object",
         "required": [
           "name",
@@ -2377,14 +2579,20 @@
                 "$ref": "#/components/schemas/ResponseMeta"
               }
             ],
-            "title": "Meta",
             "description": "A meta object containing non-standard information"
           },
           "errors": {
-            "items": {
-              "$ref": "#/components/schemas/Error"
-            },
-            "type": "array",
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "uniqueItems": true,
             "title": "Errors",
             "description": "A list of unique errors"
@@ -2402,27 +2610,35 @@
                   "type": "object"
                 },
                 "type": "array"
+              },
+              {
+                "type": "null"
               }
             ],
             "uniqueItems": true,
-            "title": "Included"
+            "title": "Included",
+            "description": "A list of unique included OPTIMADE entry resources."
           },
           "links": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/ToplevelLinks"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Links",
             "description": "Links associated with the primary data or errors"
           },
           "jsonapi": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/JsonApi"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Jsonapi",
             "description": "Information about the JSON API used"
           }
         },
@@ -2431,11 +2647,11 @@
           "data",
           "meta"
         ],
-        "title": "LinksResponse",
-        "description": "errors are not allowed"
+        "title": "LinksResponse"
       },
       "Meta": {
         "properties": {},
+        "additionalProperties": true,
         "type": "object",
         "title": "Meta",
         "description": "Non-standard meta-information that can not be represented as an attribute or relationship."
@@ -2443,31 +2659,61 @@
       "OptimadeError": {
         "properties": {
           "id": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Id",
             "description": "A unique identifier for this particular occurrence of the problem."
           },
           "links": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/ErrorLinks"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Links",
             "description": "A links object storing about"
           },
           "status": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Status",
             "description": "the HTTP status code applicable to this problem, expressed as a string value."
           },
           "code": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Code",
             "description": "an application-specific error code, expressed as a string value."
           },
           "title": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Title",
             "description": "A short, human-readable summary of the problem. It **SHOULD NOT** change from occurrence to occurrence of the problem, except for purposes of localization."
           },
@@ -2477,21 +2723,25 @@
             "description": "A human-readable explanation specific to this occurrence of the problem."
           },
           "source": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/ErrorSource"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Source",
             "description": "An object containing references to the source of the error"
           },
           "meta": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/Meta"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Meta",
             "description": "a meta object containing non-standard meta-information about the error."
           }
         },
@@ -2517,22 +2767,36 @@
             "type": "string",
             "title": "Name",
             "description": "Full name of the person, REQUIRED.",
-            "x-optimade-support": "must",
-            "x-optimade-queryable": "optional"
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "must"
           },
           "firstname": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Firstname",
             "description": "First name of the person.",
-            "x-optimade-support": "optional",
-            "x-optimade-queryable": "optional"
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "lastname": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Lastname",
             "description": "Last name of the person.",
-            "x-optimade-support": "optional",
-            "x-optimade-queryable": "optional"
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           }
         },
         "type": "object",
@@ -2564,12 +2828,14 @@
             "anyOf": [
               {
                 "type": "string",
-                "maxLength": 65536,
                 "minLength": 1,
                 "format": "uri"
               },
               {
                 "$ref": "#/components/schemas/Link"
+              },
+              {
+                "type": "null"
               }
             ],
             "title": "Homepage",
@@ -2588,12 +2854,14 @@
       "ReferenceRelationship": {
         "properties": {
           "links": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/RelationshipLinks"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Links",
             "description": "a links object containing at least one of the following: self, related"
           },
           "data": {
@@ -2606,6 +2874,9 @@
                   "$ref": "#/components/schemas/BaseRelationshipResource"
                 },
                 "type": "array"
+              },
+              {
+                "type": "null"
               }
             ],
             "uniqueItems": true,
@@ -2613,18 +2884,19 @@
             "description": "Resource linkage"
           },
           "meta": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/Meta"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Meta",
             "description": "a meta object that contains non-standard meta-information about the relationship."
           }
         },
         "type": "object",
-        "title": "ReferenceRelationship",
-        "description": "Similar to normal JSON API relationship, but with addition of OPTIONAL meta field for a resource."
+        "title": "ReferenceRelationship"
       },
       "ReferenceResource": {
         "properties": {
@@ -2632,46 +2904,52 @@
             "type": "string",
             "title": "Id",
             "description": "An entry's ID as defined in section Definition of Terms.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n\n- **Examples**:\n    - `\"db/1234567\"`\n    - `\"cod/2000000\"`\n    - `\"cod/2000000@1234567\"`\n    - `\"nomad/L1234567890\"`\n    - `\"42\"`",
-            "x-optimade-support": "must",
-            "x-optimade-queryable": "must"
+            "x-optimade-queryable": "must",
+            "x-optimade-support": "must"
           },
           "type": {
-            "type": "string",
+            "const": "references",
             "pattern": "^references$",
             "title": "Type",
             "description": "The name of the type of an entry.\n- **Type**: string.\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n    - MUST be an existing entry type.\n    - The entry of type <type> and ID <id> MUST be returned in response to a request for `/<type>/<id>` under the versioned base URL.\n- **Example**: `\"structures\"`",
             "default": "references",
-            "x-optimade-support": "must",
-            "x-optimade-queryable": "must"
+            "x-optimade-queryable": "must",
+            "x-optimade-support": "must"
           },
           "links": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/ResourceLinks"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Links",
             "description": "a links object containing links related to the resource."
           },
           "meta": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/Meta"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Meta",
             "description": "a meta object containing non-standard meta-information about a resource that can not be represented as an attribute or relationship."
           },
           "attributes": {
             "$ref": "#/components/schemas/ReferenceResourceAttributes"
           },
           "relationships": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/EntryRelationships"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Relationships",
             "description": "A dictionary containing references to other entries according to the description in section Relationships encoded as [JSON API Relationships](https://jsonapi.org/format/1.0/#document-resource-object-relationships).\nThe OPTIONAL human-readable description of the relationship MAY be provided in the `description` field inside the `meta` dictionary of the JSON API resource identifier object."
           }
         },
@@ -2687,212 +2965,408 @@
       "ReferenceResourceAttributes": {
         "properties": {
           "immutable_id": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Immutable Id",
             "description": "The entry's immutable ID (e.g., an UUID). This is important for databases having preferred IDs that point to \"the latest version\" of a record, but still offer access to older variants. This ID maps to the version-specific record, in case it changes in the future.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n\n- **Examples**:\n    - `\"8bd3e750-b477-41a0-9b11-3a799f21b44f\"`\n    - `\"fjeiwoj,54;@=%<>#32\"` (Strings that are not URL-safe are allowed.)",
-            "x-optimade-support": "optional",
-            "x-optimade-queryable": "must"
+            "x-optimade-queryable": "must",
+            "x-optimade-support": "optional"
           },
           "last_modified": {
-            "type": "string",
-            "format": "date-time",
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Last Modified",
             "description": "Date and time representing when the entry was last modified.\n\n- **Type**: timestamp.\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response unless the query parameter `response_fields` is present and does not include this property.\n\n- **Example**:\n    - As part of JSON response format: `\"2007-04-05T14:30:20Z\"` (i.e., encoded as an [RFC 3339 Internet Date/Time Format](https://tools.ietf.org/html/rfc3339#section-5.6) string.)",
-            "x-optimade-support": "should",
-            "x-optimade-queryable": "must"
+            "x-optimade-queryable": "must",
+            "x-optimade-support": "should"
           },
           "authors": {
-            "items": {
-              "$ref": "#/components/schemas/Person"
-            },
-            "type": "array",
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/Person"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Authors",
             "description": "List of person objects containing the authors of the reference.",
-            "x-optimade-support": "optional",
-            "x-optimade-queryable": "optional"
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "editors": {
-            "items": {
-              "$ref": "#/components/schemas/Person"
-            },
-            "type": "array",
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/Person"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Editors",
             "description": "List of person objects containing the editors of the reference.",
-            "x-optimade-support": "optional",
-            "x-optimade-queryable": "optional"
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "doi": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Doi",
             "description": "The digital object identifier of the reference.",
-            "x-optimade-support": "optional",
-            "x-optimade-queryable": "optional"
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "url": {
-            "type": "string",
-            "maxLength": 65536,
-            "minLength": 1,
-            "format": "uri",
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1,
+                "format": "uri"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Url",
             "description": "The URL of the reference.",
-            "x-optimade-support": "optional",
-            "x-optimade-queryable": "optional"
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "address": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Address",
             "description": "Meaning of property matches the BiBTeX specification.",
-            "x-optimade-support": "optional",
-            "x-optimade-queryable": "optional"
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "annote": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Annote",
             "description": "Meaning of property matches the BiBTeX specification.",
-            "x-optimade-support": "optional",
-            "x-optimade-queryable": "optional"
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "booktitle": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Booktitle",
             "description": "Meaning of property matches the BiBTeX specification.",
-            "x-optimade-support": "optional",
-            "x-optimade-queryable": "optional"
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "chapter": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Chapter",
             "description": "Meaning of property matches the BiBTeX specification.",
-            "x-optimade-support": "optional",
-            "x-optimade-queryable": "optional"
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "crossref": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Crossref",
             "description": "Meaning of property matches the BiBTeX specification.",
-            "x-optimade-support": "optional",
-            "x-optimade-queryable": "optional"
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "edition": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Edition",
             "description": "Meaning of property matches the BiBTeX specification.",
-            "x-optimade-support": "optional",
-            "x-optimade-queryable": "optional"
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "howpublished": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Howpublished",
             "description": "Meaning of property matches the BiBTeX specification.",
-            "x-optimade-support": "optional",
-            "x-optimade-queryable": "optional"
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "institution": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Institution",
             "description": "Meaning of property matches the BiBTeX specification.",
-            "x-optimade-support": "optional",
-            "x-optimade-queryable": "optional"
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "journal": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Journal",
             "description": "Meaning of property matches the BiBTeX specification.",
-            "x-optimade-support": "optional",
-            "x-optimade-queryable": "optional"
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "key": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Key",
             "description": "Meaning of property matches the BiBTeX specification.",
-            "x-optimade-support": "optional",
-            "x-optimade-queryable": "optional"
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "month": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Month",
             "description": "Meaning of property matches the BiBTeX specification.",
-            "x-optimade-support": "optional",
-            "x-optimade-queryable": "optional"
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "note": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Note",
             "description": "Meaning of property matches the BiBTeX specification.",
-            "x-optimade-support": "optional",
-            "x-optimade-queryable": "optional"
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "number": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Number",
             "description": "Meaning of property matches the BiBTeX specification.",
-            "x-optimade-support": "optional",
-            "x-optimade-queryable": "optional"
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "organization": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Organization",
             "description": "Meaning of property matches the BiBTeX specification.",
-            "x-optimade-support": "optional",
-            "x-optimade-queryable": "optional"
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "pages": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Pages",
             "description": "Meaning of property matches the BiBTeX specification.",
-            "x-optimade-support": "optional",
-            "x-optimade-queryable": "optional"
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "publisher": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Publisher",
             "description": "Meaning of property matches the BiBTeX specification.",
-            "x-optimade-support": "optional",
-            "x-optimade-queryable": "optional"
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "school": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "School",
             "description": "Meaning of property matches the BiBTeX specification.",
-            "x-optimade-support": "optional",
-            "x-optimade-queryable": "optional"
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "series": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Series",
             "description": "Meaning of property matches the BiBTeX specification.",
-            "x-optimade-support": "optional",
-            "x-optimade-queryable": "optional"
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "title": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Title",
             "description": "Meaning of property matches the BiBTeX specification.",
-            "x-optimade-support": "optional",
-            "x-optimade-queryable": "optional"
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "bib_type": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Bib Type",
             "description": "Type of the reference, corresponding to the **type** property in the BiBTeX specification.",
-            "x-optimade-support": "optional",
-            "x-optimade-queryable": "optional"
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "volume": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Volume",
             "description": "Meaning of property matches the BiBTeX specification.",
-            "x-optimade-support": "optional",
-            "x-optimade-queryable": "optional"
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "year": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Year",
             "description": "Meaning of property matches the BiBTeX specification.",
-            "x-optimade-support": "optional",
-            "x-optimade-queryable": "optional"
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           }
         },
+        "additionalProperties": true,
         "type": "object",
         "required": [
           "last_modified"
@@ -2927,14 +3401,20 @@
                 "$ref": "#/components/schemas/ResponseMeta"
               }
             ],
-            "title": "Meta",
             "description": "A meta object containing non-standard information"
           },
           "errors": {
-            "items": {
-              "$ref": "#/components/schemas/Error"
-            },
-            "type": "array",
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "uniqueItems": true,
             "title": "Errors",
             "description": "A list of unique errors"
@@ -2952,27 +3432,35 @@
                   "type": "object"
                 },
                 "type": "array"
+              },
+              {
+                "type": "null"
               }
             ],
             "uniqueItems": true,
-            "title": "Included"
+            "title": "Included",
+            "description": "A list of unique included OPTIMADE entry resources."
           },
           "links": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/ToplevelLinks"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Links",
             "description": "Links associated with the primary data or errors"
           },
           "jsonapi": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/JsonApi"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Jsonapi",
             "description": "Information about the JSON API used"
           }
         },
@@ -2981,8 +3469,7 @@
           "data",
           "meta"
         ],
-        "title": "ReferenceResponseMany",
-        "description": "errors are not allowed"
+        "title": "ReferenceResponseMany"
       },
       "ReferenceResponseOne": {
         "properties": {
@@ -2993,6 +3480,9 @@
               },
               {
                 "type": "object"
+              },
+              {
+                "type": "null"
               }
             ],
             "title": "Data",
@@ -3004,14 +3494,20 @@
                 "$ref": "#/components/schemas/ResponseMeta"
               }
             ],
-            "title": "Meta",
             "description": "A meta object containing non-standard information"
           },
           "errors": {
-            "items": {
-              "$ref": "#/components/schemas/Error"
-            },
-            "type": "array",
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "uniqueItems": true,
             "title": "Errors",
             "description": "A list of unique errors"
@@ -3029,27 +3525,35 @@
                   "type": "object"
                 },
                 "type": "array"
+              },
+              {
+                "type": "null"
               }
             ],
             "uniqueItems": true,
-            "title": "Included"
+            "title": "Included",
+            "description": "A list of unique included OPTIMADE entry resources."
           },
           "links": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/ToplevelLinks"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Links",
             "description": "Links associated with the primary data or errors"
           },
           "jsonapi": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/JsonApi"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Jsonapi",
             "description": "Information about the JSON API used"
           }
         },
@@ -3058,8 +3562,7 @@
           "data",
           "meta"
         ],
-        "title": "ReferenceResponseOne",
-        "description": "errors are not allowed"
+        "title": "ReferenceResponseOne"
       },
       "RelationshipLinks": {
         "properties": {
@@ -3067,12 +3570,14 @@
             "anyOf": [
               {
                 "type": "string",
-                "maxLength": 65536,
                 "minLength": 1,
                 "format": "uri"
               },
               {
                 "$ref": "#/components/schemas/Link"
+              },
+              {
+                "type": "null"
               }
             ],
             "title": "Self",
@@ -3082,12 +3587,14 @@
             "anyOf": [
               {
                 "type": "string",
-                "maxLength": 65536,
                 "minLength": 1,
                 "format": "uri"
               },
               {
                 "$ref": "#/components/schemas/Link"
+              },
+              {
+                "type": "null"
               }
             ],
             "title": "Related",
@@ -3117,39 +3624,47 @@
             "description": "Resource type"
           },
           "links": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/ResourceLinks"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Links",
             "description": "a links object containing links related to the resource."
           },
           "meta": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/Meta"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Meta",
             "description": "a meta object containing non-standard meta-information about a resource that can not be represented as an attribute or relationship."
           },
           "attributes": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/Attributes"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Attributes",
             "description": "an attributes object representing some of the resource\u2019s data."
           },
           "relationships": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/Relationships"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Relationships",
             "description": "[Relationships object](https://jsonapi.org/format/1.0/#document-resource-object-relationships)\ndescribing relationships between the resource and other JSON API resources."
           }
         },
@@ -3167,12 +3682,14 @@
             "anyOf": [
               {
                 "type": "string",
-                "maxLength": 65536,
                 "minLength": 1,
                 "format": "uri"
               },
               {
                 "$ref": "#/components/schemas/Link"
+              },
+              {
+                "type": "null"
               }
             ],
             "title": "Self",
@@ -3191,7 +3708,6 @@
                 "$ref": "#/components/schemas/ResponseMetaQuery"
               }
             ],
-            "title": "Query",
             "description": "Information on the Query that was requested"
           },
           "api_version": {
@@ -3199,7 +3715,7 @@
             "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "title": "Api Version",
             "description": "Presently used full version of the OPTIMADE API.\nThe version number string MUST NOT be prefixed by, e.g., \"v\".\nExamples: `1.0.0`, `1.0.0-rc.2`.",
-            "example": [
+            "examples": [
               "0.10.1",
               "1.0.0-rc.2",
               "1.2.3-rc.5+develop"
@@ -3214,72 +3730,121 @@
             "anyOf": [
               {
                 "type": "string",
-                "maxLength": 65536,
                 "minLength": 1,
                 "format": "uri"
               },
               {
                 "$ref": "#/components/schemas/Link"
+              },
+              {
+                "type": "null"
               }
             ],
             "title": "Schema",
             "description": "A [JSON API links object](http://jsonapi.org/format/1.0/#document-links) that points to a schema for the response.\nIf it is a string, or a dictionary containing no `meta` field, the provided URL MUST point at an [OpenAPI](https://swagger.io/specification/) schema.\nIt is possible that future versions of this specification allows for alternative schema types.\nHence, if the `meta` field of the JSON API links object is provided and contains a field `schema_type` that is not equal to the string `OpenAPI` the client MUST not handle failures to parse the schema or to validate the response against the schema as errors."
           },
           "time_stamp": {
-            "type": "string",
-            "format": "date-time",
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Time Stamp",
             "description": "A timestamp containing the date and time at which the query was executed."
           },
           "data_returned": {
-            "type": "integer",
-            "minimum": 0.0,
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Data Returned",
             "description": "An integer containing the total number of data resource objects returned for the current `filter` query, independent of pagination."
           },
           "provider": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/Provider"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Provider",
             "description": "information on the database provider of the implementation."
           },
           "data_available": {
-            "type": "integer",
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Data Available",
             "description": "An integer containing the total number of data resource objects available in the database for the endpoint."
           },
           "last_id": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Last Id",
             "description": "a string containing the last ID returned"
           },
           "response_message": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Response Message",
             "description": "response string from the server"
           },
           "implementation": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/Implementation"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Implementation",
             "description": "a dictionary describing the server implementation"
           },
           "warnings": {
-            "items": {
-              "$ref": "#/components/schemas/Warnings"
-            },
-            "type": "array",
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/Warnings"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "uniqueItems": true,
             "title": "Warnings",
             "description": "A list of warning resource objects representing non-critical errors or warnings.\nA warning resource object is defined similarly to a [JSON API error object](http://jsonapi.org/format/1.0/#error-objects), but MUST also include the field `type`, which MUST have the value `\"warning\"`.\nThe field `detail` MUST be present and SHOULD contain a non-critical message, e.g., reporting unrecognized search attributes or deprecated features.\nThe field `status`, representing a HTTP response status code, MUST NOT be present for a warning resource object.\nThis is an exclusive field for error resource objects."
           }
         },
+        "additionalProperties": true,
         "type": "object",
         "required": [
           "query",
@@ -3310,18 +3875,19 @@
             "type": "string",
             "title": "Name",
             "description": "Gives the name of the species; the **name** value MUST be unique in the `species` list.",
-            "x-optimade-support": "must",
-            "x-optimade-queryable": "optional"
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "must"
           },
           "chemical_symbols": {
             "items": {
-              "type": "string"
+              "type": "string",
+              "pattern": "(H|He|Li|Be|B|C|N|O|F|Ne|Na|Mg|Al|Si|P|S|Cl|Ar|K|Ca|Sc|Ti|V|Cr|Mn|Fe|Co|Ni|Cu|Zn|Ga|Ge|As|Se|Br|Kr|Rb|Sr|Y|Zr|Nb|Mo|Tc|Ru|Rh|Pd|Ag|Cd|In|Sn|Sb|Te|I|Xe|Cs|Ba|La|Ce|Pr|Nd|Pm|Sm|Eu|Gd|Tb|Dy|Ho|Er|Tm|Yb|Lu|Hf|Ta|W|Re|Os|Ir|Pt|Au|Hg|Tl|Pb|Bi|Po|At|Rn|Fr|Ra|Ac|Th|Pa|U|Np|Pu|Am|Cm|Bk|Cf|Es|Fm|Md|No|Lr|Rf|Db|Sg|Bh|Hs|Mt|Ds|Rg|Cn|Nh|Fl|Mc|Lv|Ts|Og|X|vacancy)"
             },
             "type": "array",
             "title": "Chemical Symbols",
             "description": "MUST be a list of strings of all chemical elements composing this species. Each item of the list MUST be one of the following:\n\n- a valid chemical-element symbol, or\n- the special value `\"X\"` to represent a non-chemical element, or\n- the special value `\"vacancy\"` to represent that this site has a non-zero probability of having a vacancy (the respective probability is indicated in the `concentration` list, see below).\n\nIf any one entry in the `species` list has a `chemical_symbols` list that is longer than 1 element, the correct flag MUST be set in the list `structure_features`.",
-            "x-optimade-support": "must",
-            "x-optimade-queryable": "optional"
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "must"
           },
           "concentration": {
             "items": {
@@ -3330,46 +3896,74 @@
             "type": "array",
             "title": "Concentration",
             "description": "MUST be a list of floats, with same length as `chemical_symbols`. The numbers represent the relative concentration of the corresponding chemical symbol in this species. The numbers SHOULD sum to one. Cases in which the numbers do not sum to one typically fall only in the following two categories:\n\n- Numerical errors when representing float numbers in fixed precision, e.g. for two chemical symbols with concentrations `1/3` and `2/3`, the concentration might look something like `[0.33333333333, 0.66666666666]`. If the client is aware that the sum is not one because of numerical precision, it can renormalize the values so that the sum is exactly one.\n- Experimental errors in the data present in the database. In this case, it is the responsibility of the client to decide how to process the data.\n\nNote that concentrations are uncorrelated between different site (even of the same species).",
-            "x-optimade-support": "must",
-            "x-optimade-queryable": "optional"
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "must"
           },
           "mass": {
-            "items": {
-              "type": "number"
-            },
-            "type": "array",
+            "anyOf": [
+              {
+                "items": {
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Mass",
             "description": "If present MUST be a list of floats expressed in a.m.u.\nElements denoting vacancies MUST have masses equal to 0.",
-            "x-optimade-support": "optional",
             "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional",
             "x-optimade-unit": "a.m.u."
           },
           "original_name": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Original Name",
             "description": "Can be any valid Unicode string, and SHOULD contain (if specified) the name of the species that is used internally in the source database.\n\nNote: With regards to \"source database\", we refer to the immediate source being queried via the OPTIMADE API implementation.",
-            "x-optimade-support": "optional",
-            "x-optimade-queryable": "optional"
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "attached": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Attached",
             "description": "If provided MUST be a list of length 1 or more of strings of chemical symbols for the elements attached to this site, or \"X\" for a non-chemical element.",
-            "x-optimade-support": "optional",
-            "x-optimade-queryable": "optional"
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "nattached": {
-            "items": {
-              "type": "integer"
-            },
-            "type": "array",
+            "anyOf": [
+              {
+                "items": {
+                  "type": "integer"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Nattached",
             "description": "If provided MUST be a list of length 1 or more of integers indicating the number of attached atoms of the kind specified in the value of the :field:`attached` key.",
-            "x-optimade-support": "optional",
-            "x-optimade-queryable": "optional"
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           }
         },
         "type": "object",
@@ -3382,6 +3976,7 @@
         "description": "A list describing the species of the sites of this structure.\n\nSpecies can represent pure chemical elements, virtual-crystal atoms representing a\nstatistical occupation of a given site by multiple chemical elements, and/or a\nlocation to which there are attached atoms, i.e., atoms whose precise location are\nunknown beyond that they are attached to that position (frequently used to indicate\nhydrogen atoms attached to another element, e.g., a carbon with three attached\nhydrogens might represent a methyl group, -CH3).\n\n- **Examples**:\n    - `[ {\"name\": \"Ti\", \"chemical_symbols\": [\"Ti\"], \"concentration\": [1.0]} ]`: any site with this species is occupied by a Ti atom.\n    - `[ {\"name\": \"Ti\", \"chemical_symbols\": [\"Ti\", \"vacancy\"], \"concentration\": [0.9, 0.1]} ]`: any site with this species is occupied by a Ti atom with 90 % probability, and has a vacancy with 10 % probability.\n    - `[ {\"name\": \"BaCa\", \"chemical_symbols\": [\"vacancy\", \"Ba\", \"Ca\"], \"concentration\": [0.05, 0.45, 0.5], \"mass\": [0.0, 137.327, 40.078]} ]`: any site with this species is occupied by a Ba atom with 45 % probability, a Ca atom with 50 % probability, and by a vacancy with 5 % probability. The mass of this site is (on average) 88.5 a.m.u.\n    - `[ {\"name\": \"C12\", \"chemical_symbols\": [\"C\"], \"concentration\": [1.0], \"mass\": [12.0]} ]`: any site with this species is occupied by a carbon isotope with mass 12.\n    - `[ {\"name\": \"C13\", \"chemical_symbols\": [\"C\"], \"concentration\": [1.0], \"mass\": [13.0]} ]`: any site with this species is occupied by a carbon isotope with mass 13.\n    - `[ {\"name\": \"CH3\", \"chemical_symbols\": [\"C\"], \"concentration\": [1.0], \"attached\": [\"H\"], \"nattached\": [3]} ]`: any site with this species is occupied by a methyl group, -CH3, which is represented without specifying precise positions of the hydrogen atoms."
       },
       "StructureFeatures": {
+        "type": "string",
         "enum": [
           "disorder",
           "implicit_atoms",
@@ -3394,12 +3989,14 @@
       "StructureRelationship": {
         "properties": {
           "links": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/RelationshipLinks"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Links",
             "description": "a links object containing at least one of the following: self, related"
           },
           "data": {
@@ -3412,6 +4009,9 @@
                   "$ref": "#/components/schemas/BaseRelationshipResource"
                 },
                 "type": "array"
+              },
+              {
+                "type": "null"
               }
             ],
             "uniqueItems": true,
@@ -3419,18 +4019,19 @@
             "description": "Resource linkage"
           },
           "meta": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/Meta"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Meta",
             "description": "a meta object that contains non-standard meta-information about the relationship."
           }
         },
         "type": "object",
-        "title": "StructureRelationship",
-        "description": "Similar to normal JSON API relationship, but with addition of OPTIONAL meta field for a resource."
+        "title": "StructureRelationship"
       },
       "StructureResource": {
         "properties": {
@@ -3438,46 +4039,52 @@
             "type": "string",
             "title": "Id",
             "description": "An entry's ID as defined in section Definition of Terms.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n\n- **Examples**:\n    - `\"db/1234567\"`\n    - `\"cod/2000000\"`\n    - `\"cod/2000000@1234567\"`\n    - `\"nomad/L1234567890\"`\n    - `\"42\"`",
-            "x-optimade-support": "must",
-            "x-optimade-queryable": "must"
+            "x-optimade-queryable": "must",
+            "x-optimade-support": "must"
           },
           "type": {
-            "type": "string",
+            "const": "structures",
             "pattern": "^structures$",
             "title": "Type",
             "description": "The name of the type of an entry.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n    - MUST be an existing entry type.\n    - The entry of type `<type>` and ID `<id>` MUST be returned in response to a request for `/<type>/<id>` under the versioned base URL.\n\n- **Examples**:\n    - `\"structures\"`",
             "default": "structures",
-            "x-optimade-support": "must",
-            "x-optimade-queryable": "must"
+            "x-optimade-queryable": "must",
+            "x-optimade-support": "must"
           },
           "links": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/ResourceLinks"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Links",
             "description": "a links object containing links related to the resource."
           },
           "meta": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/Meta"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Meta",
             "description": "a meta object containing non-standard meta-information about a resource that can not be represented as an attribute or relationship."
           },
           "attributes": {
             "$ref": "#/components/schemas/StructureResourceAttributes"
           },
           "relationships": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/EntryRelationships"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Relationships",
             "description": "A dictionary containing references to other entries according to the description in section Relationships encoded as [JSON API Relationships](https://jsonapi.org/format/1.0/#document-resource-object-relationships).\nThe OPTIONAL human-readable description of the relationship MAY be provided in the `description` field inside the `meta` dictionary of the JSON API resource identifier object."
           }
         },
@@ -3493,181 +4100,296 @@
       "StructureResourceAttributes": {
         "properties": {
           "immutable_id": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Immutable Id",
             "description": "The entry's immutable ID (e.g., an UUID). This is important for databases having preferred IDs that point to \"the latest version\" of a record, but still offer access to older variants. This ID maps to the version-specific record, in case it changes in the future.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n\n- **Examples**:\n    - `\"8bd3e750-b477-41a0-9b11-3a799f21b44f\"`\n    - `\"fjeiwoj,54;@=%<>#32\"` (Strings that are not URL-safe are allowed.)",
-            "x-optimade-support": "optional",
-            "x-optimade-queryable": "must"
+            "x-optimade-queryable": "must",
+            "x-optimade-support": "optional"
           },
           "last_modified": {
-            "type": "string",
-            "format": "date-time",
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Last Modified",
             "description": "Date and time representing when the entry was last modified.\n\n- **Type**: timestamp.\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response unless the query parameter `response_fields` is present and does not include this property.\n\n- **Example**:\n    - As part of JSON response format: `\"2007-04-05T14:30:20Z\"` (i.e., encoded as an [RFC 3339 Internet Date/Time Format](https://tools.ietf.org/html/rfc3339#section-5.6) string.)",
-            "x-optimade-support": "should",
             "x-optimade-queryable": "must",
-            "nullable": true
+            "x-optimade-support": "should"
           },
           "elements": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Elements",
             "description": "The chemical symbols of the different elements present in the structure.\n\n- **Type**: list of strings.\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - The strings are the chemical symbols, i.e., either a single uppercase letter or an uppercase letter followed by a number of lowercase letters.\n    - The order MUST be alphabetical.\n    - MUST refer to the same elements in the same order, and therefore be of the same length, as `elements_ratios`, if the latter is provided.\n    - Note: This property SHOULD NOT contain the string \"X\" to indicate non-chemical elements or \"vacancy\" to indicate vacancies (in contrast to the field `chemical_symbols` for the `species` property).\n\n- **Examples**:\n    - `[\"Si\"]`\n    - `[\"Al\",\"O\",\"Si\"]`\n\n- **Query examples**:\n    - A filter that matches all records of structures that contain Si, Al **and** O, and possibly other elements: `elements HAS ALL \"Si\", \"Al\", \"O\"`.\n    - To match structures with exactly these three elements, use `elements HAS ALL \"Si\", \"Al\", \"O\" AND elements LENGTH 3`.\n    - Note: length queries on this property can be equivalently formulated by filtering on the `nelements`_ property directly.",
-            "x-optimade-support": "should",
             "x-optimade-queryable": "must",
-            "nullable": true
+            "x-optimade-support": "should"
           },
           "nelements": {
-            "type": "integer",
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Nelements",
             "description": "Number of different elements in the structure as an integer.\n\n- **Type**: integer\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - MUST be equal to the lengths of the list properties `elements` and `elements_ratios`, if they are provided.\n\n- **Examples**:\n    - `3`\n\n- **Querying**:\n    - Note: queries on this property can equivalently be formulated using `elements LENGTH`.\n    - A filter that matches structures that have exactly 4 elements: `nelements=4`.\n    - A filter that matches structures that have between 2 and 7 elements: `nelements>=2 AND nelements<=7`.",
-            "x-optimade-support": "should",
             "x-optimade-queryable": "must",
-            "nullable": true
+            "x-optimade-support": "should"
           },
           "elements_ratios": {
-            "items": {
-              "type": "number"
-            },
-            "type": "array",
+            "anyOf": [
+              {
+                "items": {
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Elements Ratios",
             "description": "Relative proportions of different elements in the structure.\n\n- **Type**: list of floats\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - Composed by the proportions of elements in the structure as a list of floating point numbers.\n    - The sum of the numbers MUST be 1.0 (within floating point accuracy)\n    - MUST refer to the same elements in the same order, and therefore be of the same length, as `elements`, if the latter is provided.\n\n- **Examples**:\n    - `[1.0]`\n    - `[0.3333333333333333, 0.2222222222222222, 0.4444444444444444]`\n\n- **Query examples**:\n    - Note: Useful filters can be formulated using the set operator syntax for correlated values.\n      However, since the values are floating point values, the use of equality comparisons is generally inadvisable.\n    - OPTIONAL: a filter that matches structures where approximately 1/3 of the atoms in the structure are the element Al is: `elements:elements_ratios HAS ALL \"Al\":>0.3333, \"Al\":<0.3334`.",
-            "x-optimade-support": "should",
             "x-optimade-queryable": "must",
-            "nullable": true
+            "x-optimade-support": "should"
           },
           "chemical_formula_descriptive": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Chemical Formula Descriptive",
             "description": "The chemical formula for a structure as a string in a form chosen by the API implementation.\n\n- **Type**: string\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - The chemical formula is given as a string consisting of properly capitalized element symbols followed by integers or decimal numbers, balanced parentheses, square, and curly brackets `(`,`)`, `[`,`]`, `{`, `}`, commas, the `+`, `-`, `:` and `=` symbols. The parentheses are allowed to be followed by a number. Spaces are allowed anywhere except within chemical symbols. The order of elements and any groupings indicated by parentheses or brackets are chosen freely by the API implementation.\n    - The string SHOULD be arithmetically consistent with the element ratios in the `chemical_formula_reduced` property.\n    - It is RECOMMENDED, but not mandatory, that symbols, parentheses and brackets, if used, are used with the meanings prescribed by [IUPAC's Nomenclature of Organic Chemistry](https://www.qmul.ac.uk/sbcs/iupac/bibliog/blue.html).\n\n- **Examples**:\n    - `\"(H2O)2 Na\"`\n    - `\"NaCl\"`\n    - `\"CaCO3\"`\n    - `\"CCaO3\"`\n    - `\"(CH3)3N+ - [CH2]2-OH = Me3N+ - CH2 - CH2OH\"`\n\n- **Query examples**:\n    - Note: the free-form nature of this property is likely to make queries on it across different databases inconsistent.\n    - A filter that matches an exactly given formula: `chemical_formula_descriptive=\"(H2O)2 Na\"`.\n    - A filter that does a partial match: `chemical_formula_descriptive CONTAINS \"H2O\"`.",
-            "x-optimade-support": "should",
             "x-optimade-queryable": "must",
-            "nullable": true
+            "x-optimade-support": "should"
           },
           "chemical_formula_reduced": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "(^$)|^([A-Z][a-z]?([2-9]|[1-9]\\d+)?)+$"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "pattern": "(^$)|^([A-Z][a-z]?([2-9]|[1-9]\\d+)?)+$",
             "title": "Chemical Formula Reduced",
             "description": "The reduced chemical formula for a structure as a string with element symbols and integer chemical proportion numbers.\nThe proportion number MUST be omitted if it is 1.\n\n- **Type**: string\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property.\n      However, support for filters using partial string matching with this property is OPTIONAL (i.e., BEGINS WITH, ENDS WITH, and CONTAINS).\n      Intricate queries on formula components are instead suggested to be formulated using set-type filter operators on the multi valued `elements` and `elements_ratios` properties.\n    - Element symbols MUST have proper capitalization (e.g., `\"Si\"`, not `\"SI\"` for \"silicon\").\n    - Elements MUST be placed in alphabetical order, followed by their integer chemical proportion number.\n    - For structures with no partial occupation, the chemical proportion numbers are the smallest integers for which the chemical proportion is exactly correct.\n    - For structures with partial occupation, the chemical proportion numbers are integers that within reasonable approximation indicate the correct chemical proportions. The precise details of how to perform the rounding is chosen by the API implementation.\n    - No spaces or separators are allowed.\n\n- **Examples**:\n    - `\"H2NaO\"`\n    - `\"ClNa\"`\n    - `\"CCaO3\"`\n\n- **Query examples**:\n    - A filter that matches an exactly given formula is `chemical_formula_reduced=\"H2NaO\"`.",
-            "x-optimade-support": "should",
             "x-optimade-queryable": "must",
-            "nullable": true
+            "x-optimade-support": "should"
           },
           "chemical_formula_hill": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "(^$)|^([A-Z][a-z]?([2-9]|[1-9]\\d+)?)+$"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "pattern": "(^$)|^([A-Z][a-z]?([2-9]|[1-9]\\d+)?)+$",
             "title": "Chemical Formula Hill",
             "description": "The chemical formula for a structure in [Hill form](https://dx.doi.org/10.1021/ja02046a005) with element symbols followed by integer chemical proportion numbers. The proportion number MUST be omitted if it is 1.\n\n- **Type**: string\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n    - **Query**: Support for queries on this property is OPTIONAL.\n      If supported, only a subset of the filter features MAY be supported.\n    - The overall scale factor of the chemical proportions is chosen such that the resulting values are integers that indicate the most chemically relevant unit of which the system is composed.\n      For example, if the structure is a repeating unit cell with four hydrogens and four oxygens that represents two hydroperoxide molecules, `chemical_formula_hill` is `\"H2O2\"` (i.e., not `\"HO\"`, nor `\"H4O4\"`).\n    - If the chemical insight needed to ascribe a Hill formula to the system is not present, the property MUST be handled as unset.\n    - Element symbols MUST have proper capitalization (e.g., `\"Si\"`, not `\"SI\"` for \"silicon\").\n    - Elements MUST be placed in [Hill order](https://dx.doi.org/10.1021/ja02046a005), followed by their integer chemical proportion number.\n      Hill order means: if carbon is present, it is placed first, and if also present, hydrogen is placed second.\n      After that, all other elements are ordered alphabetically.\n      If carbon is not present, all elements are ordered alphabetically.\n    - If the system has sites with partial occupation and the total occupations of each element do not all sum up to integers, then the Hill formula SHOULD be handled as unset.\n    - No spaces or separators are allowed.\n\n- **Examples**:\n    - `\"H2O2\"`\n\n- **Query examples**:\n    - A filter that matches an exactly given formula is `chemical_formula_hill=\"H2O2\"`.",
-            "x-optimade-support": "optional",
-            "x-optimade-queryable": "optional"
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "chemical_formula_anonymous": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "(^$)|^([A-Z][a-z]?([2-9]|[1-9]\\d+)?)+$"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "pattern": "(^$)|^([A-Z][a-z]?([2-9]|[1-9]\\d+)?)+$",
             "title": "Chemical Formula Anonymous",
             "description": "The anonymous formula is the `chemical_formula_reduced`, but where the elements are instead first ordered by their chemical proportion number, and then, in order left to right, replaced by anonymous symbols A, B, C, ..., Z, Aa, Ba, ..., Za, Ab, Bb, ... and so on.\n\n- **Type**: string\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property.\n      However, support for filters using partial string matching with this property is OPTIONAL (i.e., BEGINS WITH, ENDS WITH, and CONTAINS).\n\n- **Examples**:\n    - `\"A2B\"`\n    - `\"A42B42C16D12E10F9G5\"`\n\n- **Querying**:\n    - A filter that matches an exactly given formula is `chemical_formula_anonymous=\"A2B\"`.",
-            "x-optimade-support": "should",
             "x-optimade-queryable": "must",
-            "nullable": true
+            "x-optimade-support": "should"
           },
           "dimension_types": {
-            "items": {
-              "$ref": "#/components/schemas/Periodicity"
-            },
-            "type": "array",
-            "maxItems": 3,
-            "minItems": 3,
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/Periodicity"
+                },
+                "type": "array",
+                "maxItems": 3,
+                "minItems": 3
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Dimension Types",
             "description": "List of three integers.\nFor each of the three directions indicated by the three lattice vectors (see property `lattice_vectors`), this list indicates if the direction is periodic (value `1`) or non-periodic (value `0`).\nNote: the elements in this list each refer to the direction of the corresponding entry in `lattice_vectors` and *not* the Cartesian x, y, z directions.\n\n- **Type**: list of integers.\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: Support for queries on this property is OPTIONAL.\n    - MUST be a list of length 3.\n    - Each integer element MUST assume only the value 0 or 1.\n\n- **Examples**:\n    - For a molecule: `[0, 0, 0]`\n    - For a wire along the direction specified by the third lattice vector: `[0, 0, 1]`\n    - For a 2D surface/slab, periodic on the plane defined by the first and third lattice vectors: `[1, 0, 1]`\n    - For a bulk 3D system: `[1, 1, 1]`",
-            "x-optimade-support": "should",
             "x-optimade-queryable": "optional",
-            "nullable": true
+            "x-optimade-support": "should"
           },
           "nperiodic_dimensions": {
-            "type": "integer",
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Nperiodic Dimensions",
             "description": "An integer specifying the number of periodic dimensions in the structure, equivalent to the number of non-zero entries in `dimension_types`.\n\n- **Type**: integer\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - The integer value MUST be between 0 and 3 inclusive and MUST be equal to the sum of the items in the `dimension_types` property.\n    - This property only reflects the treatment of the lattice vectors provided for the structure, and not any physical interpretation of the dimensionality of its contents.\n\n- **Examples**:\n    - `2` should be indicated in cases where `dimension_types` is any of `[1, 1, 0]`, `[1, 0, 1]`, `[0, 1, 1]`.\n\n- **Query examples**:\n    - Match only structures with exactly 3 periodic dimensions: `nperiodic_dimensions=3`\n    - Match all structures with 2 or fewer periodic dimensions: `nperiodic_dimensions<=2`",
-            "x-optimade-support": "should",
             "x-optimade-queryable": "must",
-            "nullable": true
+            "x-optimade-support": "should"
           },
           "lattice_vectors": {
-            "items": {
-              "items": {
-                "type": "number"
+            "anyOf": [
+              {
+                "items": {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "type": "array",
+                  "maxItems": 3,
+                  "minItems": 3
+                },
+                "type": "array",
+                "maxItems": 3,
+                "minItems": 3
               },
-              "type": "array",
-              "maxItems": 3,
-              "minItems": 3
-            },
-            "type": "array",
-            "maxItems": 3,
-            "minItems": 3,
+              {
+                "type": "null"
+              }
+            ],
             "title": "Lattice Vectors",
             "description": "The three lattice vectors in Cartesian coordinates, in \u00e5ngstr\u00f6m (\u00c5).\n\n- **Type**: list of list of floats or unknown values.\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: Support for queries on this property is OPTIONAL.\n      If supported, filters MAY support only a subset of comparison operators.\n    - MUST be a list of three vectors *a*, *b*, and *c*, where each of the vectors MUST BE a list of the vector's coordinates along the x, y, and z Cartesian coordinates.\n      (Therefore, the first index runs over the three lattice vectors and the second index runs over the x, y, z Cartesian coordinates).\n    - For databases that do not define an absolute Cartesian system (e.g., only defining the length and angles between vectors), the first lattice vector SHOULD be set along *x* and the second on the *xy*-plane.\n    - MUST always contain three vectors of three coordinates each, independently of the elements of property `dimension_types`.\n      The vectors SHOULD by convention be chosen so the determinant of the `lattice_vectors` matrix is different from zero.\n      The vectors in the non-periodic directions have no significance beyond fulfilling these requirements.\n    - The coordinates of the lattice vectors of non-periodic dimensions (i.e., those dimensions for which `dimension_types` is `0`) MAY be given as a list of all `null` values.\n        If a lattice vector contains the value `null`, all coordinates of that lattice vector MUST be `null`.\n\n- **Examples**:\n    - `[[4.0,0.0,0.0],[0.0,4.0,0.0],[0.0,1.0,4.0]]` represents a cell, where the first vector is `(4, 0, 0)`, i.e., a vector aligned along the `x` axis of length 4 \u00c5; the second vector is `(0, 4, 0)`; and the third vector is `(0, 1, 4)`.",
-            "x-optimade-support": "should",
             "x-optimade-queryable": "optional",
-            "nullable": true,
+            "x-optimade-support": "should",
             "x-optimade-unit": "\u00c5"
           },
           "cartesian_site_positions": {
-            "items": {
-              "items": {
-                "type": "number"
+            "anyOf": [
+              {
+                "items": {
+                  "items": {
+                    "type": "number"
+                  },
+                  "type": "array",
+                  "maxItems": 3,
+                  "minItems": 3
+                },
+                "type": "array"
               },
-              "type": "array",
-              "maxItems": 3,
-              "minItems": 3
-            },
-            "type": "array",
+              {
+                "type": "null"
+              }
+            ],
             "title": "Cartesian Site Positions",
             "description": "Cartesian positions of each site in the structure.\nA site is usually used to describe positions of atoms; what atoms can be encountered at a given site is conveyed by the `species_at_sites` property, and the species themselves are described in the `species` property.\n\n- **Type**: list of list of floats\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: Support for queries on this property is OPTIONAL.\n      If supported, filters MAY support only a subset of comparison operators.\n    - It MUST be a list of length equal to the number of sites in the structure, where every element is a list of the three Cartesian coordinates of a site expressed as float values in the unit angstrom (\u00c5).\n    - An entry MAY have multiple sites at the same Cartesian position (for a relevant use of this, see e.g., the property `assemblies`).\n\n- **Examples**:\n    - `[[0,0,0],[0,0,2]]` indicates a structure with two sites, one sitting at the origin and one along the (positive) *z*-axis, 2 \u00c5 away from the origin.",
-            "x-optimade-support": "should",
             "x-optimade-queryable": "optional",
-            "nullable": true,
+            "x-optimade-support": "should",
             "x-optimade-unit": "\u00c5"
           },
           "nsites": {
-            "type": "integer",
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Nsites",
             "description": "An integer specifying the length of the `cartesian_site_positions` property.\n\n- **Type**: integer\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n\n- **Examples**:\n    - `42`\n\n- **Query examples**:\n    - Match only structures with exactly 4 sites: `nsites=4`\n    - Match structures that have between 2 and 7 sites: `nsites>=2 AND nsites<=7`",
-            "x-optimade-support": "should",
             "x-optimade-queryable": "must",
-            "nullable": true
+            "x-optimade-support": "should"
           },
           "species": {
-            "items": {
-              "$ref": "#/components/schemas/Species"
-            },
-            "type": "array",
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/Species"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Species",
             "description": "A list describing the species of the sites of this structure.\nSpecies can represent pure chemical elements, virtual-crystal atoms representing a statistical occupation of a given site by multiple chemical elements, and/or a location to which there are attached atoms, i.e., atoms whose precise location are unknown beyond that they are attached to that position (frequently used to indicate hydrogen atoms attached to another element, e.g., a carbon with three attached hydrogens might represent a methyl group, -CH3).\n\n- **Type**: list of dictionary with keys:\n    - `name`: string (REQUIRED)\n    - `chemical_symbols`: list of strings (REQUIRED)\n    - `concentration`: list of float (REQUIRED)\n    - `attached`: list of strings (REQUIRED)\n    - `nattached`: list of integers (OPTIONAL)\n    - `mass`: list of floats (OPTIONAL)\n    - `original_name`: string (OPTIONAL).\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: Support for queries on this property is OPTIONAL.\n        If supported, filters MAY support only a subset of comparison operators.\n    - Each list member MUST be a dictionary with the following keys:\n        - **name**: REQUIRED; gives the name of the species; the **name** value MUST be unique in the `species` list;\n        - **chemical_symbols**: REQUIRED; MUST be a list of strings of all chemical elements composing this species.\n          Each item of the list MUST be one of the following:\n            - a valid chemical-element symbol, or\n            - the special value `\"X\"` to represent a non-chemical element, or\n            - the special value `\"vacancy\"` to represent that this site has a non-zero probability of having a vacancy (the respective probability is indicated in the `concentration` list, see below).\n\n          If any one entry in the `species` list has a `chemical_symbols` list that is longer than 1 element, the correct flag MUST be set in the list `structure_features`.\n\n        - **concentration**: REQUIRED; MUST be a list of floats, with same length as `chemical_symbols`.\n          The numbers represent the relative concentration of the corresponding chemical symbol in this species.\n          The numbers SHOULD sum to one. Cases in which the numbers do not sum to one typically fall only in the following two categories:\n\n            - Numerical errors when representing float numbers in fixed precision, e.g. for two chemical symbols with concentrations `1/3` and `2/3`, the concentration might look something like `[0.33333333333, 0.66666666666]`. If the client is aware that the sum is not one because of numerical precision, it can renormalize the values so that the sum is exactly one.\n            - Experimental errors in the data present in the database. In this case, it is the responsibility of the client to decide how to process the data.\n\n            Note that concentrations are uncorrelated between different sites (even of the same species).\n\n        - **attached**: OPTIONAL; if provided MUST be a list of length 1 or more of strings of chemical symbols for the elements attached to this site, or \"X\" for a non-chemical element.\n\n        - **nattached**: OPTIONAL; if provided MUST be a list of length 1 or more of integers indicating the number of attached atoms of the kind specified in the value of the `attached` key.\n\n          The implementation MUST include either both or none of the `attached` and `nattached` keys, and if they are provided, they MUST be of the same length.\n          Furthermore, if they are provided, the `structure_features` property MUST include the string `site_attachments`.\n\n        - **mass**: OPTIONAL. If present MUST be a list of floats, with the same length as `chemical_symbols`, providing element masses expressed in a.m.u.\n          Elements denoting vacancies MUST have masses equal to 0.\n\n        - **original_name**: OPTIONAL. Can be any valid Unicode string, and SHOULD contain (if specified) the name of the species that is used internally in the source database.\n\n          Note: With regards to \"source database\", we refer to the immediate source being queried via the OPTIMADE API implementation.\n\n          The main use of this field is for source databases that use species names, containing characters that are not allowed (see description of the list property `species_at_sites`).\n\n    - For systems that have only species formed by a single chemical symbol, and that have at most one species per chemical symbol, SHOULD use the chemical symbol as species name (e.g., `\"Ti\"` for titanium, `\"O\"` for oxygen, etc.)\n      However, note that this is OPTIONAL, and client implementations MUST NOT assume that the key corresponds to a chemical symbol, nor assume that if the species name is a valid chemical symbol, that it represents a species with that chemical symbol.\n      This means that a species `{\"name\": \"C\", \"chemical_symbols\": [\"Ti\"], \"concentration\": [1.0]}` is valid and represents a titanium species (and *not* a carbon species).\n    - It is NOT RECOMMENDED that a structure includes species that do not have at least one corresponding site.\n\n- **Examples**:\n    - `[ {\"name\": \"Ti\", \"chemical_symbols\": [\"Ti\"], \"concentration\": [1.0]} ]`: any site with this species is occupied by a Ti atom.\n    - `[ {\"name\": \"Ti\", \"chemical_symbols\": [\"Ti\", \"vacancy\"], \"concentration\": [0.9, 0.1]} ]`: any site with this species is occupied by a Ti atom with 90 % probability, and has a vacancy with 10 % probability.\n    - `[ {\"name\": \"BaCa\", \"chemical_symbols\": [\"vacancy\", \"Ba\", \"Ca\"], \"concentration\": [0.05, 0.45, 0.5], \"mass\": [0.0, 137.327, 40.078]} ]`: any site with this species is occupied by a Ba atom with 45 % probability, a Ca atom with 50 % probability, and by a vacancy with 5 % probability. The mass of this site is (on average) 88.5 a.m.u.\n    - `[ {\"name\": \"C12\", \"chemical_symbols\": [\"C\"], \"concentration\": [1.0], \"mass\": [12.0]} ]`: any site with this species is occupied by a carbon isotope with mass 12.\n    - `[ {\"name\": \"C13\", \"chemical_symbols\": [\"C\"], \"concentration\": [1.0], \"mass\": [13.0]} ]`: any site with this species is occupied by a carbon isotope with mass 13.\n    - `[ {\"name\": \"CH3\", \"chemical_symbols\": [\"C\"], \"concentration\": [1.0], \"attached\": [\"H\"], \"nattached\": [3]} ]`: any site with this species is occupied by a methyl group, -CH3, which is represented without specifying precise positions of the hydrogen atoms.",
-            "x-optimade-support": "should",
             "x-optimade-queryable": "optional",
-            "nullable": true
+            "x-optimade-support": "should"
           },
           "species_at_sites": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Species At Sites",
             "description": "Name of the species at each site (where values for sites are specified with the same order of the property `cartesian_site_positions`).\nThe properties of the species are found in the property `species`.\n\n- **Type**: list of strings.\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: Support for queries on this property is OPTIONAL.\n      If supported, filters MAY support only a subset of comparison operators.\n    - MUST have length equal to the number of sites in the structure (first dimension of the list property `cartesian_site_positions`).\n    - Each species name mentioned in the `species_at_sites` list MUST be described in the list property `species` (i.e. for each value in the `species_at_sites` list there MUST exist exactly one dictionary in the `species` list with the `name` attribute equal to the corresponding `species_at_sites` value).\n    - Each site MUST be associated only to a single species.\n      **Note**: However, species can represent mixtures of atoms, and multiple species MAY be defined for the same chemical element.\n      This latter case is useful when different atoms of the same type need to be grouped or distinguished, for instance in simulation codes to assign different initial spin states.\n\n- **Examples**:\n    - `[\"Ti\",\"O2\"]` indicates that the first site is hosting a species labeled `\"Ti\"` and the second a species labeled `\"O2\"`.\n    - `[\"Ac\", \"Ac\", \"Ag\", \"Ir\"]` indicating the first two sites contains the `\"Ac\"` species, while the third and fourth sites contain the `\"Ag\"` and `\"Ir\"` species, respectively.",
-            "x-optimade-support": "should",
             "x-optimade-queryable": "optional",
-            "nullable": true
+            "x-optimade-support": "should"
           },
           "assemblies": {
-            "items": {
-              "$ref": "#/components/schemas/Assembly"
-            },
-            "type": "array",
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/Assembly"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Assemblies",
             "description": "A description of groups of sites that are statistically correlated.\n\n- **Type**: list of dictionary with keys:\n    - `sites_in_groups`: list of list of integers (REQUIRED)\n    - `group_probabilities`: list of floats (REQUIRED)\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n    - **Query**: Support for queries on this property is OPTIONAL.\n        If supported, filters MAY support only a subset of comparison operators.\n    - The property SHOULD be `null` for entries that have no partial occupancies.\n    - If present, the correct flag MUST be set in the list `structure_features`.\n    - Client implementations MUST check its presence (as its presence changes the interpretation of the structure).\n    - If present, it MUST be a list of dictionaries, each of which represents an assembly and MUST have the following two keys:\n        - **sites_in_groups**: Index of the sites (0-based) that belong to each group for each assembly.\n\n            Example: `[[1], [2]]`: two groups, one with the second site, one with the third.\n            Example: `[[1,2], [3]]`: one group with the second and third site, one with the fourth.\n\n        - **group_probabilities**: Statistical probability of each group. It MUST have the same length as `sites_in_groups`.\n            It SHOULD sum to one.\n            See below for examples of how to specify the probability of the occurrence of a vacancy.\n            The possible reasons for the values not to sum to one are the same as already specified above for the `concentration` of each `species`.\n\n    - If a site is not present in any group, it means that it is present with 100 % probability (as if no assembly was specified).\n    - A site MUST NOT appear in more than one group.\n\n- **Examples** (for each entry of the assemblies list):\n    - `{\"sites_in_groups\": [[0], [1]], \"group_probabilities: [0.3, 0.7]}`: the first site and the second site never occur at the same time in the unit cell.\n        Statistically, 30 % of the times the first site is present, while 70 % of the times the second site is present.\n    - `{\"sites_in_groups\": [[1,2], [3]], \"group_probabilities: [0.3, 0.7]}`: the second and third site are either present together or not present; they form the first group of atoms for this assembly.\n        The second group is formed by the fourth site.\n        Sites of the first group (the second and the third) are never present at the same time as the fourth site.\n        30 % of times sites 1 and 2 are present (and site 3 is absent); 70 % of times site 3 is present (and sites 1 and 2 are absent).\n\n- **Notes**:\n    - Assemblies are essential to represent, for instance, the situation where an atom can statistically occupy two different positions (sites).\n\n    - By defining groups, it is possible to represent, e.g., the case where a functional molecule (and not just one atom) is either present or absent (or the case where it it is present in two conformations)\n\n    - Considerations on virtual alloys and on vacancies: In the special case of a virtual alloy, these specifications allow two different, equivalent ways of specifying them.\n        For instance, for a site at the origin with 30 % probability of being occupied by Si, 50 % probability of being occupied by Ge, and 20 % of being a vacancy, the following two representations are possible:\n\n        - Using a single species:\n            ```json\n            {\n              \"cartesian_site_positions\": [[0,0,0]],\n              \"species_at_sites\": [\"SiGe-vac\"],\n              \"species\": [\n              {\n                \"name\": \"SiGe-vac\",\n                \"chemical_symbols\": [\"Si\", \"Ge\", \"vacancy\"],\n                \"concentration\": [0.3, 0.5, 0.2]\n              }\n              ]\n              // ...\n            }\n            ```\n\n        - Using multiple species and the assemblies:\n            ```json\n            {\n              \"cartesian_site_positions\": [ [0,0,0], [0,0,0], [0,0,0] ],\n              \"species_at_sites\": [\"Si\", \"Ge\", \"vac\"],\n              \"species\": [\n                { \"name\": \"Si\", \"chemical_symbols\": [\"Si\"], \"concentration\": [1.0] },\n                { \"name\": \"Ge\", \"chemical_symbols\": [\"Ge\"], \"concentration\": [1.0] },\n                { \"name\": \"vac\", \"chemical_symbols\": [\"vacancy\"], \"concentration\": [1.0] }\n              ],\n              \"assemblies\": [\n                {\n              \"sites_in_groups\": [ [0], [1], [2] ],\n              \"group_probabilities\": [0.3, 0.5, 0.2]\n                }\n              ]\n              // ...\n            }\n            ```\n\n    - It is up to the database provider to decide which representation to use, typically depending on the internal format in which the structure is stored.\n        However, given a structure identified by a unique ID, the API implementation MUST always provide the same representation for it.\n\n    - The probabilities of occurrence of different assemblies are uncorrelated.\n        So, for instance in the following case with two assemblies:\n        ```json\n        {\n          \"assemblies\": [\n            {\n              \"sites_in_groups\": [ [0], [1] ],\n              \"group_probabilities\": [0.2, 0.8],\n            },\n            {\n              \"sites_in_groups\": [ [2], [3] ],\n              \"group_probabilities\": [0.3, 0.7]\n            }\n          ]\n        }\n        ```\n\n        Site 0 is present with a probability of 20 % and site 1 with a probability of 80 %. These two sites are correlated (either site 0 or 1 is present). Similarly, site 2 is present with a probability of 30 % and site 3 with a probability of 70 %.\n        These two sites are correlated (either site 2 or 3 is present).\n        However, the presence or absence of sites 0 and 1 is not correlated with the presence or absence of sites 2 and 3 (in the specific example, the pair of sites (0, 2) can occur with 0.2*0.3 = 6 % probability; the pair (0, 3) with 0.2*0.7 = 14 % probability; the pair (1, 2) with 0.8*0.3 = 24 % probability; and the pair (1, 3) with 0.8*0.7 = 56 % probability).",
-            "x-optimade-support": "optional",
-            "x-optimade-queryable": "optional"
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "structure_features": {
             "items": {
@@ -3676,26 +4398,14 @@
             "type": "array",
             "title": "Structure Features",
             "description": "A list of strings that flag which special features are used by the structure.\n\n- **Type**: list of strings\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property.\n    Filters on the list MUST support all mandatory HAS-type queries.\n    Filter operators for comparisons on the string components MUST support equality, support for other comparison operators are OPTIONAL.\n    - MUST be an empty list if no special features are used.\n    - MUST be sorted alphabetically.\n    - If a special feature listed below is used, the list MUST contain the corresponding string.\n    - If a special feature listed below is not used, the list MUST NOT contain the corresponding string.\n    - **List of strings used to indicate special structure features**:\n        - `disorder`: this flag MUST be present if any one entry in the `species` list has a `chemical_symbols` list that is longer than 1 element.\n        - `implicit_atoms`: this flag MUST be present if the structure contains atoms that are not assigned to sites via the property `species_at_sites` (e.g., because their positions are unknown).\n           When this flag is present, the properties related to the chemical formula will likely not match the type and count of atoms represented by the `species_at_sites`, `species` and `assemblies` properties.\n        - `site_attachments`: this flag MUST be present if any one entry in the `species` list includes `attached` and `nattached`.\n        - `assemblies`: this flag MUST be present if the property `assemblies` is present.\n\n- **Examples**: A structure having implicit atoms and using assemblies: `[\"assemblies\", \"implicit_atoms\"]`",
-            "x-optimade-support": "must",
-            "x-optimade-queryable": "must"
+            "x-optimade-queryable": "must",
+            "x-optimade-support": "must"
           }
         },
+        "additionalProperties": true,
         "type": "object",
         "required": [
           "last_modified",
-          "elements",
-          "nelements",
-          "elements_ratios",
-          "chemical_formula_descriptive",
-          "chemical_formula_reduced",
-          "chemical_formula_anonymous",
-          "dimension_types",
-          "nperiodic_dimensions",
-          "lattice_vectors",
-          "cartesian_site_positions",
-          "nsites",
-          "species",
-          "species_at_sites",
           "structure_features"
         ],
         "title": "StructureResourceAttributes",
@@ -3728,14 +4438,20 @@
                 "$ref": "#/components/schemas/ResponseMeta"
               }
             ],
-            "title": "Meta",
             "description": "A meta object containing non-standard information"
           },
           "errors": {
-            "items": {
-              "$ref": "#/components/schemas/Error"
-            },
-            "type": "array",
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "uniqueItems": true,
             "title": "Errors",
             "description": "A list of unique errors"
@@ -3753,27 +4469,35 @@
                   "type": "object"
                 },
                 "type": "array"
+              },
+              {
+                "type": "null"
               }
             ],
             "uniqueItems": true,
-            "title": "Included"
+            "title": "Included",
+            "description": "A list of unique included OPTIMADE entry resources."
           },
           "links": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/ToplevelLinks"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Links",
             "description": "Links associated with the primary data or errors"
           },
           "jsonapi": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/JsonApi"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Jsonapi",
             "description": "Information about the JSON API used"
           }
         },
@@ -3782,8 +4506,7 @@
           "data",
           "meta"
         ],
-        "title": "StructureResponseMany",
-        "description": "errors are not allowed"
+        "title": "StructureResponseMany"
       },
       "StructureResponseOne": {
         "properties": {
@@ -3794,6 +4517,9 @@
               },
               {
                 "type": "object"
+              },
+              {
+                "type": "null"
               }
             ],
             "title": "Data",
@@ -3805,14 +4531,20 @@
                 "$ref": "#/components/schemas/ResponseMeta"
               }
             ],
-            "title": "Meta",
             "description": "A meta object containing non-standard information"
           },
           "errors": {
-            "items": {
-              "$ref": "#/components/schemas/Error"
-            },
-            "type": "array",
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "uniqueItems": true,
             "title": "Errors",
             "description": "A list of unique errors"
@@ -3830,27 +4562,35 @@
                   "type": "object"
                 },
                 "type": "array"
+              },
+              {
+                "type": "null"
               }
             ],
             "uniqueItems": true,
-            "title": "Included"
+            "title": "Included",
+            "description": "A list of unique included OPTIMADE entry resources."
           },
           "links": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/ToplevelLinks"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Links",
             "description": "Links associated with the primary data or errors"
           },
           "jsonapi": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/JsonApi"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Jsonapi",
             "description": "Information about the JSON API used"
           }
         },
@@ -3859,8 +4599,7 @@
           "data",
           "meta"
         ],
-        "title": "StructureResponseOne",
-        "description": "errors are not allowed"
+        "title": "StructureResponseOne"
       },
       "ToplevelLinks": {
         "properties": {
@@ -3868,12 +4607,14 @@
             "anyOf": [
               {
                 "type": "string",
-                "maxLength": 65536,
                 "minLength": 1,
                 "format": "uri"
               },
               {
                 "$ref": "#/components/schemas/Link"
+              },
+              {
+                "type": "null"
               }
             ],
             "title": "Self",
@@ -3883,12 +4624,14 @@
             "anyOf": [
               {
                 "type": "string",
-                "maxLength": 65536,
                 "minLength": 1,
                 "format": "uri"
               },
               {
                 "$ref": "#/components/schemas/Link"
+              },
+              {
+                "type": "null"
               }
             ],
             "title": "Related",
@@ -3898,12 +4641,14 @@
             "anyOf": [
               {
                 "type": "string",
-                "maxLength": 65536,
                 "minLength": 1,
                 "format": "uri"
               },
               {
                 "$ref": "#/components/schemas/Link"
+              },
+              {
+                "type": "null"
               }
             ],
             "title": "First",
@@ -3913,12 +4658,14 @@
             "anyOf": [
               {
                 "type": "string",
-                "maxLength": 65536,
                 "minLength": 1,
                 "format": "uri"
               },
               {
                 "$ref": "#/components/schemas/Link"
+              },
+              {
+                "type": "null"
               }
             ],
             "title": "Last",
@@ -3928,12 +4675,14 @@
             "anyOf": [
               {
                 "type": "string",
-                "maxLength": 65536,
                 "minLength": 1,
                 "format": "uri"
               },
               {
                 "$ref": "#/components/schemas/Link"
+              },
+              {
+                "type": "null"
               }
             ],
             "title": "Prev",
@@ -3943,18 +4692,21 @@
             "anyOf": [
               {
                 "type": "string",
-                "maxLength": 65536,
                 "minLength": 1,
                 "format": "uri"
               },
               {
                 "$ref": "#/components/schemas/Link"
+              },
+              {
+                "type": "null"
               }
             ],
             "title": "Next",
             "description": "The next page of data"
           }
         },
+        "additionalProperties": true,
         "type": "object",
         "title": "ToplevelLinks",
         "description": "A set of Links objects, possibly including pagination"
@@ -3962,26 +4714,49 @@
       "Warnings": {
         "properties": {
           "id": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Id",
             "description": "A unique identifier for this particular occurrence of the problem."
           },
           "links": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/ErrorLinks"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Links",
             "description": "A links object storing about"
           },
           "code": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Code",
             "description": "an application-specific error code, expressed as a string value."
           },
           "title": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Title",
             "description": "A short, human-readable summary of the problem. It **SHOULD NOT** change from occurrence to occurrence of the problem, except for purposes of localization."
           },
@@ -3991,25 +4766,29 @@
             "description": "A human-readable explanation specific to this occurrence of the problem."
           },
           "source": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/ErrorSource"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Source",
             "description": "An object containing references to the source of the error"
           },
           "meta": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/Meta"
+              },
+              {
+                "type": "null"
               }
             ],
-            "title": "Meta",
             "description": "a meta object containing non-standard meta-information about the error."
           },
           "type": {
-            "type": "string",
+            "const": "warning",
             "pattern": "^warning$",
             "title": "Type",
             "description": "Warnings must be of type \"warning\"",

--- a/optimade/adapters/base.py
+++ b/optimade/adapters/base.py
@@ -19,8 +19,7 @@ resources can be converted to for [`ReferenceResource`][optimade.models.referenc
 and [`StructureResource`][optimade.models.structures.StructureResource]s, respectively.
 """
 import re
-from collections.abc import Callable
-from typing import Any, Optional, Union
+from typing import Any, Callable, Optional, Union
 
 from pydantic import BaseModel
 

--- a/optimade/adapters/base.py
+++ b/optimade/adapters/base.py
@@ -156,7 +156,7 @@ class EntryAdapter:
 
         return cls(
             {
-                "attributes": cls._type_ingesters[format](data).dict(),
+                "attributes": cls._type_ingesters[format](data).model_dump(),
                 "id": "",
                 "type": "structures",
             }
@@ -170,7 +170,7 @@ class EntryAdapter:
         for res in starting_instances:
             nested_attributes = name.split(".")
             for nested_attribute in nested_attributes:
-                if nested_attribute in getattr(res, "__fields__", {}):
+                if nested_attribute in getattr(res, "model_fields", {}):
                     res = getattr(res, nested_attribute)
                 else:
                     res = None

--- a/optimade/adapters/base.py
+++ b/optimade/adapters/base.py
@@ -19,11 +19,11 @@ resources can be converted to for [`ReferenceResource`][optimade.models.referenc
 and [`StructureResource`][optimade.models.structures.StructureResource]s, respectively.
 """
 import re
-from typing import Any, Callable, Optional, Union
+from collections.abc import Callable
+from typing import Any, Optional, Union
 
-from pydantic import BaseModel  # pylint: disable=no-name-in-module
+from pydantic import BaseModel
 
-from optimade.adapters.logger import LOGGER
 from optimade.models.entries import EntryResource
 
 
@@ -47,22 +47,21 @@ class EntryAdapter:
     _type_ingesters: dict[str, Callable] = {}
     _type_ingesters_by_type: dict[str, type] = {}
 
-    def __init__(self, entry: dict) -> None:
+    def __init__(self, entry: dict[str, Any]) -> None:
         """
         Parameters:
             entry (dict): A JSON OPTIMADE single resource entry.
         """
-        self._entry: Optional[EntryResource] = None
         self._converted: dict[str, Any] = {}
 
-        self.entry: EntryResource = entry  # type: ignore[assignment]
+        self._entry = self.ENTRY_RESOURCE(**entry)
 
         # Note that these return also the default values for otherwise non-provided properties.
         self._common_converters = {
             # Return JSON serialized string, see https://pydantic-docs.helpmanual.io/usage/exporting_models/#modeljson
-            "json": self.entry.model_dump_json,  # type: ignore[attr-defined]
+            "json": self.entry.model_dump_json,
             # Return Python dict, see https://pydantic-docs.helpmanual.io/usage/exporting_models/#modeldict
-            "dict": self.entry.model_dump,  # type: ignore[attr-defined]
+            "dict": self.entry.model_dump,
         }
 
     @property
@@ -73,22 +72,7 @@ class EntryAdapter:
             The entry resource.
 
         """
-        return self._entry  # type: ignore[return-value]
-
-    @entry.setter
-    def entry(self, value: dict) -> None:
-        """Set OPTIMADE entry.
-
-        If already set, print that this can _only_ be set once.
-
-        Parameters:
-            value (dict): Raw entry to wrap in the relevant pydantic model represented by `ENTRY_RESOURCE`.
-
-        """
-        if self._entry is None:
-            self._entry = self.ENTRY_RESOURCE(**value)
-        else:
-            LOGGER.warning("entry can only be set once and is already set.")
+        return self._entry
 
     def convert(self, format: str) -> Any:
         """Convert OPTIMADE entry to desired format.
@@ -108,8 +92,8 @@ class EntryAdapter:
             and format not in self._common_converters
         ):
             raise AttributeError(
-                f"Non-valid entry type to convert to: {format}\n"
-                f"Valid entry types: {tuple(self._type_converters.keys()) + tuple(self._common_converters.keys())}"
+                f"Non-valid entry type to convert to: {format}\nValid entry types: "
+                f"{tuple(self._type_converters.keys()) + tuple(self._common_converters.keys())}"
             )
 
         if self._converted.get(format, None) is None:

--- a/optimade/adapters/base.py
+++ b/optimade/adapters/base.py
@@ -60,9 +60,9 @@ class EntryAdapter:
         # Note that these return also the default values for otherwise non-provided properties.
         self._common_converters = {
             # Return JSON serialized string, see https://pydantic-docs.helpmanual.io/usage/exporting_models/#modeljson
-            "json": self.entry.json,  # type: ignore[attr-defined]
+            "json": self.entry.model_dump_json,  # type: ignore[attr-defined]
             # Return Python dict, see https://pydantic-docs.helpmanual.io/usage/exporting_models/#modeldict
-            "dict": self.entry.dict,  # type: ignore[attr-defined]
+            "dict": self.entry.model_dump,  # type: ignore[attr-defined]
         }
 
     @property

--- a/optimade/adapters/structures/adapter.py
+++ b/optimade/adapters/structures/adapter.py
@@ -1,4 +1,4 @@
-from collections.abc import Callable
+from typing import Callable
 
 from optimade.adapters.base import EntryAdapter
 from optimade.models import StructureResource

--- a/optimade/adapters/structures/adapter.py
+++ b/optimade/adapters/structures/adapter.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from collections.abc import Callable
 
 from optimade.adapters.base import EntryAdapter
 from optimade.models import StructureResource

--- a/optimade/adapters/structures/ase.py
+++ b/optimade/adapters/structures/ase.py
@@ -91,7 +91,7 @@ def get_ase_atoms(optimade_structure: OptimadeStructure) -> Atoms:
         )
 
     info = {}
-    for key in attributes.dict().keys():
+    for key in attributes.model_dump().keys():
         if key.startswith("_"):
             ase_key = key
             if key.startswith(f"_{EXTRA_FIELD_PREFIX}_"):
@@ -114,7 +114,7 @@ def from_ase_atoms(atoms: Atoms) -> StructureResourceAttributes:
 
     Returns:
         An OPTIMADE `StructureResourceAttributes` model, which can be converted to a raw Python
-            dictionary with `.dict()` or to JSON with `.json()`.
+            dictionary with `.model_dump()` or to JSON with `.model_dump_json()`.
 
     """
     if not isinstance(atoms, Atoms):

--- a/optimade/adapters/structures/ase.py
+++ b/optimade/adapters/structures/ase.py
@@ -7,7 +7,6 @@ This conversion function relies on the ASE code.
 
 For more information on the ASE code see [their documentation](https://wiki.fysik.dtu.dk/ase/).
 """
-
 from optimade.adapters.exceptions import ConversionError
 from optimade.adapters.structures.utils import (
     elements_ratios_from_species_at_sites,

--- a/optimade/adapters/structures/cif.py
+++ b/optimade/adapters/structures/cif.py
@@ -16,7 +16,6 @@ Note:
 
 This conversion function relies on the [NumPy](https://numpy.org/) library.
 """
-
 from optimade.adapters.structures.utils import (
     cell_to_cellpar,
     fractional_coordinates,

--- a/optimade/adapters/structures/proteindatabank.py
+++ b/optimade/adapters/structures/proteindatabank.py
@@ -21,7 +21,6 @@ These conversion functions both rely on the [NumPy](https://numpy.org/) library.
 Warning:
     Currently, the PDBx/mmCIF conversion function is not parsing as a complete PDBx/mmCIF file.
 """
-
 try:
     import numpy as np
 except ImportError:

--- a/optimade/adapters/structures/pymatgen.py
+++ b/optimade/adapters/structures/pymatgen.py
@@ -112,7 +112,7 @@ def _pymatgen_species(
     Create list of {"symbol": "concentration"} per site for values to pymatgen species parameters.
     Remove vacancies, if they are present.
     """
-    if not species:
+    if species is None:
         # If species is missing, infer data from species_at_sites
         species = species_from_species_at_sites(species_at_sites)
 
@@ -147,7 +147,7 @@ def from_pymatgen(pmg_structure: Structure) -> StructureResourceAttributes:
 
     Returns:
         An OPTIMADE `StructureResourceAttributes` model, which can be converted to a raw Python
-            dictionary with `.dict()` or to JSON with `.json()`.
+            dictionary with `.model_dump()` or to JSON with `.model_dump_json()`.
 
     """
 

--- a/optimade/adapters/structures/utils.py
+++ b/optimade/adapters/structures/utils.py
@@ -98,7 +98,7 @@ def fractional_coordinates(
         fractional[:, i] %= 1.0
         fractional[:, i] %= 1.0
 
-    return [tuple(position) for position in fractional]
+    return [tuple(position) for position in fractional]  # type: ignore
 
 
 def cell_to_cellpar(
@@ -158,12 +158,12 @@ def unit_vector(x: Vector3D) -> Vector3D:
         return None  # type: ignore[return-value]
 
     y = np.array(x, dtype="float")
-    return y / np.linalg.norm(y)
+    return y / np.linalg.norm(y)  # type: ignore
 
 
 def cellpar_to_cell(
     cellpar: list[float],
-    ab_normal: tuple[int, int, int] = (0, 0, 1),
+    ab_normal: tuple[float, float, float] = (0.0, 0.0, 1.0),
     a_direction: Optional[tuple[int, int, int]] = None,
 ) -> list[Vector3D]:
     """Return a 3x3 cell matrix from `cellpar=[a,b,c,alpha,beta,gamma]`.
@@ -219,7 +219,7 @@ def cellpar_to_cell(
     # Define rotated X,Y,Z-system, with Z along ab_normal and X along
     # the projection of a_direction onto the normal plane of Z.
     a_direction_array = np.array(a_direction)
-    Z = unit_vector(ab_normal)
+    Z = unit_vector(ab_normal)  # type: ignore
     X = unit_vector(a_direction_array - np.dot(a_direction_array, Z) * Z)
     Y = np.cross(Z, X)
 

--- a/optimade/adapters/structures/utils.py
+++ b/optimade/adapters/structures/utils.py
@@ -163,7 +163,7 @@ def unit_vector(x: Vector3D) -> Vector3D:
 
 def cellpar_to_cell(
     cellpar: list[float],
-    ab_normal: tuple[float, float, float] = (0.0, 0.0, 1.0),
+    ab_normal: tuple[int, int, int] = (0, 0, 1),
     a_direction: Optional[tuple[int, int, int]] = None,
 ) -> list[Vector3D]:
     """Return a 3x3 cell matrix from `cellpar=[a,b,c,alpha,beta,gamma]`.

--- a/optimade/client/cli.py
+++ b/optimade/client/cli.py
@@ -178,13 +178,13 @@ def _get(
         "base_urls": base_url,
         "use_async": use_async,
         "max_results_per_provider": max_results_per_provider,
-        "include_providers": set(_.strip() for _ in include_providers.split(","))
+        "include_providers": {_.strip() for _ in include_providers.split(",")}
         if include_providers
         else None,
-        "exclude_providers": set(_.strip() for _ in exclude_providers.split(","))
+        "exclude_providers": {_.strip() for _ in exclude_providers.split(",")}
         if exclude_providers
         else None,
-        "exclude_databases": set(_.strip() for _ in exclude_databases.split(","))
+        "exclude_databases": {_.strip() for _ in exclude_databases.split(",")}
         if exclude_databases
         else None,
         "silent": silent,

--- a/optimade/client/cli.py
+++ b/optimade/client/cli.py
@@ -1,11 +1,23 @@
 import json
 import pathlib
 import sys
+from typing import TYPE_CHECKING
 
 import click
 import rich
 
 from optimade.client.client import OptimadeClient
+
+if TYPE_CHECKING:  # pragma: no cover
+    from typing import Union
+
+    from optimade.client.utils import QueryResults
+
+    ClientResult = Union[
+        dict[str, list[str]],
+        dict[str, dict[str, dict[str, int]]],
+        dict[str, dict[str, dict[str, QueryResults]]],
+    ]
 
 __all__ = ("_get",)
 
@@ -162,21 +174,21 @@ def _get(
                 f"Desired output file {output_file} already exists, not overwriting."
             )
 
-    args = dict(
-        base_urls=base_url,
-        use_async=use_async,
-        max_results_per_provider=max_results_per_provider,
-        include_providers={_.strip() for _ in include_providers.split(",")}
+    args = {
+        "base_urls": base_url,
+        "use_async": use_async,
+        "max_results_per_provider": max_results_per_provider,
+        "include_providers": set(_.strip() for _ in include_providers.split(","))
         if include_providers
         else None,
-        exclude_providers={_.strip() for _ in exclude_providers.split(",")}
+        "exclude_providers": set(_.strip() for _ in exclude_providers.split(","))
         if exclude_providers
         else None,
-        exclude_databases={_.strip() for _ in exclude_databases.split(",")}
+        "exclude_databases": set(_.strip() for _ in exclude_databases.split(","))
         if exclude_databases
         else None,
-        silent=silent,
-    )
+        "silent": silent,
+    }
 
     # Only set http timeout if its not null to avoid overwriting or duplicating the
     # default value set on the OptimadeClient class
@@ -190,6 +202,9 @@ def _get(
     if response_fields:
         response_fields = response_fields.split(",")
     try:
+        if TYPE_CHECKING:  # pragma: no cover
+            results: ClientResult
+
         if count:
             for f in filter:
                 client.count(f, endpoint=endpoint)

--- a/optimade/filtertransformers/base_transformer.py
+++ b/optimade/filtertransformers/base_transformer.py
@@ -7,13 +7,16 @@ for turning filters parsed by lark into backend-specific queries.
 
 import abc
 import warnings
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from lark import Transformer, Tree, v_args
 
 from optimade.exceptions import BadRequest
 from optimade.server.mappers import BaseResourceMapper
 from optimade.warnings import UnknownProviderProperty
+
+if TYPE_CHECKING:  # pragma: no cover
+    from typing import Union
 
 __all__ = (
     "BaseTransformer",
@@ -285,6 +288,9 @@ class BaseTransformer(Transformer, abc.ABC):
     @v_args(inline=True)
     def number(self, number):
         """number: SIGNED_INT | SIGNED_FLOAT"""
+        if TYPE_CHECKING:  # pragma: no cover
+            type_: Union[type[int], type[float]]
+
         if number.type == "SIGNED_INT":
             type_ = int
         elif number.type == "SIGNED_FLOAT":

--- a/optimade/filtertransformers/elasticsearch.py
+++ b/optimade/filtertransformers/elasticsearch.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 from elasticsearch_dsl import Field, Integer, Keyword, Q, Text
 from lark import v_args
@@ -330,7 +330,7 @@ class ElasticTransformer(BaseTransformer):
     @v_args(inline=True)
     def constant_first_comparison(self, value, op, quantity):
         # constant_first_comparison: constant OPERATOR ( non_string_value | ...not_implemented_string )
-        if not isinstance(quantity, Quantity):
+        if not isinstance(quantity, ElasticsearchQuantity):
             raise TypeError("Only quantities can be compared to constant values.")
 
         return self._query_op(quantity, self._reversed_operator_map[op], value)
@@ -461,6 +461,9 @@ class ElasticTransformer(BaseTransformer):
     @v_args(inline=True)
     def number(self, number):
         # number: SIGNED_INT | SIGNED_FLOAT
+        if TYPE_CHECKING:  # pragma: no cover
+            type_: Union[type[int], type[float]]
+
         if number.type == "SIGNED_INT":
             type_ = int
         elif number.type == "SIGNED_FLOAT":

--- a/optimade/filtertransformers/mongo.py
+++ b/optimade/filtertransformers/mongo.py
@@ -2,8 +2,6 @@
 [`MongoTransformer`][optimade.filtertransformers.mongo.MongoTransformer],
 which takes the parsed filter and converts it to a valid pymongo/BSON query.
 """
-
-
 import copy
 import itertools
 import warnings

--- a/optimade/filtertransformers/mongo.py
+++ b/optimade/filtertransformers/mongo.py
@@ -121,7 +121,7 @@ class MongoTransformer(BaseTransformer):
                 is not None
             ):
                 size_query = {
-                    self.backend_mapping[
+                    self.backend_mapping[  # type: ignore[union-attr]
                         quantity
                     ].length_quantity.backend_field: query.pop("$size")
                 }

--- a/optimade/models/baseinfo.py
+++ b/optimade/models/baseinfo.py
@@ -1,6 +1,6 @@
 # pylint: disable=no-self-argument,no-name-in-module
 import re
-from typing import Literal, Optional
+from typing import Annotated, Literal, Optional
 
 from pydantic import AnyHttpUrl, BaseModel, field_validator, model_validator
 
@@ -17,20 +17,24 @@ VERSIONED_BASE_URL_PATTERN = r"^.+/v[0-1](\.[0-9]+)*/?$"
 class AvailableApiVersion(BaseModel):
     """A JSON object containing information about an available API version"""
 
-    url: AnyHttpUrl = StrictField(
-        ...,
-        description="A string specifying a versioned base URL that MUST adhere to the rules in section Base URL",
-        json_schema_extra={
-            "pattern": VERSIONED_BASE_URL_PATTERN,
-        },
-    )
+    url: Annotated[
+        AnyHttpUrl,
+        StrictField(
+            description="A string specifying a versioned base URL that MUST adhere to the rules in section Base URL",
+            json_schema_extra={
+                "pattern": VERSIONED_BASE_URL_PATTERN,
+            },
+        ),
+    ]
 
-    version: SemanticVersion = StrictField(
-        ...,
-        description="""A string containing the full version number of the API served at that versioned base URL.
+    version: Annotated[
+        SemanticVersion,
+        StrictField(
+            description="""A string containing the full version number of the API served at that versioned base URL.
 The version number string MUST NOT be prefixed by, e.g., 'v'.
 Examples: `1.0.0`, `1.0.0-rc.2`.""",
-    )
+        ),
+    ]
 
     @field_validator("url", mode="after")
     @classmethod
@@ -68,32 +72,43 @@ Examples: `1.0.0`, `1.0.0-rc.2`.""",
 class BaseInfoAttributes(BaseModel):
     """Attributes for Base URL Info endpoint"""
 
-    api_version: SemanticVersion = StrictField(
-        ...,
-        description="""Presently used full version of the OPTIMADE API.
+    api_version: Annotated[
+        SemanticVersion,
+        StrictField(
+            description="""Presently used full version of the OPTIMADE API.
 The version number string MUST NOT be prefixed by, e.g., "v".
 Examples: `1.0.0`, `1.0.0-rc.2`.""",
-    )
-    available_api_versions: list[AvailableApiVersion] = StrictField(
-        ...,
-        description="A list of dictionaries of available API versions at other base URLs",
-    )
-    formats: list[str] = StrictField(
-        default=["json"], description="List of available output formats."
-    )
-    available_endpoints: list[str] = StrictField(
-        ...,
-        description="List of available endpoints (i.e., the string to be appended to the versioned base URL).",
-    )
-    entry_types_by_format: dict[str, list[str]] = StrictField(
-        ..., description="Available entry endpoints as a function of output formats."
-    )
-    is_index: Optional[bool] = StrictField(
-        default=False,
-        description="If true, this is an index meta-database base URL (see section Index Meta-Database). "
-        "If this member is not provided, the client MUST assume this is not an index meta-database base URL "
-        "(i.e., the default is for `is_index` to be `false`).",
-    )
+        ),
+    ]
+    available_api_versions: Annotated[
+        list[AvailableApiVersion],
+        StrictField(
+            description="A list of dictionaries of available API versions at other base URLs",
+        ),
+    ]
+    formats: Annotated[
+        list[str], StrictField(description="List of available output formats.")
+    ] = ["json"]
+    available_endpoints: Annotated[
+        list[str],
+        StrictField(
+            description="List of available endpoints (i.e., the string to be appended to the versioned base URL).",
+        ),
+    ]
+    entry_types_by_format: Annotated[
+        dict[str, list[str]],
+        StrictField(
+            description="Available entry endpoints as a function of output formats."
+        ),
+    ]
+    is_index: Annotated[
+        Optional[bool],
+        StrictField(
+            description="If true, this is an index meta-database base URL (see section Index Meta-Database). "
+            "If this member is not provided, the client MUST assume this is not an index meta-database base URL "
+            "(i.e., the default is for `is_index` to be `false`).",
+        ),
+    ] = False
 
     @model_validator(mode="after")
     def formats_and_endpoints_must_be_valid(self) -> "BaseInfoAttributes":

--- a/optimade/models/baseinfo.py
+++ b/optimade/models/baseinfo.py
@@ -46,14 +46,14 @@ Examples: `1.0.0`, `1.0.0-rc.2`.""",
     @model_validator(mode="after")
     def crosscheck_url_and_version(self) -> "AvailableApiVersion":
         """Check that URL version and API version are compatible."""
-        url_version = (
+        url = (
             str(self.url)
             .split("/")[-2 if str(self.url).endswith("/") else -1]
             .replace("v", "")
         )
         # as with version urls, we need to split any release tags or build metadata out of these URLs
         url_version = tuple(
-            int(val) for val in url_version.split("-")[0].split("+")[0].split(".")
+            int(val) for val in url.split("-")[0].split("+")[0].split(".")
         )
         api_version = tuple(
             int(val) for val in str(self.version).split("-")[0].split("+")[0].split(".")

--- a/optimade/models/entries.py
+++ b/optimade/models/entries.py
@@ -1,7 +1,7 @@
 from datetime import datetime
-from typing import Annotated, Any, Literal, Optional, Union
+from typing import Annotated, Any, ClassVar, Literal, Optional, Union
 
-from pydantic import BaseModel, PrivateAttr, field_validator
+from pydantic import BaseModel, field_validator
 
 from optimade.models.jsonapi import Attributes, Relationships, Resource
 from optimade.models.optimade_json import (
@@ -21,7 +21,7 @@ __all__ = (
 
 
 class TypedRelationship(Relationship):
-    _req_type: Annotated[str, PrivateAttr()]
+    _req_type: ClassVar[str]
 
     @field_validator("data", mode="after")
     @classmethod
@@ -33,20 +33,18 @@ class TypedRelationship(Relationship):
             # https://jsonapi.org/format/1.0/#document-resource-object-linkage
             raise ValueError("`data` key in a relationship must always store a list.")
 
-        if hasattr(cls, "_req_type") and any(
-            obj.type != cls._req_type.get_default() for obj in data  # type: ignore[attr-defined]
-        ):
+        if any(obj.type != cls._req_type for obj in data):
             raise ValueError("Object stored in relationship data has wrong type")
 
         return data
 
 
 class ReferenceRelationship(TypedRelationship):
-    _req_type: Annotated[Literal["references"], PrivateAttr()] = "references"
+    _req_type: ClassVar[Literal["references"]] = "references"
 
 
 class StructureRelationship(TypedRelationship):
-    _req_type: Annotated[Literal["structures"], PrivateAttr()] = "structures"
+    _req_type: ClassVar[Literal["structures"]] = "structures"
 
 
 class EntryRelationships(Relationships):

--- a/optimade/models/entries.py
+++ b/optimade/models/entries.py
@@ -1,6 +1,6 @@
 # pylint: disable=line-too-long,no-self-argument
 from datetime import datetime
-from typing import Optional
+from typing import Any, Optional
 
 from pydantic import BaseModel, field_validator  # pylint: disable=no-name-in-module
 
@@ -18,10 +18,9 @@ __all__ = (
 
 
 class TypedRelationship(Relationship):
-    # This may be updated when moving to Python 3.8
     @field_validator("data")
     @classmethod
-    def check_rel_type(cls, data):
+    def check_rel_type(cls, data: list) -> list:
         if not isinstance(data, list):
             # All relationships at this point are empty-to-many relationships in JSON:API:
             # https://jsonapi.org/format/1.0/#document-resource-object-linkage
@@ -94,7 +93,7 @@ class EntryResourceAttributes(Attributes):
 
     @field_validator("immutable_id", mode="before")
     @classmethod
-    def cast_immutable_id_to_str(cls, value):
+    def cast_immutable_id_to_str(cls, value: Any) -> str:
         """Convenience validator for casting `immutable_id` to a string."""
         if value is not None and not isinstance(value, str):
             value = str(value)

--- a/optimade/models/entries.py
+++ b/optimade/models/entries.py
@@ -1,11 +1,14 @@
-# pylint: disable=line-too-long,no-self-argument
 from datetime import datetime
-from typing import Any, Optional
+from typing import Annotated, Any, Literal, Optional, Union
 
-from pydantic import BaseModel, field_validator  # pylint: disable=no-name-in-module
+from pydantic import BaseModel, PrivateAttr, field_validator
 
 from optimade.models.jsonapi import Attributes, Relationships, Resource
-from optimade.models.optimade_json import DataType, Relationship
+from optimade.models.optimade_json import (
+    BaseRelationshipResource,
+    DataType,
+    Relationship,
+)
 from optimade.models.utils import OptimadeField, StrictField, SupportLevel
 
 __all__ = (
@@ -18,48 +21,59 @@ __all__ = (
 
 
 class TypedRelationship(Relationship):
-    @field_validator("data")
+    _req_type: Annotated[str, PrivateAttr()]
+
+    @field_validator("data", mode="after")
     @classmethod
-    def check_rel_type(cls, data: list) -> list:
+    def check_rel_type(
+        cls, data: Union[BaseRelationshipResource, list[BaseRelationshipResource]]
+    ) -> list[BaseRelationshipResource]:
         if not isinstance(data, list):
             # All relationships at this point are empty-to-many relationships in JSON:API:
             # https://jsonapi.org/format/1.0/#document-resource-object-linkage
             raise ValueError("`data` key in a relationship must always store a list.")
+
         if hasattr(cls, "_req_type") and any(
-            getattr(obj, "type", None) != cls._req_type.default for obj in data
+            obj.type != cls._req_type.get_default() for obj in data  # type: ignore[attr-defined]
         ):
             raise ValueError("Object stored in relationship data has wrong type")
+
         return data
 
 
 class ReferenceRelationship(TypedRelationship):
-    _req_type = "references"
+    _req_type: Annotated[Literal["references"], PrivateAttr()] = "references"
 
 
 class StructureRelationship(TypedRelationship):
-    _req_type = "structures"
+    _req_type: Annotated[Literal["structures"], PrivateAttr()] = "structures"
 
 
 class EntryRelationships(Relationships):
     """This model wraps the JSON API Relationships to include type-specific top level keys."""
 
-    references: Optional[ReferenceRelationship] = StrictField(
-        None,
-        description="Object containing links to relationships with entries of the `references` type.",
-    )
+    references: Annotated[
+        Optional[ReferenceRelationship],
+        StrictField(
+            description="Object containing links to relationships with entries of the `references` type.",
+        ),
+    ] = None
 
-    structures: Optional[StructureRelationship] = StrictField(
-        None,
-        description="Object containing links to relationships with entries of the `structures` type.",
-    )
+    structures: Annotated[
+        Optional[StructureRelationship],
+        StrictField(
+            description="Object containing links to relationships with entries of the `structures` type.",
+        ),
+    ] = None
 
 
 class EntryResourceAttributes(Attributes):
     """Contains key-value pairs representing the entry's properties."""
 
-    immutable_id: Optional[str] = OptimadeField(
-        None,
-        description="""The entry's immutable ID (e.g., an UUID). This is important for databases having preferred IDs that point to "the latest version" of a record, but still offer access to older variants. This ID maps to the version-specific record, in case it changes in the future.
+    immutable_id: Annotated[
+        Optional[str],
+        OptimadeField(
+            description="""The entry's immutable ID (e.g., an UUID). This is important for databases having preferred IDs that point to "the latest version" of a record, but still offer access to older variants. This ID maps to the version-specific record, in case it changes in the future.
 
 - **Type**: string.
 
@@ -70,13 +84,15 @@ class EntryResourceAttributes(Attributes):
 - **Examples**:
     - `"8bd3e750-b477-41a0-9b11-3a799f21b44f"`
     - `"fjeiwoj,54;@=%<>#32"` (Strings that are not URL-safe are allowed.)""",
-        support=SupportLevel.OPTIONAL,
-        queryable=SupportLevel.MUST,
-    )
+            support=SupportLevel.OPTIONAL,
+            queryable=SupportLevel.MUST,
+        ),
+    ] = None
 
-    last_modified: Optional[datetime] = OptimadeField(
-        ...,
-        description="""Date and time representing when the entry was last modified.
+    last_modified: Annotated[
+        Optional[datetime],
+        OptimadeField(
+            description="""Date and time representing when the entry was last modified.
 
 - **Type**: timestamp.
 
@@ -87,9 +103,10 @@ class EntryResourceAttributes(Attributes):
 
 - **Example**:
     - As part of JSON response format: `"2007-04-05T14:30:20Z"` (i.e., encoded as an [RFC 3339 Internet Date/Time Format](https://tools.ietf.org/html/rfc3339#section-5.6) string.)""",
-        support=SupportLevel.SHOULD,
-        queryable=SupportLevel.MUST,
-    )
+            support=SupportLevel.SHOULD,
+            queryable=SupportLevel.MUST,
+        ),
+    ]
 
     @field_validator("immutable_id", mode="before")
     @classmethod
@@ -104,9 +121,10 @@ class EntryResourceAttributes(Attributes):
 class EntryResource(Resource):
     """The base model for an entry resource."""
 
-    id: str = OptimadeField(
-        ...,
-        description="""An entry's ID as defined in section Definition of Terms.
+    id: Annotated[
+        str,
+        OptimadeField(
+            description="""An entry's ID as defined in section Definition of Terms.
 
 - **Type**: string.
 
@@ -121,12 +139,15 @@ class EntryResource(Resource):
     - `"cod/2000000@1234567"`
     - `"nomad/L1234567890"`
     - `"42"`""",
-        support=SupportLevel.MUST,
-        queryable=SupportLevel.MUST,
-    )
+            support=SupportLevel.MUST,
+            queryable=SupportLevel.MUST,
+        ),
+    ]
 
-    type: str = OptimadeField(
-        description="""The name of the type of an entry.
+    type: Annotated[
+        str,
+        OptimadeField(
+            description="""The name of the type of an entry.
 
 - **Type**: string.
 
@@ -138,65 +159,84 @@ class EntryResource(Resource):
     - The entry of type `<type>` and ID `<id>` MUST be returned in response to a request for `/<type>/<id>` under the versioned base URL.
 
 - **Example**: `"structures"`""",
-        support=SupportLevel.MUST,
-        queryable=SupportLevel.MUST,
-    )
+            support=SupportLevel.MUST,
+            queryable=SupportLevel.MUST,
+        ),
+    ]
 
-    attributes: EntryResourceAttributes = StrictField(
-        ...,
-        description="""A dictionary, containing key-value pairs representing the entry's properties, except for `type` and `id`.
+    attributes: Annotated[
+        EntryResourceAttributes,
+        StrictField(
+            description="""A dictionary, containing key-value pairs representing the entry's properties, except for `type` and `id`.
 Database-provider-specific properties need to include the database-provider-specific prefix (see section on Database-Provider-Specific Namespace Prefixes).""",
-    )
+        ),
+    ]
 
-    relationships: Optional[EntryRelationships] = StrictField(
-        None,
-        description="""A dictionary containing references to other entries according to the description in section Relationships encoded as [JSON API Relationships](https://jsonapi.org/format/1.0/#document-resource-object-relationships).
+    relationships: Annotated[
+        Optional[EntryRelationships],
+        StrictField(
+            description="""A dictionary containing references to other entries according to the description in section Relationships encoded as [JSON API Relationships](https://jsonapi.org/format/1.0/#document-resource-object-relationships).
 The OPTIONAL human-readable description of the relationship MAY be provided in the `description` field inside the `meta` dictionary of the JSON API resource identifier object.""",
-    )
+        ),
+    ] = None
 
 
 class EntryInfoProperty(BaseModel):
-    description: str = StrictField(
-        ..., description="A human-readable description of the entry property"
-    )
+    description: Annotated[
+        str,
+        StrictField(description="A human-readable description of the entry property"),
+    ]
 
-    unit: Optional[str] = StrictField(
-        None,
-        description="""The physical unit of the entry property.
+    unit: Annotated[
+        Optional[str],
+        StrictField(
+            description="""The physical unit of the entry property.
 This MUST be a valid representation of units according to version 2.1 of [The Unified Code for Units of Measure](https://unitsofmeasure.org/ucum.html).
 It is RECOMMENDED that non-standard (non-SI) units are described in the description for the property.""",
-    )
+        ),
+    ] = None
 
-    sortable: Optional[bool] = StrictField(
-        None,
-        description="""Defines whether the entry property can be used for sorting with the "sort" parameter.
+    sortable: Annotated[
+        Optional[bool],
+        StrictField(
+            description="""Defines whether the entry property can be used for sorting with the "sort" parameter.
 If the entry listing endpoint supports sorting, this key MUST be present for sortable properties with value `true`.""",
-    )
+        ),
+    ] = None
 
-    type: Optional[DataType] = StrictField(
-        None,
-        title="Type",
-        description="""The type of the property's value.
+    type: Annotated[
+        Optional[DataType],
+        StrictField(
+            title="Type",
+            description="""The type of the property's value.
 This MUST be any of the types defined in the Data types section.
 For the purpose of compatibility with future versions of this specification, a client MUST accept values that are not `string` values specifying any of the OPTIMADE Data types, but MUST then also disregard the `type` field.
 Note, if the value is a nested type, only the outermost type should be reported.
 E.g., for the entry resource `structures`, the `species` property is defined as a list of dictionaries, hence its `type` value would be `list`.""",
-    )
+        ),
+    ] = None
 
 
 class EntryInfoResource(BaseModel):
-    formats: list[str] = StrictField(
-        ..., description="List of output formats available for this type of entry."
-    )
+    formats: Annotated[
+        list[str],
+        StrictField(
+            description="List of output formats available for this type of entry."
+        ),
+    ]
 
-    description: str = StrictField(..., description="Description of the entry.")
+    description: Annotated[str, StrictField(description="Description of the entry.")]
 
-    properties: dict[str, EntryInfoProperty] = StrictField(
-        ...,
-        description="A dictionary describing queryable properties for this entry type, where each key is a property name.",
-    )
+    properties: Annotated[
+        dict[str, EntryInfoProperty],
+        StrictField(
+            description="A dictionary describing queryable properties for this entry type, where each key is a property name.",
+        ),
+    ]
 
-    output_fields_by_format: dict[str, list[str]] = StrictField(
-        ...,
-        description="Dictionary of available output fields for this entry type, where the keys are the values of the `formats` list and the values are the keys of the `properties` dictionary.",
-    )
+    output_fields_by_format: Annotated[
+        dict[str, list[str]],
+        StrictField(
+            description="Dictionary of available output fields for this entry type, where the keys are the values of the `formats` list and the values are the keys of the `properties` dictionary.",
+        ),
+    ]

--- a/optimade/models/index_metadb.py
+++ b/optimade/models/index_metadb.py
@@ -1,6 +1,6 @@
 # pylint: disable=no-self-argument
 from enum import Enum
-from typing import Union
+from typing import Literal, Union
 
 from pydantic import BaseModel, Field  # pylint: disable=no-name-in-module
 
@@ -34,7 +34,7 @@ class IndexInfoAttributes(BaseInfoAttributes):
 class RelatedLinksResource(BaseResource):
     """A related Links resource object"""
 
-    type: str = Field("links", pattern="^links$")
+    type: Literal["links"] = "links"
 
 
 class IndexRelationship(BaseModel):

--- a/optimade/models/index_metadb.py
+++ b/optimade/models/index_metadb.py
@@ -1,8 +1,7 @@
-# pylint: disable=no-self-argument
 from enum import Enum
 from typing import Literal, Union
 
-from pydantic import BaseModel, Field  # pylint: disable=no-name-in-module
+from pydantic import BaseModel, Field
 
 from optimade.models.baseinfo import BaseInfoAttributes, BaseInfoResource
 from optimade.models.jsonapi import BaseResource

--- a/optimade/models/index_metadb.py
+++ b/optimade/models/index_metadb.py
@@ -34,7 +34,7 @@ class IndexInfoAttributes(BaseInfoAttributes):
 class RelatedLinksResource(BaseResource):
     """A related Links resource object"""
 
-    type: str = Field("links", regex="^links$")
+    type: str = Field("links", pattern="^links$")
 
 
 class IndexRelationship(BaseModel):

--- a/optimade/models/index_metadb.py
+++ b/optimade/models/index_metadb.py
@@ -1,7 +1,6 @@
-from enum import Enum
-from typing import Literal, Union
+from typing import Annotated, Literal, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 from optimade.models.baseinfo import BaseInfoAttributes, BaseInfoResource
 from optimade.models.jsonapi import BaseResource
@@ -15,19 +14,15 @@ __all__ = (
 )
 
 
-class DefaultRelationship(Enum):
-    """Enumeration of key(s) for relationship dictionary in IndexInfoResource"""
-
-    DEFAULT = "default"
-
-
 class IndexInfoAttributes(BaseInfoAttributes):
     """Attributes for Base URL Info endpoint for an Index Meta-Database"""
 
-    is_index: bool = StrictField(
-        True,
-        description="This must be `true` since this is an index meta-database (see section Index Meta-Database).",
-    )
+    is_index: Annotated[
+        bool,
+        StrictField(
+            description="This must be `true` since this is an index meta-database (see section Index Meta-Database).",
+        ),
+    ] = True
 
 
 class RelatedLinksResource(BaseResource):
@@ -39,22 +34,24 @@ class RelatedLinksResource(BaseResource):
 class IndexRelationship(BaseModel):
     """Index Meta-Database relationship"""
 
-    data: Union[None, RelatedLinksResource] = StrictField(
-        ...,
-        description="""[JSON API resource linkage](http://jsonapi.org/format/1.0/#document-links).
+    data: Annotated[
+        Optional[RelatedLinksResource],
+        StrictField(
+            description="""[JSON API resource linkage](http://jsonapi.org/format/1.0/#document-links).
 It MUST be either `null` or contain a single Links identifier object with the fields `id` and `type`""",
-    )
+        ),
+    ]
 
 
 class IndexInfoResource(BaseInfoResource):
     """Index Meta-Database Base URL Info endpoint resource"""
 
-    attributes: IndexInfoAttributes = Field(...)
-    relationships: Union[
-        None, dict[DefaultRelationship, IndexRelationship]
-    ] = StrictField(  # type: ignore[assignment]
-        ...,
-        title="Relationships",
-        description="""Reference to the Links identifier object under the `links` endpoint that the provider has chosen as their 'default' OPTIMADE API database.
+    attributes: IndexInfoAttributes
+    relationships: Annotated[  # type: ignore[assignment]
+        Optional[dict[Literal["default"], IndexRelationship]],
+        StrictField(
+            title="Relationships",
+            description="""Reference to the Links identifier object under the `links` endpoint that the provider has chosen as their 'default' OPTIMADE API database.
 A client SHOULD present this database as the first choice when an end-user chooses this provider.""",
-    )
+        ),
+    ]

--- a/optimade/models/jsonapi.py
+++ b/optimade/models/jsonapi.py
@@ -92,7 +92,7 @@ class ToplevelLinks(BaseModel):
 
         """
         for field, value in self:
-            if field not in self.model_json_schema(mode="validation")["properties"]:
+            if field not in self.model_fields:
                 setattr(
                     self,
                     field,

--- a/optimade/models/jsonapi.py
+++ b/optimade/models/jsonapi.py
@@ -354,11 +354,11 @@ class Response(BaseModel):
     @model_validator(mode="after")
     def either_data_meta_or_errors_must_be_set(self) -> "Response":
         required_fields = ("data", "meta", "errors")
-        if not any(hasattr(self, field) for field in required_fields):
+        if not any(field in self.model_fields_set for field in required_fields):
             raise ValueError(
                 f"At least one of {required_fields} MUST be specified in the top-level response"
             )
-        if hasattr(self, "errors") and not self.errors:
+        if "errors" in self.model_fields_set and not self.errors:
             raise ValueError("Errors MUST NOT be an empty or 'null' value.")
         return self
 

--- a/optimade/models/jsonapi.py
+++ b/optimade/models/jsonapi.py
@@ -368,14 +368,7 @@ describing relationships between the resource and other JSON API resources.""",
 
 
 class Response(BaseModel):
-    """A top-level response.
-
-    The specification mandates that datetimes must be encoded following
-    [RFC3339](https://tools.ietf.org/html/rfc3339), which does not support
-    fractional seconds, thus they must be stripped in the response. This can
-    cause issues when the underlying database contains fields that do include
-    microseconds, as filters may return unexpected results.
-    """
+    """A top-level response."""
 
     data: Annotated[
         Optional[Union[None, Resource, list[Resource]]],
@@ -424,3 +417,9 @@ class Response(BaseModel):
             )
         }
     )
+    """The specification mandates that datetimes must be encoded following
+    [RFC3339](https://tools.ietf.org/html/rfc3339), which does not support
+    fractional seconds, thus they must be stripped in the response. This can
+    cause issues when the underlying database contains fields that do include
+    microseconds, as filters may return unexpected results.
+    """

--- a/optimade/models/jsonapi.py
+++ b/optimade/models/jsonapi.py
@@ -7,8 +7,9 @@ from pydantic import (  # pylint: disable=no-name-in-module
     AnyUrl,
     BaseModel,
     BeforeValidator,
-    TypeAdapter,
+    ConfigDict,
     model_validator,
+    typeAdapter,
 )
 
 from optimade.models.utils import StrictField
@@ -34,7 +35,7 @@ __all__ = (
 class Meta(BaseModel):
     """Non-standard meta-information that can not be represented as an attribute or relationship."""
 
-    model_config: dict[str, Any] = {"extra": "allow"}
+    model_config = ConfigDict(extra="allow")
 
 
 class Link(BaseModel):
@@ -61,6 +62,8 @@ class JsonApi(BaseModel):
 class ToplevelLinks(BaseModel):
     """A set of Links objects, possibly including pagination"""
 
+    model_config = ConfigDict(extra="allow")
+
     self: Optional[Union[AnyUrl, Link]] = StrictField(
         None, description="A link to itself"
     )
@@ -82,22 +85,21 @@ class ToplevelLinks(BaseModel):
         None, description="The next page of data"
     )
 
-    @model_validator(mode="before")
-    @classmethod
-    def check_additional_keys_are_links(cls, values):
+    @model_validator(mode="after")
+    def check_additional_keys_are_links(self) -> "ToplevelLinks":
         """The `ToplevelLinks` class allows any additional keys, as long as
         they are also Links or Urls themselves.
 
         """
-        for key, value in values.items():
-            if key not in cls.model_json_schema()["properties"]:
-                values[key] = TypeAdapter.validate_python(
-                    Optional[Union[AnyUrl, Link]], value
+        for field, value in self:
+            if field not in self.model_json_schema()["properties"]:
+                setattr(
+                    self,
+                    field,
+                    typeAdapter(Optional[Union[AnyUrl, Link]]).validate_python(value),
                 )
 
-        return values
-
-    model_config: dict[str, Any] = {"extra": "allow"}
+        return self
 
 
 class ErrorLinks(BaseModel):
@@ -163,37 +165,36 @@ class Error(BaseModel):
         return hash(self.model_dump_json())
 
 
+def resource_json_schema_extra(
+    schema: dict[str, Any], model: type["BaseResource"]
+) -> None:
+    """Ensure `id` and `type` are the first two entries in the list required properties.
+
+    Note:
+        This _requires_ that `id` and `type` are the _first_ model fields defined
+        for all sub-models of `BaseResource`.
+
+    """
+    if "id" not in schema.get("required", []):
+        schema["required"] = ["id"] + schema.get("required", [])
+    if "type" not in schema.get("required", []):
+        required = []
+        for field in schema.get("required", []):
+            required.append(field)
+            if field == "id":
+                # To make sure the property order match the listed properties,
+                # this ensures "type" is added immediately after "id".
+                required.append("type")
+        schema["required"] = required
+
+
 class BaseResource(BaseModel):
     """Minimum requirements to represent a Resource"""
 
+    model_config = ConfigDict(json_schema_extra=resource_json_schema_extra)
+
     id: str = StrictField(..., description="Resource ID")
     type: str = StrictField(..., description="Resource type")
-
-    # TODO[pydantic]: We couldn't refactor this class, please create the `model_config` manually.
-    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-config for more information.
-    class Config:
-        @staticmethod
-        def json_schema_extra(
-            schema: dict[str, Any], model: type["BaseResource"]
-        ) -> None:
-            """Ensure `id` and `type` are the first two entries in the list required properties.
-
-            Note:
-                This _requires_ that `id` and `type` are the _first_ model fields defined
-                for all sub-models of `BaseResource`.
-
-            """
-            if "id" not in schema.get("required", []):
-                schema["required"] = ["id"] + schema.get("required", [])
-            if "type" not in schema.get("required", []):
-                required = []
-                for field in schema.get("required", []):
-                    required.append(field)
-                    if field == "id":
-                        # To make sure the property order match the listed properties,
-                        # this ensures "type" is added immediately after "id".
-                        required.append("type")
-                schema["required"] = required
 
 
 class RelationshipLinks(BaseModel):
@@ -215,17 +216,13 @@ When fetched successfully, this link returns the [linkage](https://jsonapi.org/f
         description="A [related resource link](https://jsonapi.org/format/1.0/#document-resource-object-related-resource-links).",
     )
 
-    @model_validator(mode="before")
-    @classmethod
-    def either_self_or_related_must_be_specified(cls, values):
-        for value in values.values():
-            if value is not None:
-                break
-        else:
+    @model_validator(mode="after")
+    def either_self_or_related_must_be_specified(self) -> "RelationshipLinks":
+        if self.self is None and self.related is None:
             raise ValueError(
                 "Either 'self' or 'related' MUST be specified for RelationshipLinks"
             )
-        return values
+        return self
 
 
 class Relationship(BaseModel):
@@ -243,17 +240,13 @@ class Relationship(BaseModel):
         description="a meta object that contains non-standard meta-information about the relationship.",
     )
 
-    @model_validator(mode="before")
-    @classmethod
-    def at_least_one_relationship_key_must_be_set(cls, values):
-        for value in values.values():
-            if value is not None:
-                break
-        else:
+    @model_validator(mode="after")
+    def at_least_one_relationship_key_must_be_set(self) -> "Relationship":
+        if self.links is None and self.data is None and self.meta is None:
             raise ValueError(
                 "Either 'links', 'data', or 'meta' MUST be specified for Relationship"
             )
-        return values
+        return self
 
 
 class Relationships(BaseModel):
@@ -264,16 +257,15 @@ class Relationships(BaseModel):
         id
     """
 
-    @model_validator(mode="before")
-    @classmethod
-    def check_illegal_relationships_fields(cls, values):
+    @model_validator(mode="after")
+    def check_illegal_relationships_fields(self) -> "Relationships":
         illegal_fields = ("id", "type")
         for field in illegal_fields:
-            if field in values:
+            if hasattr(self, field):
                 raise ValueError(
                     f"{illegal_fields} MUST NOT be fields under Relationships"
                 )
-        return values
+        return self
 
 
 class ResourceLinks(BaseModel):
@@ -295,18 +287,17 @@ class Attributes(BaseModel):
         type
     """
 
-    model_config: dict[str, Any] = {"extra": "allow"}
+    model_config = ConfigDict(extra="allow")
 
-    @model_validator(mode="before")
-    @classmethod
-    def check_illegal_attributes_fields(cls, values):
+    @model_validator(mode="after")
+    def check_illegal_attributes_fields(self) -> "Attributes":
         illegal_fields = ("relationships", "links", "id", "type")
         for field in illegal_fields:
-            if field in values:
+            if hasattr(self, field):
                 raise ValueError(
                     f"{illegal_fields} MUST NOT be fields under Attributes"
                 )
-        return values
+        return self
 
 
 class Resource(BaseResource):
@@ -331,7 +322,14 @@ describing relationships between the resource and other JSON API resources.""",
 
 
 class Response(BaseModel):
-    """A top-level response"""
+    """A top-level response.
+
+    The specification mandates that datetimes must be encoded following
+    [RFC3339](https://tools.ietf.org/html/rfc3339), which does not support
+    fractional seconds, thus they must be stripped in the response. This can
+    cause issues when the underlying database contains fields that do include
+    microseconds, as filters may return unexpected results.
+    """
 
     data: Optional[Union[None, Resource, list[Resource]]] = StrictField(
         None, description="Outputted Data", uniqueItems=True
@@ -353,28 +351,21 @@ class Response(BaseModel):
         None, description="Information about the JSON API used"
     )
 
-    @model_validator(mode="before")
-    @classmethod
-    def either_data_meta_or_errors_must_be_set(cls, values):
+    @model_validator(mode="after")
+    def either_data_meta_or_errors_must_be_set(self) -> "Response":
         required_fields = ("data", "meta", "errors")
-        if not any(field in values for field in required_fields):
+        if not any(hasattr(self, field) for field in required_fields):
             raise ValueError(
                 f"At least one of {required_fields} MUST be specified in the top-level response"
             )
-        if "errors" in values and not values.get("errors"):
+        if hasattr(self, "errors") and not self.errors:
             raise ValueError("Errors MUST NOT be an empty or 'null' value.")
-        return values
+        return self
 
-    """The specification mandates that datetimes must be encoded following
-    [RFC3339](https://tools.ietf.org/html/rfc3339), which does not support
-    fractional seconds, thus they must be stripped in the response. This can
-    cause issues when the underlying database contains fields that do include
-    microseconds, as filters may return unexpected results.
-    """
-    model_config: dict[str, Any] = {
-        "json_encoders": {
+    model_config = ConfigDict(
+        json_encoders={
             datetime: lambda v: v.astimezone(timezone.utc).strftime(
                 "%Y-%m-%dT%H:%M:%SZ"
             )
         }
-    }
+    )

--- a/optimade/models/jsonapi.py
+++ b/optimade/models/jsonapi.py
@@ -92,7 +92,7 @@ class ToplevelLinks(BaseModel):
 
         """
         for field, value in self:
-            if field not in self.model_json_schema()["properties"]:
+            if field not in self.model_json_schema(mode="validation")["properties"]:
                 setattr(
                     self,
                     field,

--- a/optimade/models/links.py
+++ b/optimade/models/links.py
@@ -2,7 +2,7 @@
 from enum import Enum
 from typing import Optional, Union
 
-from pydantic import AnyUrl, root_validator  # pylint: disable=no-name-in-module
+from pydantic import AnyUrl, model_validator  # pylint: disable=no-name-in-module
 
 from optimade.models.entries import EntryResource
 from optimade.models.jsonapi import Attributes, Link
@@ -88,7 +88,7 @@ class LinksResource(EntryResource):
     type: str = StrictField(
         "links",
         description="These objects are described in detail in the section Links Endpoint",
-        regex="^links$",
+        pattern="^links$",
     )
 
     attributes: LinksResourceAttributes = StrictField(
@@ -96,7 +96,8 @@ class LinksResource(EntryResource):
         description="A dictionary containing key-value pairs representing the Links resource's properties.",
     )
 
-    @root_validator(pre=True)
+    @model_validator(mode="before")
+    @classmethod
     def relationships_must_not_be_present(cls, values):
         if values.get("relationships", None) is not None:
             raise ValueError('"relationships" is not allowed for links resources')

--- a/optimade/models/links.py
+++ b/optimade/models/links.py
@@ -96,9 +96,8 @@ class LinksResource(EntryResource):
         description="A dictionary containing key-value pairs representing the Links resource's properties.",
     )
 
-    @model_validator(mode="before")
-    @classmethod
-    def relationships_must_not_be_present(cls, values):
-        if values.get("relationships", None) is not None:
+    @model_validator(mode="after")
+    def relationships_must_not_be_present(self) -> "LinksResource":
+        if hasattr(self, "relationships"):
             raise ValueError('"relationships" is not allowed for links resources')
-        return values
+        return self

--- a/optimade/models/links.py
+++ b/optimade/models/links.py
@@ -98,6 +98,6 @@ class LinksResource(EntryResource):
 
     @model_validator(mode="after")
     def relationships_must_not_be_present(self) -> "LinksResource":
-        if hasattr(self, "relationships"):
+        if self.relationships or "relationships" in self.model_fields_set:
             raise ValueError('"relationships" is not allowed for links resources')
         return self

--- a/optimade/models/links.py
+++ b/optimade/models/links.py
@@ -1,11 +1,10 @@
-# pylint: disable=no-self-argument
 from enum import Enum
-from typing import Optional, Union
+from typing import Annotated, Literal, Optional
 
-from pydantic import AnyUrl, model_validator  # pylint: disable=no-name-in-module
+from pydantic import model_validator
 
 from optimade.models.entries import EntryResource
-from optimade.models.jsonapi import Attributes, Link
+from optimade.models.jsonapi import Attributes, JsonLinkType
 from optimade.models.utils import StrictField
 
 __all__ = (
@@ -35,35 +34,46 @@ class Aggregate(Enum):
 class LinksResourceAttributes(Attributes):
     """Links endpoint resource object attributes"""
 
-    name: str = StrictField(
-        ...,
-        description="Human-readable name for the OPTIMADE API implementation, e.g., for use in clients to show the name to the end-user.",
-    )
-    description: str = StrictField(
-        ...,
-        description="Human-readable description for the OPTIMADE API implementation, e.g., for use in clients to show a description to the end-user.",
-    )
-    base_url: Optional[Union[AnyUrl, Link]] = StrictField(
-        ...,
-        description="JSON API links object, pointing to the base URL for this implementation",
-    )
+    name: Annotated[
+        str,
+        StrictField(
+            description="Human-readable name for the OPTIMADE API implementation, e.g., for use in clients to show the name to the end-user.",
+        ),
+    ]
+    description: Annotated[
+        str,
+        StrictField(
+            description="Human-readable description for the OPTIMADE API implementation, e.g., for use in clients to show a description to the end-user.",
+        ),
+    ]
+    base_url: Annotated[
+        Optional[JsonLinkType],
+        StrictField(
+            description="JSON API links object, pointing to the base URL for this implementation",
+        ),
+    ]
 
-    homepage: Optional[Union[AnyUrl, Link]] = StrictField(
-        ...,
-        description="JSON API links object, pointing to a homepage URL for this implementation",
-    )
+    homepage: Annotated[
+        Optional[JsonLinkType],
+        StrictField(
+            description="JSON API links object, pointing to a homepage URL for this implementation",
+        ),
+    ]
 
-    link_type: LinkType = StrictField(
-        ...,
-        title="Link Type",
-        description="""The type of the linked relation.
+    link_type: Annotated[
+        LinkType,
+        StrictField(
+            title="Link Type",
+            description="""The type of the linked relation.
 MUST be one of these values: 'child', 'root', 'external', 'providers'.""",
-    )
+        ),
+    ]
 
-    aggregate: Optional[Aggregate] = StrictField(
-        Aggregate.OK,
-        title="Aggregate",
-        description="""A string indicating whether a client that is following links to aggregate results from different OPTIMADE implementations should follow this link or not.
+    aggregate: Annotated[
+        Optional[Aggregate],
+        StrictField(
+            title="Aggregate",
+            description="""A string indicating whether a client that is following links to aggregate results from different OPTIMADE implementations should follow this link or not.
 This flag SHOULD NOT be indicated for links where `link_type` is not `child`.
 
 If not specified, clients MAY assume that the value is `ok`.
@@ -73,28 +83,35 @@ Specific values indicate the reason why the server is providing the suggestion.
 A client MAY follow the link anyway if it has reason to do so (e.g., if the client is looking for all test databases, it MAY follow the links marked with `aggregate`=`test`).
 
 If specified, it MUST be one of the values listed in section Link Aggregate Options.""",
-    )
+        ),
+    ] = Aggregate.OK
 
-    no_aggregate_reason: Optional[str] = StrictField(
-        None,
-        description="""An OPTIONAL human-readable string indicating the reason for suggesting not to aggregate results following the link.
+    no_aggregate_reason: Annotated[
+        Optional[str],
+        StrictField(
+            description="""An OPTIONAL human-readable string indicating the reason for suggesting not to aggregate results following the link.
 It SHOULD NOT be present if `aggregate`=`ok`.""",
-    )
+        ),
+    ] = None
 
 
 class LinksResource(EntryResource):
     """A Links endpoint resource object"""
 
-    type: str = StrictField(
-        "links",
-        description="These objects are described in detail in the section Links Endpoint",
-        pattern="^links$",
-    )
+    type: Annotated[
+        Literal["links"],
+        StrictField(
+            description="These objects are described in detail in the section Links Endpoint",
+            pattern="^links$",
+        ),
+    ] = "links"
 
-    attributes: LinksResourceAttributes = StrictField(
-        ...,
-        description="A dictionary containing key-value pairs representing the Links resource's properties.",
-    )
+    attributes: Annotated[
+        LinksResourceAttributes,
+        StrictField(
+            description="A dictionary containing key-value pairs representing the Links resource's properties.",
+        ),
+    ]
 
     @model_validator(mode="after")
     def relationships_must_not_be_present(self) -> "LinksResource":

--- a/optimade/models/optimade_json.py
+++ b/optimade/models/optimade_json.py
@@ -180,7 +180,7 @@ class Warnings(OptimadeError):
 
     @model_validator(mode="after")
     def status_must_not_be_specified(self) -> "Warnings":
-        if hasattr(self, "status"):
+        if self.status or "status" in self.model_fields_set:
             raise ValueError("status MUST NOT be specified for warnings")
         return self
 
@@ -348,13 +348,13 @@ class Success(jsonapi.Response):
     def either_data_meta_or_errors_must_be_set(self) -> "Success":
         """Overwriting the existing validation function, since 'errors' MUST NOT be set."""
         required_fields = ("data", "meta")
-        if not any(hasattr(self, field) for field in required_fields):
+        if not any(field in self.model_fields_set for field in required_fields):
             raise ValueError(
                 f"At least one of {required_fields} MUST be specified in the top-level response."
             )
 
         # errors MUST be skipped
-        if hasattr(self, "errors"):
+        if self.errors or "errors" in self.model_fields_set:
             raise ValueError("'errors' MUST be skipped for a successful response.")
 
         return self

--- a/optimade/models/optimade_json.py
+++ b/optimade/models/optimade_json.py
@@ -10,7 +10,7 @@ from optimade.models.types import SemanticVersion
 from optimade.models.utils import StrictField
 
 __all__ = (
-    "Datatype",
+    "DataType",
     "ResponseMetaQuery",
     "Provider",
     "ImplementationMaintainer",
@@ -25,7 +25,7 @@ __all__ = (
 )
 
 
-class Datatype(Enum):
+class DataType(Enum):
     """Optimade Data types
 
     See the section "Data types" in the OPTIMADE API specification for more information.
@@ -48,7 +48,7 @@ class Datatype(Enum):
     @classmethod
     def from_python_type(
         cls, python_type: Union[type, str, object]
-    ) -> Optional["Datatype"]:
+    ) -> Optional["DataType"]:
         """Get OPTIMADE data type from a Python type"""
         mapping = {
             "bool": cls.BOOLEAN,
@@ -91,7 +91,7 @@ class Datatype(Enum):
         return mapping.get(python_type, None)
 
     @classmethod
-    def from_json_type(cls, json_type: str) -> Optional["Datatype"]:
+    def from_json_type(cls, json_type: str) -> Optional["DataType"]:
         """Get OPTIMADE data type from a named JSON type"""
         mapping = {
             "string": cls.STRING,

--- a/optimade/models/optimade_json.py
+++ b/optimade/models/optimade_json.py
@@ -4,7 +4,14 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Optional, Union
 
-from pydantic import AnyHttpUrl, AnyUrl, BaseModel, EmailStr, model_validator
+from pydantic import (
+    AnyHttpUrl,
+    AnyUrl,
+    BaseModel,
+    ConfigDict,
+    EmailStr,
+    model_validator,
+)
 
 from optimade.models import jsonapi
 from optimade.models.types import SemanticVersion
@@ -131,6 +138,26 @@ class OptimadeError(jsonapi.Error):
     )
 
 
+def warnings_json_schema_extra(schema: dict[str, Any], model: type["Warnings"]) -> None:
+    """Update OpenAPI JSON schema model for `Warning`.
+
+    * Ensure `type` is in the list required properties and in the correct place.
+    * Remove `status` property.
+        This property is not allowed for `Warning`, nor is it a part of the OPTIMADE
+        definition of the `Warning` object.
+
+    Note:
+        Since `type` is the _last_ model field defined, it will simply be appended.
+
+    """
+    if "required" in schema:
+        if "type" not in schema["required"]:
+            schema["required"].append("type")
+        else:
+            schema["required"] = ["type"]
+    schema.get("properties", {}).pop("status", None)
+
+
 class Warnings(OptimadeError):
     """OPTIMADE-specific warning class based on OPTIMADE-specific JSON API Error.
 
@@ -143,39 +170,19 @@ class Warnings(OptimadeError):
 
     """
 
+    model_config = ConfigDict(json_schema_extra=warnings_json_schema_extra)
+
     type: str = StrictField(
         "warning",
         description='Warnings must be of type "warning"',
         pattern="^warning$",
     )
 
-    @model_validator(mode="before")
-    @classmethod
-    def status_must_not_be_specified(cls, values):
-        if values.get("status", None) is not None:
+    @model_validator(mode="after")
+    def status_must_not_be_specified(self) -> "Warnings":
+        if hasattr(self, "status"):
             raise ValueError("status MUST NOT be specified for warnings")
-        return values
-
-    class Config:
-        @staticmethod
-        def json_schema_extra(schema: dict[str, Any], model: type["Warnings"]) -> None:
-            """Update OpenAPI JSON schema model for `Warning`.
-
-            * Ensure `type` is in the list required properties and in the correct place.
-            * Remove `status` property.
-              This property is not allowed for `Warning`, nor is it a part of the OPTIMADE
-              definition of the `Warning` object.
-
-            Note:
-                Since `type` is the _last_ model field defined, it will simply be appended.
-
-            """
-            if "required" in schema:
-                if "type" not in schema["required"]:
-                    schema["required"].append("type")
-                else:
-                    schema["required"] = ["type"]
-            schema.get("properties", {}).pop("status", None)
+        return self
 
 
 class ResponseMetaQuery(BaseModel):
@@ -337,21 +344,20 @@ class Success(jsonapi.Response):
         ..., description="A meta object containing non-standard information"
     )
 
-    @model_validator(mode="before")
-    @classmethod
-    def either_data_meta_or_errors_must_be_set(cls, values):
+    @model_validator(mode="after")
+    def either_data_meta_or_errors_must_be_set(self) -> "Success":
         """Overwriting the existing validation function, since 'errors' MUST NOT be set."""
         required_fields = ("data", "meta")
-        if not any(field in values for field in required_fields):
+        if not any(hasattr(self, field) for field in required_fields):
             raise ValueError(
                 f"At least one of {required_fields} MUST be specified in the top-level response."
             )
 
         # errors MUST be skipped
-        if "errors" in values:
+        if hasattr(self, "errors"):
             raise ValueError("'errors' MUST be skipped for a successful response.")
 
-        return values
+        return self
 
 
 class BaseRelationshipMeta(jsonapi.Meta):

--- a/optimade/models/optimade_json.py
+++ b/optimade/models/optimade_json.py
@@ -1,17 +1,9 @@
 """Modified JSON API v1.0 for OPTIMADE API"""
-# pylint: disable=no-self-argument,no-name-in-module
 from datetime import datetime
 from enum import Enum
-from typing import Any, Optional, Union
+from typing import Annotated, Any, Literal, Optional, Union
 
-from pydantic import (
-    AnyHttpUrl,
-    AnyUrl,
-    BaseModel,
-    ConfigDict,
-    EmailStr,
-    model_validator,
-)
+from pydantic import BaseModel, ConfigDict, EmailStr, model_validator
 
 from optimade.models import jsonapi
 from optimade.models.types import SemanticVersion
@@ -49,12 +41,14 @@ class Datatype(Enum):
     UNKNOWN = "unknown"
 
     @classmethod
-    def get_values(cls):
+    def get_values(cls) -> list[str]:
         """Get OPTIMADE data types (enum values) as a (sorted) list"""
         return sorted(_.value for _ in cls)
 
     @classmethod
-    def from_python_type(cls, python_type: Union[type, str, object]):
+    def from_python_type(
+        cls, python_type: Union[type, str, object]
+    ) -> Optional["Datatype"]:
         """Get OPTIMADE data type from a Python type"""
         mapping = {
             "bool": cls.BOOLEAN,
@@ -97,7 +91,7 @@ class Datatype(Enum):
         return mapping.get(python_type, None)
 
     @classmethod
-    def from_json_type(cls, json_type: str):
+    def from_json_type(cls, json_type: str) -> Optional["Datatype"]:
         """Get OPTIMADE data type from a named JSON type"""
         mapping = {
             "string": cls.STRING,
@@ -132,10 +126,12 @@ class Datatype(Enum):
 class OptimadeError(jsonapi.Error):
     """detail MUST be present"""
 
-    detail: str = StrictField(
-        ...,
-        description="A human-readable explanation specific to this occurrence of the problem.",
-    )
+    detail: Annotated[
+        str,
+        StrictField(
+            description="A human-readable explanation specific to this occurrence of the problem.",
+        ),
+    ]
 
 
 def warnings_json_schema_extra(schema: dict[str, Any], model: type["Warnings"]) -> None:
@@ -172,11 +168,13 @@ class Warnings(OptimadeError):
 
     model_config = ConfigDict(json_schema_extra=warnings_json_schema_extra)
 
-    type: str = StrictField(
-        "warning",
-        description='Warnings must be of type "warning"',
-        pattern="^warning$",
-    )
+    type: Annotated[
+        Literal["warning"],
+        StrictField(
+            description='Warnings must be of type "warning"',
+            pattern="^warning$",
+        ),
+    ] = "warning"
 
     @model_validator(mode="after")
     def status_must_not_be_specified(self) -> "Warnings":
@@ -188,72 +186,93 @@ class Warnings(OptimadeError):
 class ResponseMetaQuery(BaseModel):
     """Information on the query that was requested."""
 
-    representation: str = StrictField(
-        ...,
-        description="""A string with the part of the URL following the versioned or unversioned base URL that serves the API.
+    representation: Annotated[
+        str,
+        StrictField(
+            description="""A string with the part of the URL following the versioned or unversioned base URL that serves the API.
 Query parameters that have not been used in processing the request MAY be omitted.
 In particular, if no query parameters have been involved in processing the request, the query part of the URL MAY be excluded.
 Example: `/structures?filter=nelements=2`""",
-    )
+        ),
+    ]
 
 
 class Provider(BaseModel):
     """Information on the database provider of the implementation."""
 
-    name: str = StrictField(..., description="a short name for the database provider")
+    name: Annotated[
+        str, StrictField(description="a short name for the database provider")
+    ]
 
-    description: str = StrictField(
-        ..., description="a longer description of the database provider"
-    )
+    description: Annotated[
+        str, StrictField(description="a longer description of the database provider")
+    ]
 
-    prefix: str = StrictField(
-        ...,
-        pattern=r"^[a-z]([a-z]|[0-9]|_)*$",
-        description="database-provider-specific prefix as found in section Database-Provider-Specific Namespace Prefixes.",
-    )
+    prefix: Annotated[
+        str,
+        StrictField(
+            pattern=r"^[a-z]([a-z]|[0-9]|_)*$",
+            description="database-provider-specific prefix as found in section Database-Provider-Specific Namespace Prefixes.",
+        ),
+    ]
 
-    homepage: Optional[Union[AnyHttpUrl, jsonapi.Link]] = StrictField(
-        None,
-        description="a [JSON API links object](http://jsonapi.org/format/1.0#document-links) "
-        "pointing to homepage of the database provider, either "
-        "directly as a string, or as a link object.",
-    )
+    homepage: Annotated[
+        Optional[jsonapi.JsonLinkType],
+        StrictField(
+            description="a [JSON API links object](http://jsonapi.org/format/1.0#document-links) "
+            "pointing to homepage of the database provider, either "
+            "directly as a string, or as a link object.",
+        ),
+    ] = None
 
 
 class ImplementationMaintainer(BaseModel):
     """Details about the maintainer of the implementation"""
 
-    email: EmailStr = StrictField(..., description="the maintainer's email address")
+    email: Annotated[
+        EmailStr, StrictField(description="the maintainer's email address")
+    ]
 
 
 class Implementation(BaseModel):
     """Information on the server implementation"""
 
-    name: Optional[str] = StrictField(None, description="name of the implementation")
+    name: Annotated[
+        Optional[str], StrictField(description="name of the implementation")
+    ] = None
 
-    version: Optional[str] = StrictField(
-        None, description="version string of the current implementation"
-    )
+    version: Annotated[
+        Optional[str],
+        StrictField(description="version string of the current implementation"),
+    ] = None
 
-    homepage: Optional[Union[AnyHttpUrl, jsonapi.Link]] = StrictField(
-        None,
-        description="A [JSON API links object](http://jsonapi.org/format/1.0/#document-links) pointing to the homepage of the implementation.",
-    )
+    homepage: Annotated[
+        Optional[jsonapi.JsonLinkType],
+        StrictField(
+            description="A [JSON API links object](http://jsonapi.org/format/1.0/#document-links) pointing to the homepage of the implementation.",
+        ),
+    ] = None
 
-    source_url: Optional[Union[AnyUrl, jsonapi.Link]] = StrictField(
-        None,
-        description="A [JSON API links object](http://jsonapi.org/format/1.0/#document-links) pointing to the implementation source, either downloadable archive or version control system.",
-    )
+    source_url: Annotated[
+        Optional[jsonapi.JsonLinkType],
+        StrictField(
+            description="A [JSON API links object](http://jsonapi.org/format/1.0/#document-links) pointing to the implementation source, either downloadable archive or version control system.",
+        ),
+    ] = None
 
-    maintainer: Optional[ImplementationMaintainer] = StrictField(
-        None,
-        description="A dictionary providing details about the maintainer of the implementation.",
-    )
+    maintainer: Annotated[
+        Optional[ImplementationMaintainer],
+        StrictField(
+            description="A dictionary providing details about the maintainer of the implementation.",
+        ),
+    ] = None
 
-    issue_tracker: Optional[Union[AnyUrl, jsonapi.Link]] = StrictField(
-        None,
-        description="A [JSON API links object](http://jsonapi.org/format/1.0/#document-links) pointing to the implementation's issue tracker.",
-    )
+    issue_tracker: Annotated[
+        Optional[jsonapi.JsonLinkType],
+        StrictField(
+            description="A [JSON API links object](http://jsonapi.org/format/1.0/#document-links) pointing to the implementation's issue tracker.",
+        ),
+    ] = None
 
 
 class ResponseMeta(jsonapi.Meta):
@@ -267,82 +286,103 @@ class ResponseMeta(jsonapi.Meta):
     database-provider-specific prefix.
     """
 
-    query: ResponseMetaQuery = StrictField(
-        ..., description="Information on the Query that was requested"
-    )
+    query: Annotated[
+        ResponseMetaQuery,
+        StrictField(description="Information on the Query that was requested"),
+    ]
 
-    api_version: SemanticVersion = StrictField(
-        ...,
-        description="""Presently used full version of the OPTIMADE API.
+    api_version: Annotated[
+        SemanticVersion,
+        StrictField(
+            description="""Presently used full version of the OPTIMADE API.
 The version number string MUST NOT be prefixed by, e.g., "v".
 Examples: `1.0.0`, `1.0.0-rc.2`.""",
-    )
+        ),
+    ]
 
-    more_data_available: bool = StrictField(
-        ...,
-        description="`false` if the response contains all data for the request (e.g., a request issued to a single entry endpoint, or a `filter` query at the last page of a paginated response) and `true` if the response is incomplete in the sense that multiple objects match the request, and not all of them have been included in the response (e.g., a query with multiple pages that is not at the last page).",
-    )
+    more_data_available: Annotated[
+        bool,
+        StrictField(
+            description="`false` if the response contains all data for the request (e.g., a request issued to a single entry endpoint, or a `filter` query at the last page of a paginated response) and `true` if the response is incomplete in the sense that multiple objects match the request, and not all of them have been included in the response (e.g., a query with multiple pages that is not at the last page).",
+        ),
+    ]
 
     # start of "SHOULD" fields for meta response
-    optimade_schema: Optional[Union[AnyHttpUrl, jsonapi.Link]] = StrictField(
-        None,
-        alias="schema",
-        description="""A [JSON API links object](http://jsonapi.org/format/1.0/#document-links) that points to a schema for the response.
+    optimade_schema: Annotated[
+        Optional[jsonapi.JsonLinkType],
+        StrictField(
+            alias="schema",
+            description="""A [JSON API links object](http://jsonapi.org/format/1.0/#document-links) that points to a schema for the response.
 If it is a string, or a dictionary containing no `meta` field, the provided URL MUST point at an [OpenAPI](https://swagger.io/specification/) schema.
 It is possible that future versions of this specification allows for alternative schema types.
 Hence, if the `meta` field of the JSON API links object is provided and contains a field `schema_type` that is not equal to the string `OpenAPI` the client MUST not handle failures to parse the schema or to validate the response against the schema as errors.""",
-    )
+        ),
+    ] = None
 
-    time_stamp: Optional[datetime] = StrictField(
-        None,
-        description="A timestamp containing the date and time at which the query was executed.",
-    )
+    time_stamp: Annotated[
+        Optional[datetime],
+        StrictField(
+            description="A timestamp containing the date and time at which the query was executed.",
+        ),
+    ] = None
 
-    data_returned: Optional[int] = StrictField(
-        None,
-        description="An integer containing the total number of data resource objects returned for the current `filter` query, independent of pagination.",
-        ge=0,
-    )
+    data_returned: Annotated[
+        Optional[int],
+        StrictField(
+            description="An integer containing the total number of data resource objects returned for the current `filter` query, independent of pagination.",
+            ge=0,
+        ),
+    ] = None
 
-    provider: Optional[Provider] = StrictField(
-        None, description="information on the database provider of the implementation."
-    )
+    provider: Annotated[
+        Optional[Provider],
+        StrictField(
+            description="information on the database provider of the implementation."
+        ),
+    ] = None
 
     # start of "MAY" fields for meta response
-    data_available: Optional[int] = StrictField(
-        None,
-        description="An integer containing the total number of data resource objects available in the database for the endpoint.",
-    )
+    data_available: Annotated[
+        Optional[int],
+        StrictField(
+            description="An integer containing the total number of data resource objects available in the database for the endpoint.",
+        ),
+    ] = None
 
-    last_id: Optional[str] = StrictField(
-        None, description="a string containing the last ID returned"
-    )
+    last_id: Annotated[
+        Optional[str],
+        StrictField(description="a string containing the last ID returned"),
+    ] = None
 
-    response_message: Optional[str] = StrictField(
-        None, description="response string from the server"
-    )
+    response_message: Annotated[
+        Optional[str], StrictField(description="response string from the server")
+    ] = None
 
-    implementation: Optional[Implementation] = StrictField(
-        None, description="a dictionary describing the server implementation"
-    )
+    implementation: Annotated[
+        Optional[Implementation],
+        StrictField(description="a dictionary describing the server implementation"),
+    ] = None
 
-    warnings: Optional[list[Warnings]] = StrictField(
-        None,
-        description="""A list of warning resource objects representing non-critical errors or warnings.
+    warnings: Annotated[
+        Optional[list[Warnings]],
+        StrictField(
+            description="""A list of warning resource objects representing non-critical errors or warnings.
 A warning resource object is defined similarly to a [JSON API error object](http://jsonapi.org/format/1.0/#error-objects), but MUST also include the field `type`, which MUST have the value `"warning"`.
 The field `detail` MUST be present and SHOULD contain a non-critical message, e.g., reporting unrecognized search attributes or deprecated features.
 The field `status`, representing a HTTP response status code, MUST NOT be present for a warning resource object.
 This is an exclusive field for error resource objects.""",
-        uniqueItems=True,
-    )
+            uniqueItems=True,
+        ),
+    ] = None
 
 
 class Success(jsonapi.Response):
     """errors are not allowed"""
 
-    meta: ResponseMeta = StrictField(
-        ..., description="A meta object containing non-standard information"
-    )
+    meta: Annotated[
+        ResponseMeta,
+        StrictField(description="A meta object containing non-standard information"),
+    ]
 
     @model_validator(mode="after")
     def either_data_meta_or_errors_must_be_set(self) -> "Success":
@@ -363,23 +403,29 @@ class Success(jsonapi.Response):
 class BaseRelationshipMeta(jsonapi.Meta):
     """Specific meta field for base relationship resource"""
 
-    description: str = StrictField(
-        ..., description="OPTIONAL human-readable description of the relationship."
-    )
+    description: Annotated[
+        str,
+        StrictField(
+            description="OPTIONAL human-readable description of the relationship."
+        ),
+    ]
 
 
 class BaseRelationshipResource(jsonapi.BaseResource):
     """Minimum requirements to represent a relationship resource"""
 
-    meta: Optional[BaseRelationshipMeta] = StrictField(
-        None,
-        description="Relationship meta field. MUST contain 'description' if supplied.",
-    )
+    meta: Annotated[
+        Optional[BaseRelationshipMeta],
+        StrictField(
+            description="Relationship meta field. MUST contain 'description' if supplied.",
+        ),
+    ] = None
 
 
 class Relationship(jsonapi.Relationship):
     """Similar to normal JSON API relationship, but with addition of OPTIONAL meta field for a resource."""
 
-    data: Optional[
-        Union[BaseRelationshipResource, list[BaseRelationshipResource]]
-    ] = StrictField(None, description="Resource linkage", uniqueItems=True)
+    data: Annotated[
+        Optional[Union[BaseRelationshipResource, list[BaseRelationshipResource]]],
+        StrictField(description="Resource linkage", uniqueItems=True),
+    ] = None

--- a/optimade/models/references.py
+++ b/optimade/models/references.py
@@ -1,5 +1,5 @@
 # pylint: disable=line-too-long,no-self-argument
-from typing import Optional
+from typing import Any, Optional
 
 from pydantic import AnyUrl, BaseModel, field_validator
 
@@ -262,9 +262,14 @@ class ReferenceResource(EntryResource):
     )
     attributes: ReferenceResourceAttributes
 
-    @field_validator("attributes")
+    @field_validator("attributes", mode="before")
     @classmethod
-    def validate_attributes(cls, v):
-        if not any(prop[1] is not None for prop in v):
+    def validate_attributes(cls, value: Any, _) -> dict:
+        if not isinstance(value, dict):
+            if isinstance(value, BaseModel):
+                value = value.model_dump()
+            else:
+                raise TypeError("attributes field must be a mapping")
+        if not any(prop[1] is not None for prop in value):
             raise ValueError("reference object must have at least one field defined")
-        return v
+        return value

--- a/optimade/models/references.py
+++ b/optimade/models/references.py
@@ -1,8 +1,9 @@
 # pylint: disable=line-too-long,no-self-argument
 from typing import Optional
 
-from pydantic import AnyUrl, BaseModel, validator  # pylint: disable=no-name-in-module
+from pydantic import AnyUrl, BaseModel, field_validator
 
+# pylint: disable=no-name-in-module
 from optimade.models.entries import EntryResource, EntryResourceAttributes
 from optimade.models.utils import OptimadeField, SupportLevel
 
@@ -255,13 +256,14 @@ class ReferenceResource(EntryResource):
     - MUST be an existing entry type.
     - The entry of type <type> and ID <id> MUST be returned in response to a request for `/<type>/<id>` under the versioned base URL.
 - **Example**: `"structures"`""",
-        regex="^references$",
+        pattern="^references$",
         support=SupportLevel.MUST,
         queryable=SupportLevel.MUST,
     )
     attributes: ReferenceResourceAttributes
 
-    @validator("attributes")
+    @field_validator("attributes")
+    @classmethod
     def validate_attributes(cls, v):
         if not any(prop[1] is not None for prop in v):
             raise ValueError("reference object must have at least one field defined")

--- a/optimade/models/references.py
+++ b/optimade/models/references.py
@@ -1,9 +1,7 @@
-# pylint: disable=line-too-long,no-self-argument
-from typing import Any, Optional
+from typing import Annotated, Any, Literal, Optional
 
 from pydantic import AnyUrl, BaseModel, field_validator
 
-# pylint: disable=no-name-in-module
 from optimade.models.entries import EntryResource, EntryResourceAttributes
 from optimade.models.utils import OptimadeField, SupportLevel
 
@@ -13,26 +11,32 @@ __all__ = ("Person", "ReferenceResourceAttributes", "ReferenceResource")
 class Person(BaseModel):
     """A person, i.e., an author, editor or other."""
 
-    name: str = OptimadeField(
-        ...,
-        description="""Full name of the person, REQUIRED.""",
-        support=SupportLevel.MUST,
-        queryable=SupportLevel.OPTIONAL,
-    )
+    name: Annotated[
+        str,
+        OptimadeField(
+            description="""Full name of the person, REQUIRED.""",
+            support=SupportLevel.MUST,
+            queryable=SupportLevel.OPTIONAL,
+        ),
+    ]
 
-    firstname: Optional[str] = OptimadeField(
-        None,
-        description="""First name of the person.""",
-        support=SupportLevel.OPTIONAL,
-        queryable=SupportLevel.OPTIONAL,
-    )
+    firstname: Annotated[
+        Optional[str],
+        OptimadeField(
+            description="""First name of the person.""",
+            support=SupportLevel.OPTIONAL,
+            queryable=SupportLevel.OPTIONAL,
+        ),
+    ] = None
 
-    lastname: Optional[str] = OptimadeField(
-        None,
-        description="""Last name of the person.""",
-        support=SupportLevel.OPTIONAL,
-        queryable=SupportLevel.OPTIONAL,
-    )
+    lastname: Annotated[
+        Optional[str],
+        OptimadeField(
+            description="""Last name of the person.""",
+            support=SupportLevel.OPTIONAL,
+            queryable=SupportLevel.OPTIONAL,
+        ),
+    ] = None
 
 
 class ReferenceResourceAttributes(EntryResourceAttributes):
@@ -43,187 +47,239 @@ class ReferenceResourceAttributes(EntryResourceAttributes):
 
     """
 
-    authors: Optional[list[Person]] = OptimadeField(
-        None,
-        description="List of person objects containing the authors of the reference.",
-        support=SupportLevel.OPTIONAL,
-        queryable=SupportLevel.OPTIONAL,
-    )
+    authors: Annotated[
+        Optional[list[Person]],
+        OptimadeField(
+            description="List of person objects containing the authors of the reference.",
+            support=SupportLevel.OPTIONAL,
+            queryable=SupportLevel.OPTIONAL,
+        ),
+    ] = None
 
-    editors: Optional[list[Person]] = OptimadeField(
-        None,
-        description="List of person objects containing the editors of the reference.",
-        support=SupportLevel.OPTIONAL,
-        queryable=SupportLevel.OPTIONAL,
-    )
+    editors: Annotated[
+        Optional[list[Person]],
+        OptimadeField(
+            description="List of person objects containing the editors of the reference.",
+            support=SupportLevel.OPTIONAL,
+            queryable=SupportLevel.OPTIONAL,
+        ),
+    ] = None
 
-    doi: Optional[str] = OptimadeField(
-        None,
-        description="The digital object identifier of the reference.",
-        support=SupportLevel.OPTIONAL,
-        queryable=SupportLevel.OPTIONAL,
-    )
+    doi: Annotated[
+        Optional[str],
+        OptimadeField(
+            description="The digital object identifier of the reference.",
+            support=SupportLevel.OPTIONAL,
+            queryable=SupportLevel.OPTIONAL,
+        ),
+    ] = None
 
-    url: Optional[AnyUrl] = OptimadeField(
-        None,
-        description="The URL of the reference.",
-        support=SupportLevel.OPTIONAL,
-        queryable=SupportLevel.OPTIONAL,
-    )
+    url: Annotated[
+        Optional[AnyUrl],
+        OptimadeField(
+            description="The URL of the reference.",
+            support=SupportLevel.OPTIONAL,
+            queryable=SupportLevel.OPTIONAL,
+        ),
+    ] = None
 
-    address: Optional[str] = OptimadeField(
-        None,
-        description="Meaning of property matches the BiBTeX specification.",
-        support=SupportLevel.OPTIONAL,
-        queryable=SupportLevel.OPTIONAL,
-    )
+    address: Annotated[
+        Optional[str],
+        OptimadeField(
+            description="Meaning of property matches the BiBTeX specification.",
+            support=SupportLevel.OPTIONAL,
+            queryable=SupportLevel.OPTIONAL,
+        ),
+    ] = None
 
-    annote: Optional[str] = OptimadeField(
-        None,
-        description="Meaning of property matches the BiBTeX specification.",
-        support=SupportLevel.OPTIONAL,
-        queryable=SupportLevel.OPTIONAL,
-    )
+    annote: Annotated[
+        Optional[str],
+        OptimadeField(
+            description="Meaning of property matches the BiBTeX specification.",
+            support=SupportLevel.OPTIONAL,
+            queryable=SupportLevel.OPTIONAL,
+        ),
+    ] = None
 
-    booktitle: Optional[str] = OptimadeField(
-        None,
-        description="Meaning of property matches the BiBTeX specification.",
-        support=SupportLevel.OPTIONAL,
-        queryable=SupportLevel.OPTIONAL,
-    )
+    booktitle: Annotated[
+        Optional[str],
+        OptimadeField(
+            description="Meaning of property matches the BiBTeX specification.",
+            support=SupportLevel.OPTIONAL,
+            queryable=SupportLevel.OPTIONAL,
+        ),
+    ] = None
 
-    chapter: Optional[str] = OptimadeField(
-        None,
-        description="Meaning of property matches the BiBTeX specification.",
-        support=SupportLevel.OPTIONAL,
-        queryable=SupportLevel.OPTIONAL,
-    )
+    chapter: Annotated[
+        Optional[str],
+        OptimadeField(
+            description="Meaning of property matches the BiBTeX specification.",
+            support=SupportLevel.OPTIONAL,
+            queryable=SupportLevel.OPTIONAL,
+        ),
+    ] = None
 
-    crossref: Optional[str] = OptimadeField(
-        None,
-        description="Meaning of property matches the BiBTeX specification.",
-        support=SupportLevel.OPTIONAL,
-        queryable=SupportLevel.OPTIONAL,
-    )
+    crossref: Annotated[
+        Optional[str],
+        OptimadeField(
+            description="Meaning of property matches the BiBTeX specification.",
+            support=SupportLevel.OPTIONAL,
+            queryable=SupportLevel.OPTIONAL,
+        ),
+    ] = None
 
-    edition: Optional[str] = OptimadeField(
-        None,
-        description="Meaning of property matches the BiBTeX specification.",
-        support=SupportLevel.OPTIONAL,
-        queryable=SupportLevel.OPTIONAL,
-    )
+    edition: Annotated[
+        Optional[str],
+        OptimadeField(
+            description="Meaning of property matches the BiBTeX specification.",
+            support=SupportLevel.OPTIONAL,
+            queryable=SupportLevel.OPTIONAL,
+        ),
+    ] = None
 
-    howpublished: Optional[str] = OptimadeField(
-        None,
-        description="Meaning of property matches the BiBTeX specification.",
-        support=SupportLevel.OPTIONAL,
-        queryable=SupportLevel.OPTIONAL,
-    )
+    howpublished: Annotated[
+        Optional[str],
+        OptimadeField(
+            description="Meaning of property matches the BiBTeX specification.",
+            support=SupportLevel.OPTIONAL,
+            queryable=SupportLevel.OPTIONAL,
+        ),
+    ] = None
 
-    institution: Optional[str] = OptimadeField(
-        None,
-        description="Meaning of property matches the BiBTeX specification.",
-        support=SupportLevel.OPTIONAL,
-        queryable=SupportLevel.OPTIONAL,
-    )
+    institution: Annotated[
+        Optional[str],
+        OptimadeField(
+            description="Meaning of property matches the BiBTeX specification.",
+            support=SupportLevel.OPTIONAL,
+            queryable=SupportLevel.OPTIONAL,
+        ),
+    ] = None
 
-    journal: Optional[str] = OptimadeField(
-        None,
-        description="Meaning of property matches the BiBTeX specification.",
-        support=SupportLevel.OPTIONAL,
-        queryable=SupportLevel.OPTIONAL,
-    )
+    journal: Annotated[
+        Optional[str],
+        OptimadeField(
+            description="Meaning of property matches the BiBTeX specification.",
+            support=SupportLevel.OPTIONAL,
+            queryable=SupportLevel.OPTIONAL,
+        ),
+    ] = None
 
-    key: Optional[str] = OptimadeField(
-        None,
-        description="Meaning of property matches the BiBTeX specification.",
-        support=SupportLevel.OPTIONAL,
-        queryable=SupportLevel.OPTIONAL,
-    )
+    key: Annotated[
+        Optional[str],
+        OptimadeField(
+            description="Meaning of property matches the BiBTeX specification.",
+            support=SupportLevel.OPTIONAL,
+            queryable=SupportLevel.OPTIONAL,
+        ),
+    ] = None
 
-    month: Optional[str] = OptimadeField(
-        None,
-        description="Meaning of property matches the BiBTeX specification.",
-        support=SupportLevel.OPTIONAL,
-        queryable=SupportLevel.OPTIONAL,
-    )
+    month: Annotated[
+        Optional[str],
+        OptimadeField(
+            description="Meaning of property matches the BiBTeX specification.",
+            support=SupportLevel.OPTIONAL,
+            queryable=SupportLevel.OPTIONAL,
+        ),
+    ] = None
 
-    note: Optional[str] = OptimadeField(
-        None,
-        description="Meaning of property matches the BiBTeX specification.",
-        support=SupportLevel.OPTIONAL,
-        queryable=SupportLevel.OPTIONAL,
-    )
+    note: Annotated[
+        Optional[str],
+        OptimadeField(
+            description="Meaning of property matches the BiBTeX specification.",
+            support=SupportLevel.OPTIONAL,
+            queryable=SupportLevel.OPTIONAL,
+        ),
+    ] = None
 
-    number: Optional[str] = OptimadeField(
-        None,
-        description="Meaning of property matches the BiBTeX specification.",
-        support=SupportLevel.OPTIONAL,
-        queryable=SupportLevel.OPTIONAL,
-    )
+    number: Annotated[
+        Optional[str],
+        OptimadeField(
+            description="Meaning of property matches the BiBTeX specification.",
+            support=SupportLevel.OPTIONAL,
+            queryable=SupportLevel.OPTIONAL,
+        ),
+    ] = None
 
-    organization: Optional[str] = OptimadeField(
-        None,
-        description="Meaning of property matches the BiBTeX specification.",
-        support=SupportLevel.OPTIONAL,
-        queryable=SupportLevel.OPTIONAL,
-    )
+    organization: Annotated[
+        Optional[str],
+        OptimadeField(
+            description="Meaning of property matches the BiBTeX specification.",
+            support=SupportLevel.OPTIONAL,
+            queryable=SupportLevel.OPTIONAL,
+        ),
+    ] = None
 
-    pages: Optional[str] = OptimadeField(
-        None,
-        description="Meaning of property matches the BiBTeX specification.",
-        support=SupportLevel.OPTIONAL,
-        queryable=SupportLevel.OPTIONAL,
-    )
+    pages: Annotated[
+        Optional[str],
+        OptimadeField(
+            description="Meaning of property matches the BiBTeX specification.",
+            support=SupportLevel.OPTIONAL,
+            queryable=SupportLevel.OPTIONAL,
+        ),
+    ] = None
 
-    publisher: Optional[str] = OptimadeField(
-        None,
-        description="Meaning of property matches the BiBTeX specification.",
-        support=SupportLevel.OPTIONAL,
-        queryable=SupportLevel.OPTIONAL,
-    )
+    publisher: Annotated[
+        Optional[str],
+        OptimadeField(
+            description="Meaning of property matches the BiBTeX specification.",
+            support=SupportLevel.OPTIONAL,
+            queryable=SupportLevel.OPTIONAL,
+        ),
+    ] = None
 
-    school: Optional[str] = OptimadeField(
-        None,
-        description="Meaning of property matches the BiBTeX specification.",
-        support=SupportLevel.OPTIONAL,
-        queryable=SupportLevel.OPTIONAL,
-    )
+    school: Annotated[
+        Optional[str],
+        OptimadeField(
+            description="Meaning of property matches the BiBTeX specification.",
+            support=SupportLevel.OPTIONAL,
+            queryable=SupportLevel.OPTIONAL,
+        ),
+    ] = None
 
-    series: Optional[str] = OptimadeField(
-        None,
-        description="Meaning of property matches the BiBTeX specification.",
-        support=SupportLevel.OPTIONAL,
-        queryable=SupportLevel.OPTIONAL,
-    )
+    series: Annotated[
+        Optional[str],
+        OptimadeField(
+            description="Meaning of property matches the BiBTeX specification.",
+            support=SupportLevel.OPTIONAL,
+            queryable=SupportLevel.OPTIONAL,
+        ),
+    ] = None
 
-    title: Optional[str] = OptimadeField(
-        None,
-        description="Meaning of property matches the BiBTeX specification.",
-        support=SupportLevel.OPTIONAL,
-        queryable=SupportLevel.OPTIONAL,
-    )
+    title: Annotated[
+        Optional[str],
+        OptimadeField(
+            description="Meaning of property matches the BiBTeX specification.",
+            support=SupportLevel.OPTIONAL,
+            queryable=SupportLevel.OPTIONAL,
+        ),
+    ] = None
 
-    bib_type: Optional[str] = OptimadeField(
-        None,
-        description="Type of the reference, corresponding to the **type** property in the BiBTeX specification.",
-        support=SupportLevel.OPTIONAL,
-        queryable=SupportLevel.OPTIONAL,
-    )
+    bib_type: Annotated[
+        Optional[str],
+        OptimadeField(
+            description="Type of the reference, corresponding to the **type** property in the BiBTeX specification.",
+            support=SupportLevel.OPTIONAL,
+            queryable=SupportLevel.OPTIONAL,
+        ),
+    ] = None
 
-    volume: Optional[str] = OptimadeField(
-        None,
-        description="Meaning of property matches the BiBTeX specification.",
-        support=SupportLevel.OPTIONAL,
-        queryable=SupportLevel.OPTIONAL,
-    )
+    volume: Annotated[
+        Optional[str],
+        OptimadeField(
+            description="Meaning of property matches the BiBTeX specification.",
+            support=SupportLevel.OPTIONAL,
+            queryable=SupportLevel.OPTIONAL,
+        ),
+    ] = None
 
-    year: Optional[str] = OptimadeField(
-        None,
-        description="Meaning of property matches the BiBTeX specification.",
-        support=SupportLevel.OPTIONAL,
-        queryable=SupportLevel.OPTIONAL,
-    )
+    year: Annotated[
+        Optional[str],
+        OptimadeField(
+            description="Meaning of property matches the BiBTeX specification.",
+            support=SupportLevel.OPTIONAL,
+            queryable=SupportLevel.OPTIONAL,
+        ),
+    ] = None
 
 
 class ReferenceResource(EntryResource):
@@ -245,9 +301,10 @@ class ReferenceResource(EntryResource):
 
     """
 
-    type: str = OptimadeField(
-        "references",
-        description="""The name of the type of an entry.
+    type: Annotated[
+        Literal["references"],
+        OptimadeField(
+            description="""The name of the type of an entry.
 - **Type**: string.
 - **Requirements/Conventions**:
     - **Support**: MUST be supported by all implementations, MUST NOT be `null`.
@@ -256,15 +313,16 @@ class ReferenceResource(EntryResource):
     - MUST be an existing entry type.
     - The entry of type <type> and ID <id> MUST be returned in response to a request for `/<type>/<id>` under the versioned base URL.
 - **Example**: `"structures"`""",
-        pattern="^references$",
-        support=SupportLevel.MUST,
-        queryable=SupportLevel.MUST,
-    )
+            pattern="^references$",
+            support=SupportLevel.MUST,
+            queryable=SupportLevel.MUST,
+        ),
+    ] = "references"
     attributes: ReferenceResourceAttributes
 
     @field_validator("attributes", mode="before")
     @classmethod
-    def validate_attributes(cls, value: Any, _) -> dict:
+    def validate_attributes(cls, value: Any) -> dict[str, Any]:
         if not isinstance(value, dict):
             if isinstance(value, BaseModel):
                 value = value.model_dump()

--- a/optimade/models/responses.py
+++ b/optimade/models/responses.py
@@ -40,12 +40,11 @@ class ErrorResponse(Response):
         uniqueItems=True,
     )
 
-    @model_validator(mode="before")
-    @classmethod
-    def data_must_be_skipped(cls, values):
-        if "data" in values:
+    @model_validator(mode="after")
+    def data_must_be_skipped(self) -> "ErrorResponse":
+        if hasattr(self, "data"):
             raise ValueError("data MUST be skipped for failures reporting errors.")
-        return values
+        return self
 
 
 class IndexInfoResponse(Success):

--- a/optimade/models/responses.py
+++ b/optimade/models/responses.py
@@ -1,7 +1,7 @@
 # pylint: disable=no-self-argument
 from typing import Any, Optional, Union
 
-from pydantic import Field, model_validator
+from pydantic import model_validator
 
 from optimade.models.baseinfo import BaseInfoResource
 from optimade.models.entries import EntryInfoResource, EntryResource
@@ -66,18 +66,24 @@ class InfoResponse(Success):
 
 
 class EntryResponseOne(Success):
-    data: Union[EntryResource, dict[str, Any], None] = Field(None)  # type: ignore[assignment]
-    included: Optional[Union[list[EntryResource], list[dict[str, Any]]]] = Field(  # type: ignore[assignment]
-        None, uniqueItems=True
+    data: Union[EntryResource, dict[str, Any], None] = None  # type: ignore[assignment]
+    included: Optional[Union[list[EntryResource], list[dict[str, Any]]]] = StrictField(  # type: ignore[assignment]
+        None,
+        description="A list of unique included OPTIMADE entry resources.",
+        uniqueItems=True,
     )
 
 
 class EntryResponseMany(Success):
-    data: Union[list[EntryResource], list[dict[str, Any]]] = Field(  # type: ignore[assignment]
-        ..., uniqueItems=True
+    data: Union[list[EntryResource], list[dict[str, Any]]] = StrictField(  # type: ignore[assignment]
+        ...,
+        description="List of unique OPTIMADE entry resource objects.",
+        uniqueItems=True,
     )
-    included: Optional[Union[list[EntryResource], list[dict[str, Any]]]] = Field(  # type: ignore[assignment]
-        None, uniqueItems=True
+    included: Optional[Union[list[EntryResource], list[dict[str, Any]]]] = StrictField(  # type: ignore[assignment]
+        None,
+        description="A list of unique included OPTIMADE entry resources.",
+        uniqueItems=True,
     )
 
 

--- a/optimade/models/responses.py
+++ b/optimade/models/responses.py
@@ -42,7 +42,7 @@ class ErrorResponse(Response):
 
     @model_validator(mode="after")
     def data_must_be_skipped(self) -> "ErrorResponse":
-        if hasattr(self, "data"):
+        if self.data or "data" in self.model_fields_set:
             raise ValueError("data MUST be skipped for failures reporting errors.")
         return self
 

--- a/optimade/models/responses.py
+++ b/optimade/models/responses.py
@@ -1,7 +1,7 @@
 # pylint: disable=no-self-argument
 from typing import Any, Optional, Union
 
-from pydantic import Field, root_validator
+from pydantic import Field, model_validator
 
 from optimade.models.baseinfo import BaseInfoResource
 from optimade.models.entries import EntryInfoResource, EntryResource
@@ -40,7 +40,8 @@ class ErrorResponse(Response):
         uniqueItems=True,
     )
 
-    @root_validator(pre=True)
+    @model_validator(mode="before")
+    @classmethod
     def data_must_be_skipped(cls, values):
         if "data" in values:
             raise ValueError("data MUST be skipped for failures reporting errors.")
@@ -66,7 +67,7 @@ class InfoResponse(Success):
 
 
 class EntryResponseOne(Success):
-    data: Union[EntryResource, dict[str, Any], None] = Field(...)  # type: ignore[assignment]
+    data: Union[EntryResource, dict[str, Any], None] = Field(None)  # type: ignore[assignment]
     included: Optional[Union[list[EntryResource], list[dict[str, Any]]]] = Field(  # type: ignore[assignment]
         None, uniqueItems=True
     )

--- a/optimade/models/responses.py
+++ b/optimade/models/responses.py
@@ -1,5 +1,5 @@
 # pylint: disable=no-self-argument
-from typing import Any, Optional, Union
+from typing import Annotated, Any, Optional, Union
 
 from pydantic import model_validator
 
@@ -31,14 +31,17 @@ __all__ = (
 class ErrorResponse(Response):
     """errors MUST be present and data MUST be skipped"""
 
-    meta: ResponseMeta = StrictField(
-        ..., description="A meta object containing non-standard information."
-    )
-    errors: list[OptimadeError] = StrictField(
-        ...,
-        description="A list of OPTIMADE-specific JSON API error objects, where the field detail MUST be present.",
-        uniqueItems=True,
-    )
+    meta: Annotated[
+        ResponseMeta,
+        StrictField(description="A meta object containing non-standard information."),
+    ]
+    errors: Annotated[
+        list[OptimadeError],
+        StrictField(
+            description="A list of OPTIMADE-specific JSON API error objects, where the field detail MUST be present.",
+            uniqueItems=True,
+        ),
+    ]
 
     @model_validator(mode="after")
     def data_must_be_skipped(self) -> "ErrorResponse":
@@ -48,76 +51,91 @@ class ErrorResponse(Response):
 
 
 class IndexInfoResponse(Success):
-    data: IndexInfoResource = StrictField(
-        ..., description="Index meta-database /info data."
-    )
+    data: Annotated[
+        IndexInfoResource, StrictField(description="Index meta-database /info data.")
+    ]
 
 
 class EntryInfoResponse(Success):
-    data: EntryInfoResource = StrictField(
-        ..., description="OPTIMADE information for an entry endpoint."
-    )
+    data: Annotated[
+        EntryInfoResource,
+        StrictField(description="OPTIMADE information for an entry endpoint."),
+    ]
 
 
 class InfoResponse(Success):
-    data: BaseInfoResource = StrictField(
-        ..., description="The implementations /info data."
-    )
+    data: Annotated[
+        BaseInfoResource, StrictField(description="The implementations /info data.")
+    ]
 
 
 class EntryResponseOne(Success):
-    data: Union[EntryResource, dict[str, Any], None] = None  # type: ignore[assignment]
-    included: Optional[Union[list[EntryResource], list[dict[str, Any]]]] = StrictField(  # type: ignore[assignment]
-        None,
-        description="A list of unique included OPTIMADE entry resources.",
-        uniqueItems=True,
-    )
+    data: Optional[Union[EntryResource, dict[str, Any]]] = None  # type: ignore[assignment]
+    included: Annotated[
+        Optional[Union[list[EntryResource], list[dict[str, Any]]]],
+        StrictField(
+            description="A list of unique included OPTIMADE entry resources.",
+            uniqueItems=True,
+        ),
+    ] = None  # type: ignore[assignment]
 
 
 class EntryResponseMany(Success):
-    data: Union[list[EntryResource], list[dict[str, Any]]] = StrictField(  # type: ignore[assignment]
-        ...,
-        description="List of unique OPTIMADE entry resource objects.",
-        uniqueItems=True,
-    )
-    included: Optional[Union[list[EntryResource], list[dict[str, Any]]]] = StrictField(  # type: ignore[assignment]
-        None,
-        description="A list of unique included OPTIMADE entry resources.",
-        uniqueItems=True,
-    )
+    data: Annotated[  # type: ignore[assignment]
+        Union[list[EntryResource], list[dict[str, Any]]],
+        StrictField(
+            description="List of unique OPTIMADE entry resource objects.",
+            uniqueItems=True,
+        ),
+    ]
+    included: Annotated[
+        Optional[Union[list[EntryResource], list[dict[str, Any]]]],
+        StrictField(
+            description="A list of unique included OPTIMADE entry resources.",
+            uniqueItems=True,
+        ),
+    ] = None  # type: ignore[assignment]
 
 
 class LinksResponse(EntryResponseMany):
-    data: Union[list[LinksResource], list[dict[str, Any]]] = StrictField(
-        ...,
-        description="List of unique OPTIMADE links resource objects.",
-        uniqueItems=True,
-    )
+    data: Annotated[
+        Union[list[LinksResource], list[dict[str, Any]]],
+        StrictField(
+            description="List of unique OPTIMADE links resource objects.",
+            uniqueItems=True,
+        ),
+    ]
 
 
 class StructureResponseOne(EntryResponseOne):
-    data: Union[StructureResource, dict[str, Any], None] = StrictField(
-        ..., description="A single structures entry resource."
-    )
+    data: Annotated[
+        Optional[Union[StructureResource, dict[str, Any]]],
+        StrictField(description="A single structures entry resource."),
+    ]
 
 
 class StructureResponseMany(EntryResponseMany):
-    data: Union[list[StructureResource], list[dict[str, Any]]] = StrictField(
-        ...,
-        description="List of unique OPTIMADE structures entry resource objects.",
-        uniqueItems=True,
-    )
+    data: Annotated[
+        Union[list[StructureResource], list[dict[str, Any]]],
+        StrictField(
+            description="List of unique OPTIMADE structures entry resource objects.",
+            uniqueItems=True,
+        ),
+    ]
 
 
 class ReferenceResponseOne(EntryResponseOne):
-    data: Union[ReferenceResource, dict[str, Any], None] = StrictField(
-        ..., description="A single references entry resource."
-    )
+    data: Annotated[
+        Optional[Union[ReferenceResource, dict[str, Any]]],
+        StrictField(description="A single references entry resource."),
+    ]
 
 
 class ReferenceResponseMany(EntryResponseMany):
-    data: Union[list[ReferenceResource], list[dict[str, Any]]] = StrictField(
-        ...,
-        description="List of unique OPTIMADE references entry resource objects.",
-        uniqueItems=True,
-    )
+    data: Annotated[
+        Union[list[ReferenceResource], list[dict[str, Any]]],
+        StrictField(
+            description="List of unique OPTIMADE references entry resource objects.",
+            uniqueItems=True,
+        ),
+    ]

--- a/optimade/models/structures.py
+++ b/optimade/models/structures.py
@@ -2,12 +2,11 @@
 import re
 import warnings
 from enum import Enum, IntEnum
-from typing import Annotated, Any, Optional, Union
+from typing import Annotated, Optional, Union
 
 from pydantic import (
     BaseModel,
     BeforeValidator,
-    ConfigDict,
     Field,
     ValidationInfo,
     field_validator,
@@ -272,37 +271,8 @@ CORRELATED_STRUCTURE_FIELDS = (
 )
 
 
-def structure_json_schema_extra(
-    schema: dict[str, Any], model: type["StructureResourceAttributes"]
-) -> None:
-    """Two things need to be added to the schema:
-
-    1. Constrained types in pydantic do not currently play nicely with
-    "Required Optional" fields, i.e. fields must be specified but can be null.
-    The two constrained list fields, `dimension_types` and `lattice_vectors`,
-    are OPTIMADE 'SHOULD' fields, which means that they are allowed to be null.
-
-    2. All OPTIMADE 'SHOULD' fields are allowed to be null, so we manually set them
-    to be `nullable` according to the OpenAPI definition.
-
-    """
-    schema["required"].insert(7, "dimension_types")
-    schema["required"].insert(9, "lattice_vectors")
-
-    nullable_props = (
-        prop
-        for prop in schema["required"]
-        if schema["properties"][prop].get("x-optimade-support")
-        == SupportLevel.SHOULD.value
-    )
-    for prop in nullable_props:
-        schema["properties"][prop]["nullable"] = True
-
-
 class StructureResourceAttributes(EntryResourceAttributes):
     """This class contains the Field for the attributes used to represent a structure, e.g. unit cell, atoms, positions."""
-
-    model_config = ConfigDict(json_schema_extra=structure_json_schema_extra)
 
     elements: Optional[list[str]] = OptimadeField(
         None,

--- a/optimade/models/structures.py
+++ b/optimade/models/structures.py
@@ -174,7 +174,7 @@ Note: With regards to "source database", we refer to the immediate source being 
     @classmethod
     def validate_minimum_list_length(
         cls, value: Optional[Union[list[str], list[int]]]
-    ) -> Optional[list[Union[str, int]]]:
+    ) -> Optional[Union[list[str], list[int]]]:
         if value is not None and len(value) < 1:
             raise ValueError(
                 "The list's length MUST be 1 or more, instead it was found to be "
@@ -994,8 +994,8 @@ The properties of the species are found in the property `species`.
             return value
 
         if info.data.get("dimension_types"):
-            dimension_types: Optional[
-                Annotated[list[Periodicity], Field(min_length=3, max_length=3)]
+            dimension_types: Annotated[
+                list[Periodicity], Field(min_length=3, max_length=3)
             ] = info.data["dimension_types"]
 
             for dim_type, vector in zip(dimension_types, value):

--- a/optimade/models/structures.py
+++ b/optimade/models/structures.py
@@ -279,7 +279,7 @@ def structure_json_schema_extra(
 
     1. Constrained types in pydantic do not currently play nicely with
     "Required Optional" fields, i.e. fields must be specified but can be null.
-    The two contrained list fields, `dimension_types` and `lattice_vectors`,
+    The two constrained list fields, `dimension_types` and `lattice_vectors`,
     are OPTIMADE 'SHOULD' fields, which means that they are allowed to be null.
 
     2. All OPTIMADE 'SHOULD' fields are allowed to be null, so we manually set them
@@ -292,7 +292,8 @@ def structure_json_schema_extra(
     nullable_props = (
         prop
         for prop in schema["required"]
-        if schema["properties"][prop].get("x-optimade-support") == SupportLevel.SHOULD
+        if schema["properties"][prop].get("x-optimade-support")
+        == SupportLevel.SHOULD.value
     )
     for prop in nullable_props:
         schema["properties"][prop]["nullable"] = True
@@ -487,7 +488,7 @@ The proportion number MUST be omitted if it is 1.
         pattern=CHEMICAL_FORMULA_REGEXP,
     )
 
-    dimension_types: Optional[  # type: ignore[valid-type]
+    dimension_types: Optional[
         Annotated[list[Periodicity], Field(min_length=3, max_length=3)]
     ] = OptimadeField(
         None,
@@ -535,7 +536,7 @@ Note: the elements in this list each refer to the direction of the corresponding
         queryable=SupportLevel.MUST,
     )
 
-    lattice_vectors: Optional[  # type: ignore[valid-type]
+    lattice_vectors: Optional[
         Annotated[list[Vector3D_unknown], Field(min_length=3, max_length=3)]
     ] = OptimadeField(
         None,
@@ -563,7 +564,7 @@ Note: the elements in this list each refer to the direction of the corresponding
         queryable=SupportLevel.OPTIONAL,
     )
 
-    cartesian_site_positions: Optional[list[Vector3D]] = OptimadeField(  # type: ignore[valid-type]
+    cartesian_site_positions: Optional[list[Vector3D]] = OptimadeField(
         None,
         description="""Cartesian positions of each site in the structure.
 A site is usually used to describe positions of atoms; what atoms can be encountered at a given site is conveyed by the `species_at_sites` property, and the species themselves are described in the `species` property.

--- a/optimade/models/structures.py
+++ b/optimade/models/structures.py
@@ -1013,7 +1013,7 @@ The properties of the species are found in the property `species`.
             return value
 
         for vector in value:
-            if None in vector and any((isinstance(_, float) for _ in vector)):
+            if None in vector and any(isinstance(_, float) for _ in vector):
                 raise ValueError(
                     "A lattice vector MUST be either all `null` or all numbers "
                     f"(vector: {vector}, all vectors: {value})"
@@ -1080,7 +1080,7 @@ The properties of the species are found in the property `species`.
     def validate_structure_features(self) -> "StructureResourceAttributes":
         if [
             StructureFeatures(value)
-            for value in sorted((_.value for _ in self.structure_features))
+            for value in sorted(_.value for _ in self.structure_features)
         ] != self.structure_features:
             raise ValueError(
                 "structure_features MUST be sorted alphabetically, structure_features: "

--- a/optimade/models/structures.py
+++ b/optimade/models/structures.py
@@ -1,17 +1,9 @@
-# pylint: disable=no-self-argument,line-too-long,no-name-in-module
 import re
 import warnings
 from enum import Enum, IntEnum
-from typing import Annotated, Optional, Union
+from typing import TYPE_CHECKING, Annotated, Literal, Optional, Union
 
-from pydantic import (
-    BaseModel,
-    BeforeValidator,
-    Field,
-    ValidationInfo,
-    field_validator,
-    model_validator,
-)
+from pydantic import BaseModel, BeforeValidator, Field, field_validator, model_validator
 
 from optimade.models.entries import EntryResource, EntryResourceAttributes
 from optimade.models.types import ChemicalSymbol
@@ -25,6 +17,9 @@ from optimade.models.utils import (
     reduce_formula,
 )
 from optimade.warnings import MissingExpectedField
+
+if TYPE_CHECKING:  # pragma: no cover
+    from pydantic import ValidationInfo
 
 __all__ = (
     "Vector3D",
@@ -45,7 +40,7 @@ Vector3D = Annotated[
     list[Annotated[float, BeforeValidator(float)]], Field(min_length=3, max_length=3)
 ]
 Vector3D_unknown = Annotated[
-    list[Union[None, Annotated[float, BeforeValidator(float)]]],
+    list[Optional[Annotated[float, BeforeValidator(float)]]],
     Field(min_length=3, max_length=3),
 ]
 
@@ -86,73 +81,87 @@ class Species(BaseModel):
 
     """
 
-    name: str = OptimadeField(
-        ...,
-        description="""Gives the name of the species; the **name** value MUST be unique in the `species` list.""",
-        support=SupportLevel.MUST,
-        queryable=SupportLevel.OPTIONAL,
-    )
+    name: Annotated[
+        str,
+        OptimadeField(
+            description="""Gives the name of the species; the **name** value MUST be unique in the `species` list.""",
+            support=SupportLevel.MUST,
+            queryable=SupportLevel.OPTIONAL,
+        ),
+    ]
 
-    chemical_symbols: list[ChemicalSymbol] = OptimadeField(
-        ...,
-        description="""MUST be a list of strings of all chemical elements composing this species. Each item of the list MUST be one of the following:
+    chemical_symbols: Annotated[
+        list[ChemicalSymbol],
+        OptimadeField(
+            description="""MUST be a list of strings of all chemical elements composing this species. Each item of the list MUST be one of the following:
 
 - a valid chemical-element symbol, or
 - the special value `"X"` to represent a non-chemical element, or
 - the special value `"vacancy"` to represent that this site has a non-zero probability of having a vacancy (the respective probability is indicated in the `concentration` list, see below).
 
 If any one entry in the `species` list has a `chemical_symbols` list that is longer than 1 element, the correct flag MUST be set in the list `structure_features`.""",
-        support=SupportLevel.MUST,
-        queryable=SupportLevel.OPTIONAL,
-    )
+            support=SupportLevel.MUST,
+            queryable=SupportLevel.OPTIONAL,
+        ),
+    ]
 
-    concentration: list[float] = OptimadeField(
-        ...,
-        description="""MUST be a list of floats, with same length as `chemical_symbols`. The numbers represent the relative concentration of the corresponding chemical symbol in this species. The numbers SHOULD sum to one. Cases in which the numbers do not sum to one typically fall only in the following two categories:
+    concentration: Annotated[
+        list[float],
+        OptimadeField(
+            description="""MUST be a list of floats, with same length as `chemical_symbols`. The numbers represent the relative concentration of the corresponding chemical symbol in this species. The numbers SHOULD sum to one. Cases in which the numbers do not sum to one typically fall only in the following two categories:
 
 - Numerical errors when representing float numbers in fixed precision, e.g. for two chemical symbols with concentrations `1/3` and `2/3`, the concentration might look something like `[0.33333333333, 0.66666666666]`. If the client is aware that the sum is not one because of numerical precision, it can renormalize the values so that the sum is exactly one.
 - Experimental errors in the data present in the database. In this case, it is the responsibility of the client to decide how to process the data.
 
 Note that concentrations are uncorrelated between different site (even of the same species).""",
-        support=SupportLevel.MUST,
-        queryable=SupportLevel.OPTIONAL,
-    )
+            support=SupportLevel.MUST,
+            queryable=SupportLevel.OPTIONAL,
+        ),
+    ]
 
-    mass: Optional[list[float]] = OptimadeField(
-        None,
-        description="""If present MUST be a list of floats expressed in a.m.u.
+    mass: Annotated[
+        Optional[list[float]],
+        OptimadeField(
+            description="""If present MUST be a list of floats expressed in a.m.u.
 Elements denoting vacancies MUST have masses equal to 0.""",
-        unit="a.m.u.",
-        support=SupportLevel.OPTIONAL,
-        queryable=SupportLevel.OPTIONAL,
-    )
+            unit="a.m.u.",
+            support=SupportLevel.OPTIONAL,
+            queryable=SupportLevel.OPTIONAL,
+        ),
+    ] = None
 
-    original_name: Optional[str] = OptimadeField(
-        None,
-        description="""Can be any valid Unicode string, and SHOULD contain (if specified) the name of the species that is used internally in the source database.
+    original_name: Annotated[
+        Optional[str],
+        OptimadeField(
+            description="""Can be any valid Unicode string, and SHOULD contain (if specified) the name of the species that is used internally in the source database.
 
 Note: With regards to "source database", we refer to the immediate source being queried via the OPTIMADE API implementation.""",
-        support=SupportLevel.OPTIONAL,
-        queryable=SupportLevel.OPTIONAL,
-    )
+            support=SupportLevel.OPTIONAL,
+            queryable=SupportLevel.OPTIONAL,
+        ),
+    ] = None
 
-    attached: Optional[list[str]] = OptimadeField(
-        None,
-        description="""If provided MUST be a list of length 1 or more of strings of chemical symbols for the elements attached to this site, or "X" for a non-chemical element.""",
-        support=SupportLevel.OPTIONAL,
-        queryable=SupportLevel.OPTIONAL,
-    )
+    attached: Annotated[
+        Optional[list[str]],
+        OptimadeField(
+            description="""If provided MUST be a list of length 1 or more of strings of chemical symbols for the elements attached to this site, or "X" for a non-chemical element.""",
+            support=SupportLevel.OPTIONAL,
+            queryable=SupportLevel.OPTIONAL,
+        ),
+    ] = None
 
-    nattached: Optional[list[int]] = OptimadeField(
-        None,
-        description="""If provided MUST be a list of length 1 or more of integers indicating the number of attached atoms of the kind specified in the value of the :field:`attached` key.""",
-        support=SupportLevel.OPTIONAL,
-        queryable=SupportLevel.OPTIONAL,
-    )
+    nattached: Annotated[
+        Optional[list[int]],
+        OptimadeField(
+            description="""If provided MUST be a list of length 1 or more of integers indicating the number of attached atoms of the kind specified in the value of the :field:`attached` key.""",
+            support=SupportLevel.OPTIONAL,
+            queryable=SupportLevel.OPTIONAL,
+        ),
+    ] = None
 
     @field_validator("concentration", "mass", mode="after")
     def validate_concentration_and_mass(
-        cls, value: Optional[list[float]], info: ValidationInfo
+        cls, value: Optional[list[float]], info: "ValidationInfo"
     ) -> Optional[list[float]]:
         if not value:
             return value
@@ -216,26 +225,30 @@ class Assembly(BaseModel):
 
     """
 
-    sites_in_groups: list[list[int]] = OptimadeField(
-        ...,
-        description="""Index of the sites (0-based) that belong to each group for each assembly.
+    sites_in_groups: Annotated[
+        list[list[int]],
+        OptimadeField(
+            description="""Index of the sites (0-based) that belong to each group for each assembly.
 
 - **Examples**:
     - `[[1], [2]]`: two groups, one with the second site, one with the third.
     - `[[1,2], [3]]`: one group with the second and third site, one with the fourth.""",
-        support=SupportLevel.MUST,
-        queryable=SupportLevel.OPTIONAL,
-    )
+            support=SupportLevel.MUST,
+            queryable=SupportLevel.OPTIONAL,
+        ),
+    ]
 
-    group_probabilities: list[float] = OptimadeField(
-        ...,
-        description="""Statistical probability of each group. It MUST have the same length as `sites_in_groups`.
+    group_probabilities: Annotated[
+        list[float],
+        OptimadeField(
+            description="""Statistical probability of each group. It MUST have the same length as `sites_in_groups`.
 It SHOULD sum to one.
 See below for examples of how to specify the probability of the occurrence of a vacancy.
 The possible reasons for the values not to sum to one are the same as already specified above for the `concentration` of each `species`.""",
-        support=SupportLevel.MUST,
-        queryable=SupportLevel.OPTIONAL,
-    )
+            support=SupportLevel.MUST,
+            queryable=SupportLevel.OPTIONAL,
+        ),
+    ]
 
     @field_validator("sites_in_groups", mode="after")
     @classmethod
@@ -249,18 +262,15 @@ The possible reasons for the values not to sum to one are the same as already sp
             )
         return value
 
-    @field_validator("group_probabilities", mode="after")
-    @classmethod
-    def check_self_consistency(
-        cls, value: list[float], info: ValidationInfo
-    ) -> list[float]:
-        if len(value) != len(info.data["sites_in_groups"]):
+    @model_validator(mode="after")
+    def check_self_consistency(self) -> "Assembly":
+        if len(self.group_probabilities) != len(self.sites_in_groups):
             raise ValueError(
                 f"sites_in_groups and group_probabilities MUST be of same length, "
-                f"but are {len(info.data['sites_in_groups'])} and {len(value)}, "
+                f"but are {len(self.sites_in_groups)} and {len(self.group_probabilities)}, "
                 "respectively"
             )
-        return value
+        return self
 
 
 CORRELATED_STRUCTURE_FIELDS = (
@@ -274,9 +284,10 @@ CORRELATED_STRUCTURE_FIELDS = (
 class StructureResourceAttributes(EntryResourceAttributes):
     """This class contains the Field for the attributes used to represent a structure, e.g. unit cell, atoms, positions."""
 
-    elements: Optional[list[str]] = OptimadeField(
-        None,
-        description="""The chemical symbols of the different elements present in the structure.
+    elements: Annotated[
+        Optional[list[str]],
+        OptimadeField(
+            description="""The chemical symbols of the different elements present in the structure.
 
 - **Type**: list of strings.
 
@@ -296,13 +307,15 @@ class StructureResourceAttributes(EntryResourceAttributes):
     - A filter that matches all records of structures that contain Si, Al **and** O, and possibly other elements: `elements HAS ALL "Si", "Al", "O"`.
     - To match structures with exactly these three elements, use `elements HAS ALL "Si", "Al", "O" AND elements LENGTH 3`.
     - Note: length queries on this property can be equivalently formulated by filtering on the `nelements`_ property directly.""",
-        support=SupportLevel.SHOULD,
-        queryable=SupportLevel.MUST,
-    )
+            support=SupportLevel.SHOULD,
+            queryable=SupportLevel.MUST,
+        ),
+    ] = None
 
-    nelements: Optional[int] = OptimadeField(
-        None,
-        description="""Number of different elements in the structure as an integer.
+    nelements: Annotated[
+        Optional[int],
+        OptimadeField(
+            description="""Number of different elements in the structure as an integer.
 
 - **Type**: integer
 
@@ -318,13 +331,15 @@ class StructureResourceAttributes(EntryResourceAttributes):
     - Note: queries on this property can equivalently be formulated using `elements LENGTH`.
     - A filter that matches structures that have exactly 4 elements: `nelements=4`.
     - A filter that matches structures that have between 2 and 7 elements: `nelements>=2 AND nelements<=7`.""",
-        support=SupportLevel.SHOULD,
-        queryable=SupportLevel.MUST,
-    )
+            support=SupportLevel.SHOULD,
+            queryable=SupportLevel.MUST,
+        ),
+    ] = None
 
-    elements_ratios: Optional[list[float]] = OptimadeField(
-        None,
-        description="""Relative proportions of different elements in the structure.
+    elements_ratios: Annotated[
+        Optional[list[float]],
+        OptimadeField(
+            description="""Relative proportions of different elements in the structure.
 
 - **Type**: list of floats
 
@@ -343,13 +358,15 @@ class StructureResourceAttributes(EntryResourceAttributes):
     - Note: Useful filters can be formulated using the set operator syntax for correlated values.
       However, since the values are floating point values, the use of equality comparisons is generally inadvisable.
     - OPTIONAL: a filter that matches structures where approximately 1/3 of the atoms in the structure are the element Al is: `elements:elements_ratios HAS ALL "Al":>0.3333, "Al":<0.3334`.""",
-        support=SupportLevel.SHOULD,
-        queryable=SupportLevel.MUST,
-    )
+            support=SupportLevel.SHOULD,
+            queryable=SupportLevel.MUST,
+        ),
+    ] = None
 
-    chemical_formula_descriptive: Optional[str] = OptimadeField(
-        None,
-        description="""The chemical formula for a structure as a string in a form chosen by the API implementation.
+    chemical_formula_descriptive: Annotated[
+        Optional[str],
+        OptimadeField(
+            description="""The chemical formula for a structure as a string in a form chosen by the API implementation.
 
 - **Type**: string
 
@@ -371,13 +388,15 @@ class StructureResourceAttributes(EntryResourceAttributes):
     - Note: the free-form nature of this property is likely to make queries on it across different databases inconsistent.
     - A filter that matches an exactly given formula: `chemical_formula_descriptive="(H2O)2 Na"`.
     - A filter that does a partial match: `chemical_formula_descriptive CONTAINS "H2O"`.""",
-        support=SupportLevel.SHOULD,
-        queryable=SupportLevel.MUST,
-    )
+            support=SupportLevel.SHOULD,
+            queryable=SupportLevel.MUST,
+        ),
+    ] = None
 
-    chemical_formula_reduced: Optional[str] = OptimadeField(
-        None,
-        description="""The reduced chemical formula for a structure as a string with element symbols and integer chemical proportion numbers.
+    chemical_formula_reduced: Annotated[
+        Optional[str],
+        OptimadeField(
+            description="""The reduced chemical formula for a structure as a string with element symbols and integer chemical proportion numbers.
 The proportion number MUST be omitted if it is 1.
 
 - **Type**: string
@@ -400,14 +419,16 @@ The proportion number MUST be omitted if it is 1.
 
 - **Query examples**:
     - A filter that matches an exactly given formula is `chemical_formula_reduced="H2NaO"`.""",
-        support=SupportLevel.SHOULD,
-        queryable=SupportLevel.MUST,
-        pattern=CHEMICAL_FORMULA_REGEXP,
-    )
+            support=SupportLevel.SHOULD,
+            queryable=SupportLevel.MUST,
+            pattern=CHEMICAL_FORMULA_REGEXP,
+        ),
+    ] = None
 
-    chemical_formula_hill: Optional[str] = OptimadeField(
-        None,
-        description="""The chemical formula for a structure in [Hill form](https://dx.doi.org/10.1021/ja02046a005) with element symbols followed by integer chemical proportion numbers. The proportion number MUST be omitted if it is 1.
+    chemical_formula_hill: Annotated[
+        Optional[str],
+        OptimadeField(
+            description="""The chemical formula for a structure in [Hill form](https://dx.doi.org/10.1021/ja02046a005) with element symbols followed by integer chemical proportion numbers. The proportion number MUST be omitted if it is 1.
 
 - **Type**: string
 
@@ -431,14 +452,16 @@ The proportion number MUST be omitted if it is 1.
 
 - **Query examples**:
     - A filter that matches an exactly given formula is `chemical_formula_hill="H2O2"`.""",
-        support=SupportLevel.OPTIONAL,
-        queryable=SupportLevel.OPTIONAL,
-        pattern=CHEMICAL_FORMULA_REGEXP,
-    )
+            support=SupportLevel.OPTIONAL,
+            queryable=SupportLevel.OPTIONAL,
+            pattern=CHEMICAL_FORMULA_REGEXP,
+        ),
+    ] = None
 
-    chemical_formula_anonymous: Optional[str] = OptimadeField(
-        None,
-        description="""The anonymous formula is the `chemical_formula_reduced`, but where the elements are instead first ordered by their chemical proportion number, and then, in order left to right, replaced by anonymous symbols A, B, C, ..., Z, Aa, Ba, ..., Za, Ab, Bb, ... and so on.
+    chemical_formula_anonymous: Annotated[
+        Optional[str],
+        OptimadeField(
+            description="""The anonymous formula is the `chemical_formula_reduced`, but where the elements are instead first ordered by their chemical proportion number, and then, in order left to right, replaced by anonymous symbols A, B, C, ..., Z, Aa, Ba, ..., Za, Ab, Bb, ... and so on.
 
 - **Type**: string
 
@@ -453,17 +476,19 @@ The proportion number MUST be omitted if it is 1.
 
 - **Querying**:
     - A filter that matches an exactly given formula is `chemical_formula_anonymous="A2B"`.""",
-        support=SupportLevel.SHOULD,
-        queryable=SupportLevel.MUST,
-        pattern=CHEMICAL_FORMULA_REGEXP,
-    )
+            support=SupportLevel.SHOULD,
+            queryable=SupportLevel.MUST,
+            pattern=CHEMICAL_FORMULA_REGEXP,
+        ),
+    ] = None
 
-    dimension_types: Optional[
-        Annotated[list[Periodicity], Field(min_length=3, max_length=3)]
-    ] = OptimadeField(
-        None,
-        title="Dimension Types",
-        description="""List of three integers.
+    dimension_types: Annotated[
+        Optional[list[Periodicity]],
+        OptimadeField(
+            min_length=3,
+            max_length=3,
+            title="Dimension Types",
+            description="""List of three integers.
 For each of the three directions indicated by the three lattice vectors (see property `lattice_vectors`), this list indicates if the direction is periodic (value `1`) or non-periodic (value `0`).
 Note: the elements in this list each refer to the direction of the corresponding entry in `lattice_vectors` and *not* the Cartesian x, y, z directions.
 
@@ -480,13 +505,15 @@ Note: the elements in this list each refer to the direction of the corresponding
     - For a wire along the direction specified by the third lattice vector: `[0, 0, 1]`
     - For a 2D surface/slab, periodic on the plane defined by the first and third lattice vectors: `[1, 0, 1]`
     - For a bulk 3D system: `[1, 1, 1]`""",
-        support=SupportLevel.SHOULD,
-        queryable=SupportLevel.OPTIONAL,
-    )
+            support=SupportLevel.SHOULD,
+            queryable=SupportLevel.OPTIONAL,
+        ),
+    ] = None
 
-    nperiodic_dimensions: Optional[int] = OptimadeField(
-        None,
-        description="""An integer specifying the number of periodic dimensions in the structure, equivalent to the number of non-zero entries in `dimension_types`.
+    nperiodic_dimensions: Annotated[
+        Optional[int],
+        OptimadeField(
+            description="""An integer specifying the number of periodic dimensions in the structure, equivalent to the number of non-zero entries in `dimension_types`.
 
 - **Type**: integer
 
@@ -502,15 +529,17 @@ Note: the elements in this list each refer to the direction of the corresponding
 - **Query examples**:
     - Match only structures with exactly 3 periodic dimensions: `nperiodic_dimensions=3`
     - Match all structures with 2 or fewer periodic dimensions: `nperiodic_dimensions<=2`""",
-        support=SupportLevel.SHOULD,
-        queryable=SupportLevel.MUST,
-    )
+            support=SupportLevel.SHOULD,
+            queryable=SupportLevel.MUST,
+        ),
+    ] = None
 
-    lattice_vectors: Optional[
-        Annotated[list[Vector3D_unknown], Field(min_length=3, max_length=3)]
-    ] = OptimadeField(
-        None,
-        description="""The three lattice vectors in Cartesian coordinates, in ångström (Å).
+    lattice_vectors: Annotated[
+        Optional[list[Vector3D_unknown]],
+        OptimadeField(
+            min_length=3,
+            max_length=3,
+            description="""The three lattice vectors in Cartesian coordinates, in ångström (Å).
 
 - **Type**: list of list of floats or unknown values.
 
@@ -529,14 +558,16 @@ Note: the elements in this list each refer to the direction of the corresponding
 
 - **Examples**:
     - `[[4.0,0.0,0.0],[0.0,4.0,0.0],[0.0,1.0,4.0]]` represents a cell, where the first vector is `(4, 0, 0)`, i.e., a vector aligned along the `x` axis of length 4 Å; the second vector is `(0, 4, 0)`; and the third vector is `(0, 1, 4)`.""",
-        unit="Å",
-        support=SupportLevel.SHOULD,
-        queryable=SupportLevel.OPTIONAL,
-    )
+            unit="Å",
+            support=SupportLevel.SHOULD,
+            queryable=SupportLevel.OPTIONAL,
+        ),
+    ] = None
 
-    cartesian_site_positions: Optional[list[Vector3D]] = OptimadeField(
-        None,
-        description="""Cartesian positions of each site in the structure.
+    cartesian_site_positions: Annotated[
+        Optional[list[Vector3D]],
+        OptimadeField(
+            description="""Cartesian positions of each site in the structure.
 A site is usually used to describe positions of atoms; what atoms can be encountered at a given site is conveyed by the `species_at_sites` property, and the species themselves are described in the `species` property.
 
 - **Type**: list of list of floats
@@ -550,14 +581,16 @@ A site is usually used to describe positions of atoms; what atoms can be encount
 
 - **Examples**:
     - `[[0,0,0],[0,0,2]]` indicates a structure with two sites, one sitting at the origin and one along the (positive) *z*-axis, 2 Å away from the origin.""",
-        unit="Å",
-        support=SupportLevel.SHOULD,
-        queryable=SupportLevel.OPTIONAL,
-    )
+            unit="Å",
+            support=SupportLevel.SHOULD,
+            queryable=SupportLevel.OPTIONAL,
+        ),
+    ] = None
 
-    nsites: Optional[int] = OptimadeField(
-        None,
-        description="""An integer specifying the length of the `cartesian_site_positions` property.
+    nsites: Annotated[
+        Optional[int],
+        OptimadeField(
+            description="""An integer specifying the length of the `cartesian_site_positions` property.
 
 - **Type**: integer
 
@@ -571,13 +604,15 @@ A site is usually used to describe positions of atoms; what atoms can be encount
 - **Query examples**:
     - Match only structures with exactly 4 sites: `nsites=4`
     - Match structures that have between 2 and 7 sites: `nsites>=2 AND nsites<=7`""",
-        queryable=SupportLevel.MUST,
-        support=SupportLevel.SHOULD,
-    )
+            queryable=SupportLevel.MUST,
+            support=SupportLevel.SHOULD,
+        ),
+    ] = None
 
-    species: Optional[list[Species]] = OptimadeField(
-        None,
-        description="""A list describing the species of the sites of this structure.
+    species: Annotated[
+        Optional[list[Species]],
+        OptimadeField(
+            description="""A list describing the species of the sites of this structure.
 Species can represent pure chemical elements, virtual-crystal atoms representing a statistical occupation of a given site by multiple chemical elements, and/or a location to which there are attached atoms, i.e., atoms whose precise location are unknown beyond that they are attached to that position (frequently used to indicate hydrogen atoms attached to another element, e.g., a carbon with three attached hydrogens might represent a methyl group, -CH3).
 
 - **Type**: list of dictionary with keys:
@@ -640,13 +675,15 @@ Species can represent pure chemical elements, virtual-crystal atoms representing
     - `[ {"name": "C12", "chemical_symbols": ["C"], "concentration": [1.0], "mass": [12.0]} ]`: any site with this species is occupied by a carbon isotope with mass 12.
     - `[ {"name": "C13", "chemical_symbols": ["C"], "concentration": [1.0], "mass": [13.0]} ]`: any site with this species is occupied by a carbon isotope with mass 13.
     - `[ {"name": "CH3", "chemical_symbols": ["C"], "concentration": [1.0], "attached": ["H"], "nattached": [3]} ]`: any site with this species is occupied by a methyl group, -CH3, which is represented without specifying precise positions of the hydrogen atoms.""",
-        support=SupportLevel.SHOULD,
-        queryable=SupportLevel.OPTIONAL,
-    )
+            support=SupportLevel.SHOULD,
+            queryable=SupportLevel.OPTIONAL,
+        ),
+    ] = None
 
-    species_at_sites: Optional[list[str]] = OptimadeField(
-        None,
-        description="""Name of the species at each site (where values for sites are specified with the same order of the property `cartesian_site_positions`).
+    species_at_sites: Annotated[
+        Optional[list[str]],
+        OptimadeField(
+            description="""Name of the species at each site (where values for sites are specified with the same order of the property `cartesian_site_positions`).
 The properties of the species are found in the property `species`.
 
 - **Type**: list of strings.
@@ -664,13 +701,15 @@ The properties of the species are found in the property `species`.
 - **Examples**:
     - `["Ti","O2"]` indicates that the first site is hosting a species labeled `"Ti"` and the second a species labeled `"O2"`.
     - `["Ac", "Ac", "Ag", "Ir"]` indicating the first two sites contains the `"Ac"` species, while the third and fourth sites contain the `"Ag"` and `"Ir"` species, respectively.""",
-        support=SupportLevel.SHOULD,
-        queryable=SupportLevel.OPTIONAL,
-    )
+            support=SupportLevel.SHOULD,
+            queryable=SupportLevel.OPTIONAL,
+        ),
+    ] = None
 
-    assemblies: Optional[list[Assembly]] = OptimadeField(
-        None,
-        description="""A description of groups of sites that are statistically correlated.
+    assemblies: Annotated[
+        Optional[list[Assembly]],
+        OptimadeField(
+            description="""A description of groups of sites that are statistically correlated.
 
 - **Type**: list of dictionary with keys:
     - `sites_in_groups`: list of list of integers (REQUIRED)
@@ -772,14 +811,16 @@ The properties of the species are found in the property `species`.
         Site 0 is present with a probability of 20 % and site 1 with a probability of 80 %. These two sites are correlated (either site 0 or 1 is present). Similarly, site 2 is present with a probability of 30 % and site 3 with a probability of 70 %.
         These two sites are correlated (either site 2 or 3 is present).
         However, the presence or absence of sites 0 and 1 is not correlated with the presence or absence of sites 2 and 3 (in the specific example, the pair of sites (0, 2) can occur with 0.2*0.3 = 6 % probability; the pair (0, 3) with 0.2*0.7 = 14 % probability; the pair (1, 2) with 0.8*0.3 = 24 % probability; and the pair (1, 3) with 0.8*0.7 = 56 % probability).""",
-        support=SupportLevel.OPTIONAL,
-        queryable=SupportLevel.OPTIONAL,
-    )
+            support=SupportLevel.OPTIONAL,
+            queryable=SupportLevel.OPTIONAL,
+        ),
+    ] = None
 
-    structure_features: list[StructureFeatures] = OptimadeField(
-        ...,
-        title="Structure Features",
-        description="""A list of strings that flag which special features are used by the structure.
+    structure_features: Annotated[
+        list[StructureFeatures],
+        OptimadeField(
+            title="Structure Features",
+            description="""A list of strings that flag which special features are used by the structure.
 
 - **Type**: list of strings
 
@@ -800,9 +841,10 @@ The properties of the species are found in the property `species`.
         - `assemblies`: this flag MUST be present if the property `assemblies` is present.
 
 - **Examples**: A structure having implicit atoms and using assemblies: `["assemblies", "implicit_atoms"]`""",
-        support=SupportLevel.MUST,
-        queryable=SupportLevel.MUST,
-    )
+            support=SupportLevel.MUST,
+            queryable=SupportLevel.MUST,
+        ),
+    ]
 
     @model_validator(mode="after")
     def warn_on_missing_correlated_fields(self) -> "StructureResourceAttributes":
@@ -816,7 +858,7 @@ The properties of the species are found in the property `species`.
             }
             if missing_fields and len(missing_fields) != len(field_set):
                 accumulated_warnings += [
-                    "Structure with attributes {self} is missing fields "
+                    f"Structure with attributes {self} is missing fields "
                     f"{missing_fields} which are required if "
                     f"{field_set - missing_fields} are present."
                 ]
@@ -829,7 +871,7 @@ The properties of the species are found in the property `species`.
     @field_validator("chemical_formula_reduced", "chemical_formula_hill", mode="after")
     @classmethod
     def check_ordered_formula(
-        cls, value: Optional[str], info: ValidationInfo
+        cls, value: Optional[str], info: "ValidationInfo"
     ) -> Optional[str]:
         if value is None:
             return value
@@ -892,7 +934,7 @@ The properties of the species are found in the property `species`.
     )
     @classmethod
     def check_reduced_formulae(
-        cls, value: Optional[str], info: ValidationInfo
+        cls, value: Optional[str], info: "ValidationInfo"
     ) -> Optional[str]:
         if value is None:
             return value
@@ -933,53 +975,31 @@ The properties of the species are found in the property `species`.
             )
         return value
 
-    @field_validator("nperiodic_dimensions", mode="after")
-    @classmethod
-    def check_periodic_dimensions(
-        cls, value: Optional[int], info: ValidationInfo
-    ) -> Optional[int]:
-        if value is None:
-            return value
+    @model_validator(mode="after")
+    def check_dimensions_types_dependencies(self) -> "StructureResourceAttributes":
+        if self.nperiodic_dimensions is not None:
+            if self.dimension_types and self.nperiodic_dimensions != sum(
+                self.dimension_types
+            ):
+                raise ValueError(
+                    f"nperiodic_dimensions ({self.nperiodic_dimensions}) does not match "
+                    f"expected value of {sum(self.dimension_types)} from dimension_types "
+                    f"({self.dimension_types})"
+                )
 
-        if info.data.get("dimension_types") and value != sum(
-            info.data.get("dimension_types")
-        ):
-            raise ValueError(
-                f"nperiodic_dimensions ({value}) does not match expected value of "
-                f"{sum(info.data['dimension_types'])} from dimension_types "
-                f"({info.data['dimension_types']})"
-            )
+        if self.lattice_vectors is not None:
+            if self.dimension_types:
+                for dim_type, vector in zip(self.dimension_types, self.lattice_vectors):
+                    if None in vector and dim_type == Periodicity.PERIODIC.value:
+                        raise ValueError(
+                            f"Null entries in lattice vectors are only permitted when the "
+                            "corresponding dimension type is "
+                            f"{Periodicity.APERIODIC.value}. Here: dimension_types = "
+                            f"{tuple(getattr(_, 'value', None) for _ in self.dimension_types)},"
+                            f" lattice_vectors = {self.lattice_vectors}"
+                        )
 
-        return value
-
-    @field_validator("lattice_vectors", mode="after")
-    @classmethod
-    def required_if_dimension_types_has_one(
-        cls,
-        value: Optional[
-            Annotated[list[Vector3D_unknown], Field(min_length=3, max_length=3)]
-        ],
-        info: ValidationInfo,
-    ) -> Optional[Annotated[list[Vector3D_unknown], Field(min_length=3, max_length=3)]]:
-        if value is None:
-            return value
-
-        if info.data.get("dimension_types"):
-            dimension_types: Annotated[
-                list[Periodicity], Field(min_length=3, max_length=3)
-            ] = info.data["dimension_types"]
-
-            for dim_type, vector in zip(dimension_types, value):
-                if None in vector and dim_type == Periodicity.PERIODIC.value:
-                    raise ValueError(
-                        f"Null entries in lattice vectors are only permitted when the "
-                        "corresponding dimension type is "
-                        f"{Periodicity.APERIODIC.value}. Here: dimension_types = "
-                        f"{tuple(getattr(_, 'value', None) for _ in dimension_types)},"
-                        f" lattice_vectors = {value}"
-                    )
-
-        return value
+        return self
 
     @field_validator("lattice_vectors", mode="after")
     @classmethod
@@ -1000,48 +1020,44 @@ The properties of the species are found in the property `species`.
                 )
         return value
 
-    @field_validator("nsites", mode="after")
-    @classmethod
-    def validate_nsites(
-        cls, value: Optional[int], info: ValidationInfo
-    ) -> Optional[int]:
-        if value is None:
-            return value
+    @model_validator(mode="after")
+    def validate_nsites(self) -> "StructureResourceAttributes":
+        if self.nsites is None:
+            return self
 
-        if info.data.get("cartesian_site_positions") and value != len(
-            info.data["cartesian_site_positions"]
+        if self.cartesian_site_positions and self.nsites != len(
+            self.cartesian_site_positions
         ):
             raise ValueError(
-                f"nsites (value: {value}) MUST equal length of "
+                f"nsites (value: {self.nsites}) MUST equal length of "
                 "cartesian_site_positions (value: "
-                f"{len(info.data['cartesian_site_positions'])})"
+                f"{len(self.cartesian_site_positions)})"
             )
-        return value
+        return self
 
-    @field_validator("species_at_sites", mode="after")
-    @classmethod
-    def validate_species_at_sites(
-        cls, value: Optional[list[str]], info: ValidationInfo
-    ) -> Optional[list[str]]:
-        if value is None:
-            return value
+    @model_validator(mode="after")
+    def validate_species_at_sites(self) -> "StructureResourceAttributes":
+        if self.species_at_sites is None:
+            return self
 
-        if info.data.get("nsites") and len(value) != info.data["nsites"]:
+        if self.nsites and len(self.species_at_sites) != self.nsites:
             raise ValueError(
-                f"Number of species_at_sites (value: {len(value)}) MUST equal number "
-                f"of sites (value: {info.data['nsites']})"
+                f"Number of species_at_sites (value: {len(self.species_at_sites)}) "
+                f"MUST equal number of sites (value: {self.nsites})"
             )
-        if info.data.get("species"):
-            all_species_names: set[str] = {_.name for _ in info.data["species"]}
 
-            for species_at_site in value:
+        if self.species:
+            all_species_names = {_.name for _ in self.species}
+
+            for species_at_site in self.species_at_sites:
                 if species_at_site not in all_species_names:
                     raise ValueError(
                         "species_at_sites MUST be represented by a species' name, "
                         f"but {species_at_site} was not found in the list of species "
                         f"names: {all_species_names}"
                     )
-        return value
+
+        return self
 
     @field_validator("species", mode="after")
     @classmethod
@@ -1152,9 +1168,10 @@ The properties of the species are found in the property `species`.
 class StructureResource(EntryResource):
     """Representing a structure."""
 
-    type: str = StrictField(
-        "structures",
-        description="""The name of the type of an entry.
+    type: Annotated[
+        Literal["structures"],
+        StrictField(
+            description="""The name of the type of an entry.
 
 - **Type**: string.
 
@@ -1167,9 +1184,10 @@ class StructureResource(EntryResource):
 
 - **Examples**:
     - `"structures"`""",
-        pattern="^structures$",
-        support=SupportLevel.MUST,
-        queryable=SupportLevel.MUST,
-    )
+            pattern="^structures$",
+            support=SupportLevel.MUST,
+            queryable=SupportLevel.MUST,
+        ),
+    ] = "structures"
 
     attributes: StructureResourceAttributes

--- a/optimade/models/types.py
+++ b/optimade/models/types.py
@@ -17,6 +17,6 @@ ElementSymbol = Annotated[str, Field(pattern=ELEMENT_SYMBOLS_PATTERN)]
 SemanticVersion = Annotated[
     str,
     Field(
-        pattern=SEMVER_PATTERN, example=["0.10.1", "1.0.0-rc.2", "1.2.3-rc.5+develop"]
+        pattern=SEMVER_PATTERN, examples=["0.10.1", "1.0.0-rc.2", "1.2.3-rc.5+develop"]
     ),
 ]

--- a/optimade/models/types.py
+++ b/optimade/models/types.py
@@ -1,0 +1,22 @@
+from typing import Annotated
+
+from pydantic import Field
+
+from optimade.models.utils import (
+    ELEMENT_SYMBOLS_PATTERN,
+    EXTENDED_CHEMICAL_SYMBOLS_PATTERN,
+    SEMVER_PATTERN,
+)
+
+__all__ = ("ChemicalSymbol", "SemanticVersion")
+
+ChemicalSymbol = Annotated[str, Field(pattern=EXTENDED_CHEMICAL_SYMBOLS_PATTERN)]
+
+ElementSymbol = Annotated[str, Field(pattern=ELEMENT_SYMBOLS_PATTERN)]
+
+SemanticVersion = Annotated[
+    str,
+    Field(
+        pattern=SEMVER_PATTERN, example=["0.10.1", "1.0.0-rc.2", "1.2.3-rc.5+develop"]
+    ),
+]

--- a/optimade/models/types.py
+++ b/optimade/models/types.py
@@ -1,4 +1,4 @@
-from typing import Annotated
+from typing import Annotated, Optional
 
 from pydantic import Field
 
@@ -20,3 +20,7 @@ SemanticVersion = Annotated[
         pattern=SEMVER_PATTERN, examples=["0.10.1", "1.0.0-rc.2", "1.2.3-rc.5+develop"]
     ),
 ]
+
+AnnotatedType = type(ChemicalSymbol)
+OptionalType = type(Optional[str])
+UnionType = type(str | int)

--- a/optimade/models/types.py
+++ b/optimade/models/types.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Optional, Union
+from typing import Annotated, Optional, Union, get_args
 
 from pydantic import Field
 
@@ -24,3 +24,41 @@ SemanticVersion = Annotated[
 AnnotatedType = type(ChemicalSymbol)
 OptionalType = type(Optional[str])
 UnionType = type(Union[str, int])
+NoneType = type(None)
+
+
+def _get_origin_type(annotation: type) -> type:
+    """Get the origin type of a type annotation.
+
+    Parameters:
+        annotation: The type annotation.
+
+    Returns:
+        The origin type.
+
+    """
+    # If the annotation is a Union, get the first non-None type (this includes
+    # Optional[T])
+    if isinstance(annotation, (OptionalType, UnionType)):
+        for arg in get_args(annotation):
+            if arg not in (None, NoneType):
+                annotation = arg
+                break
+
+    # If the annotation is an Annotated type, get the first type
+    if isinstance(annotation, AnnotatedType):
+        annotation = get_args(annotation)[0]
+
+    # Recursively unpack annotation, if it is a Union, Optional, or Annotated type
+    while isinstance(annotation, (OptionalType, UnionType, AnnotatedType)):
+        annotation = _get_origin_type(annotation)
+
+    # Special case for Literal
+    # NOTE: Expecting Literal arguments to all be of a single type
+    arg = get_args(annotation)
+    if arg and not isinstance(arg, type):
+        # Expect arg to be a Literal type argument
+        annotation = type(arg)
+
+    # Ensure that the annotation is a builtin type
+    return getattr(annotation, "__origin__", annotation)

--- a/optimade/models/types.py
+++ b/optimade/models/types.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Optional
+from typing import Annotated, Optional, Union
 
 from pydantic import Field
 
@@ -23,4 +23,4 @@ SemanticVersion = Annotated[
 
 AnnotatedType = type(ChemicalSymbol)
 OptionalType = type(Optional[str])
-UnionType = type(str | int)
+UnionType = type(Union[str, int])

--- a/optimade/models/utils.py
+++ b/optimade/models/utils.py
@@ -5,12 +5,13 @@ import re
 import warnings
 from enum import Enum
 from functools import reduce
-from typing import Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 from pydantic import Field
-
-# from pydantic.fields import FieldInfo
 from pydantic_core import PydanticUndefined
+
+if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import Generator
 
 _PYDANTIC_FIELD_KWARGS = list(inspect.signature(Field).parameters.keys())
 
@@ -146,10 +147,12 @@ def OptimadeField(
     # Collect non-null keyword arguments to add to the Field schema
     if unit is not None:
         kwargs["unit"] = unit
+
     if queryable is not None:
         if isinstance(queryable, str):
             queryable = SupportLevel(queryable.lower())
         kwargs["queryable"] = queryable
+
     if support is not None:
         if isinstance(support, str):
             support = SupportLevel(support.lower())
@@ -158,15 +161,15 @@ def OptimadeField(
     return StrictField(default, **kwargs)
 
 
-def anonymous_element_generator():
+def anonymous_element_generator() -> "Generator[str, None, None]":
     """Generator that yields the next symbol in the A, B, Aa, ... Az naming scheme."""
     from string import ascii_lowercase
 
     for size in itertools.count(1):
-        for s in itertools.product(ascii_lowercase, repeat=size):
-            s = list(s)
-            s[0] = s[0].upper()
-            yield "".join(s)
+        for tuple_strings in itertools.product(ascii_lowercase, repeat=size):
+            list_strings = list(tuple_strings)
+            list_strings[0] = list_strings[0].upper()
+            yield "".join(list_strings)
 
 
 def _reduce_or_anonymize_formula(
@@ -175,9 +178,7 @@ def _reduce_or_anonymize_formula(
     """Takes an input formula, reduces it and either alphabetizes or anonymizes it."""
     import sys
 
-    numbers: list[int] = [
-        int(n.strip() or 1) for n in re.split(r"[A-Z][a-z]*", formula)[1:]
-    ]
+    numbers = [int(n.strip() or 1) for n in re.split(r"[A-Z][a-z]*", formula)[1:]]
     # Need to remove leading 1 from split and convert to ints
 
     species = re.findall("[A-Z][a-z]*", formula)

--- a/optimade/models/utils.py
+++ b/optimade/models/utils.py
@@ -121,6 +121,7 @@ def StrictField(
 
 def OptimadeField(
     default: "Any" = PydanticUndefined,
+    *,
     support: Optional[Union[str, SupportLevel]] = None,
     queryable: Optional[Union[str, SupportLevel]] = None,
     unit: Optional[str] = None,

--- a/optimade/models/utils.py
+++ b/optimade/models/utils.py
@@ -8,7 +8,9 @@ from functools import reduce
 from typing import Any, Optional, Union
 
 from pydantic import Field
-from pydantic.fields import FieldInfo
+
+# from pydantic.fields import FieldInfo
+from pydantic_core import PydanticUndefined
 
 _PYDANTIC_FIELD_KWARGS = list(inspect.signature(Field).parameters.keys())
 
@@ -33,36 +35,37 @@ class SupportLevel(Enum):
     OPTIONAL = "optional"
 
 
-class StrictFieldInfo(FieldInfo):
-    """Wraps the standard pydantic `FieldInfo` in order
-    to prefix any custom keys from `StrictField`.
+# class StrictFieldInfo(FieldInfo):
+#     """Wraps the standard pydantic `FieldInfo` in order
+#     to prefix any custom keys from `StrictField`.
 
-    """
+#     """
 
-    def __init__(self, *args, **kwargs):
-        if not kwargs.get("default"):
-            kwargs["default"] = args[0] if args else None
-        super().__init__(**kwargs)
-        for key in OPTIMADE_SCHEMA_EXTENSION_KEYS:
-            if self.json_schema_extra and key in self.json_schema_extra:
-                self.json_schema_extra[
-                    f"{OPTIMADE_SCHEMA_EXTENSION_PREFIX}{key}"
-                ] = self.json_schema_extra.pop(key)
+#     def __init__(self, *args, **kwargs):
+#         if not kwargs.get("default"):
+#             kwargs["default"] = args[0] if args else None
+#         super().__init__(**kwargs)
+#         for key in OPTIMADE_SCHEMA_EXTENSION_KEYS:
+#             if self.json_schema_extra and key in self.json_schema_extra:
+#                 self.json_schema_extra[
+#                     f"{OPTIMADE_SCHEMA_EXTENSION_PREFIX}{key}"
+#                 ] = self.json_schema_extra.pop(key)
 
 
-def StrictPydanticField(*args, **kwargs):
-    """Wrapper for `Field` that uses `StrictFieldInfo` instead of
-    the pydantic `FieldInfo`.
-    """
-    field_info = StrictFieldInfo(*args, **kwargs)
-    return field_info
+# def StrictPydanticField(*args, **kwargs):
+#     """Wrapper for `Field` that uses `StrictFieldInfo` instead of
+#     the pydantic `FieldInfo`.
+#     """
+#     field_info = StrictFieldInfo(*args, **kwargs)
+#     return field_info
 
 
 def StrictField(
-    *args: "Any",
+    default: "Any" = PydanticUndefined,
+    *,
     description: Optional[str] = None,
     **kwargs: "Any",
-) -> StrictFieldInfo:
+) -> Any:
     """A wrapper around `pydantic.Field` that does the following:
 
     - Forbids any "extra" keys that would be passed to `pydantic.Field`,
@@ -72,7 +75,7 @@ def StrictField(
     - Emits a warning when no description is provided.
 
     Arguments:
-        *args: Positional arguments passed through to `Field`.
+        default: The only non-keyword argument allowed for Field.
         description: The description of the `Field`; if this is not
             specified then a `UserWarning` will be emitted.
         **kwargs: Extra keyword arguments to be passed to `Field`.
@@ -96,27 +99,70 @@ def StrictField(
 
     if _banned:
         raise RuntimeError(
-            f"Not creating StrictField({args}, {kwargs}) with forbidden keywords {_banned}."
+            f"Not creating StrictField({default!r}, **{kwargs!r}) with "
+            f"forbidden keywords {_banned}."
         )
-
-    if description is not None:
-        kwargs["description"] = description
 
     if description is None:
         warnings.warn(
-            f"No description provided for StrictField specified by {args}, {kwargs}."
+            f"No description provided for StrictField specified by {default!r}, "
+            f"**{kwargs!r}."
         )
+    else:
+        kwargs["description"] = description
 
-    return StrictPydanticField(*args, **kwargs)
+    # OPTIMADE schema extensions
+    if "json_schema_extra" in kwargs:
+        json_schema_extra: dict[str, Any] = kwargs["json_schema_extra"]
+        for key in OPTIMADE_SCHEMA_EXTENSION_KEYS:
+            if key in list(kwargs["json_schema_extra"]):
+                json_schema_extra[
+                    f"{OPTIMADE_SCHEMA_EXTENSION_PREFIX}{key}"
+                ] = json_schema_extra.pop(key)
+        kwargs["json_schema_extra"] = json_schema_extra
+
+    return Field(
+        default,
+        # default_factory=kwargs.pop("default_factory", PydanticUndefined),
+        # alias=kwargs.pop("alias", PydanticUndefined),
+        # alias_priority=kwargs.pop("alias_priority", PydanticUndefined),
+        # validation_alias=kwargs.pop("validation_alias", PydanticUndefined),
+        # serialization_alias=kwargs.pop("serialization_alias", PydanticUndefined),
+        # title=kwargs.pop("title", PydanticUndefined),
+        # description=kwargs.pop("description", PydanticUndefined),
+        # examples=kwargs.pop("examples", PydanticUndefined),
+        # exclude=kwargs.pop("exclude", PydanticUndefined),
+        # discriminator=kwargs.pop("discriminator", PydanticUndefined),
+        # json_schema_extra=kwargs.pop("json_schema_extra", PydanticUndefined),
+        # frozen=kwargs.pop("frozen", PydanticUndefined),
+        # validate_default=kwargs.pop("validate_default", PydanticUndefined),
+        # repr=kwargs.pop("repr", PydanticUndefined),
+        # init_var=kwargs.pop("init_var", PydanticUndefined),
+        # kw_only=kwargs.pop("kw_only", PydanticUndefined),
+        # pattern=kwargs.pop("pattern", PydanticUndefined),
+        # strict=kwargs.pop("strict", PydanticUndefined),
+        # gt=kwargs.pop("gt", PydanticUndefined),
+        # ge=kwargs.pop("ge", PydanticUndefined),
+        # lt=kwargs.pop("lt", PydanticUndefined),
+        # le=kwargs.pop("le", PydanticUndefined),
+        # multiple_of=kwargs.pop("multiple_of", PydanticUndefined),
+        # allow_inf_nan=kwargs.pop("allow_inf_nan", PydanticUndefined),
+        # max_digits=kwargs.pop("max_digits", PydanticUndefined),
+        # decimal_places=kwargs.pop("decimal_places", PydanticUndefined),
+        # min_length=kwargs.pop("min_length", PydanticUndefined),
+        # max_length=kwargs.pop("max_length", PydanticUndefined),
+        # union_mode=kwargs.pop("union_mode", PydanticUndefined),
+        **kwargs,
+    )
 
 
 def OptimadeField(
-    *args,
+    default: "Any" = PydanticUndefined,
     support: Optional[Union[str, SupportLevel]] = None,
     queryable: Optional[Union[str, SupportLevel]] = None,
     unit: Optional[str] = None,
     **kwargs,
-) -> Field:
+) -> Any:
     """A wrapper around `pydantic.Field` that adds OPTIMADE-specific
     field paramters `queryable`, `support` and `unit`, indicating
     the corresponding support level in the specification and the
@@ -146,7 +192,7 @@ def OptimadeField(
             support = SupportLevel(support.lower())
         kwargs["support"] = support
 
-    return StrictField(*args, **kwargs)
+    return StrictField(default, **kwargs)
 
 
 def anonymous_element_generator():

--- a/optimade/models/utils.py
+++ b/optimade/models/utils.py
@@ -69,7 +69,6 @@ def StrictField(
     allowed_keys = [
         "pattern",
         "uniqueItems",
-        "nullable",
     ] + OPTIMADE_SCHEMA_EXTENSION_KEYS
     _banned = [k for k in kwargs if k not in set(_PYDANTIC_FIELD_KWARGS + allowed_keys)]
 

--- a/optimade/server/config.py
+++ b/optimade/server/config.py
@@ -439,6 +439,6 @@ class ServerConfig(BaseSettings):
 
 CONFIG: ServerConfig = ServerConfig()
 """This singleton loads the config from a hierarchy of sources (see
-[`customise_sources`][optimade.server.config.ServerConfig.Config.customise_sources])
+[`customise_sources`][optimade.server.config.ServerConfig.settings_customise_sources])
 and makes it importable in the server code.
 """

--- a/optimade/server/config.py
+++ b/optimade/server/config.py
@@ -1,16 +1,24 @@
 # pylint: disable=no-self-argument
+import json
+import os
 import warnings
 from enum import Enum
 from pathlib import Path
 from typing import Any, Literal, Optional, Union
 
+import yaml
 from pydantic import (  # pylint: disable=no-name-in-module
     AnyHttpUrl,
     Field,
     field_validator,
     model_validator,
 )
-from pydantic_settings import BaseSettings, PydanticBaseSettingsSource
+from pydantic.fields import FieldInfo
+from pydantic_settings import (
+    BaseSettings,
+    PydanticBaseSettingsSource,
+    SettingsConfigDict,
+)
 
 from optimade import __api_version__, __version__
 from optimade.models import Implementation, Provider
@@ -18,8 +26,8 @@ from optimade.models import Implementation, Provider
 DEFAULT_CONFIG_FILE_PATH: str = str(Path.home().joinpath(".optimade.json"))
 """Default configuration file path.
 
-This variable is used as the fallback value if the environment variable `OPTIMADE_CONFIG_FILE` is
-not set.
+This variable is used as the fallback value if the environment variable
+`OPTIMADE_CONFIG_FILE` is not set.
 
 !!! note
     It is set to: `pathlib.Path.home()/.optimade.json`
@@ -55,9 +63,10 @@ class SupportedBackend(Enum):
     - `elastic`: [Elasticsearch](https://www.elastic.co/).
     - `mongodb`: [MongoDB](https://www.mongodb.com/).
     - `mongomock`: Also MongoDB, but instead of using the
-        [`pymongo`](https://pymongo.readthedocs.io/) driver to connect to a live Mongo database
-        instance, this will use the [`mongomock`](https://github.com/mongomock/mongomock) driver,
-        creating an in-memory database, which is mainly used for testing.
+        [`pymongo`](https://pymongo.readthedocs.io/) driver to connect to a live Mongo
+        database instance, this will use the
+        [`mongomock`](https://github.com/mongomock/mongomock) driver, creating an
+        in-memory database, which is mainly used for testing.
 
     """
 
@@ -66,68 +75,88 @@ class SupportedBackend(Enum):
     MONGOMOCK = "mongomock"
 
 
-def config_file_settings(settings: BaseSettings) -> dict[str, Any]:
+class ConfigFileSettingsSource(PydanticBaseSettingsSource):
     """Configuration file settings source.
 
     Based on the example in the
-    [pydantic documentation](https://docs.pydantic.dev/latest/usage/pydantic_settings/#customise-settings-sources),
-    this function loads ServerConfig settings from a configuration file.
+    [pydantic documentation](https://docs.pydantic.dev/latest/concepts/pydantic_settings/#customise-settings-sources),
+    this class defines loading ServerConfig settings from a configuration file.
 
     The file must be of either type JSON or YML/YAML.
-
-    Parameters:
-        settings: The `pydantic_settings.BaseSettings` class using this function as a
-            `pydantic_settings.PydanticBaseSettingsSource`.
-
-    Returns:
-        Dictionary of settings as read from a file.
-
     """
-    import json
-    import os
 
-    import yaml
+    def get_field_value(
+        self, field: FieldInfo, field_name: str
+    ) -> tuple[Any, str, bool]:
+        """Must be defined according to parent abstract class.
 
-    encoding = settings.__config__.env_file_encoding
-    config_file = Path(os.getenv("OPTIMADE_CONFIG_FILE", DEFAULT_CONFIG_FILE_PATH))
+        It does not make sense to use it for this class, since 'extra' is set to
+        'allow'. We will instead just parse and take every key/field specified in the
+        config file.
+        """
+        raise NotImplementedError
 
-    res = {}
-    if config_file.is_file():
-        config_file_content = config_file.read_text(encoding=encoding)
+    def parse_config_file(self) -> dict[str, Any]:
+        """Parse the config file and return a dictionary of its content."""
+        encoding = self.config.get("env_file_encoding")
+        config_file = Path(os.getenv("OPTIMADE_CONFIG_FILE", DEFAULT_CONFIG_FILE_PATH))
 
-        try:
-            res = json.loads(config_file_content)
-        except json.JSONDecodeError as json_exc:
+        parsed_config_file = {}
+        if config_file.is_file():
+            config_file_content = config_file.read_text(encoding=encoding)
+
             try:
-                # This can essentially also load JSON files, as JSON is a subset of YAML v1,
-                # but I suspect it is not as rigorous
-                res = yaml.safe_load(config_file_content)
-            except yaml.YAMLError as yaml_exc:
-                warnings.warn(
-                    f"Unable to parse config file {config_file} as JSON or YAML, using the "
-                    "default settings instead..\n"
-                    f"Errors:\n  JSON:\n{json_exc}.\n\n  YAML:\n{yaml_exc}"
-                )
-    else:
-        warnings.warn(
-            f"Unable to find config file at {config_file}, using the default settings instead."
-        )
+                parsed_config_file = json.loads(config_file_content)
+            except json.JSONDecodeError as json_exc:
+                try:
+                    # This can essentially also load JSON files, as JSON is a subset of
+                    # YAML v1, but I suspect it is not as rigorous
+                    parsed_config_file = yaml.safe_load(config_file_content)
+                except yaml.YAMLError as yaml_exc:
+                    warnings.warn(
+                        f"Unable to parse config file {config_file} as JSON or "
+                        "YAML, using the default settings instead..\n"
+                        f"Errors:\n  JSON:\n{json_exc}.\n\n  YAML:\n{yaml_exc}"
+                    )
+        else:
+            warnings.warn(
+                f"Unable to find config file at {config_file}, using the default "
+                "settings instead."
+            )
 
-    if res is None:
-        # This can happen if the yaml loading doesn't succeed properly, e.g., if the file is empty.
-        warnings.warn(
-            "Unable to load any settings from {config_file}, using the default settings instead."
-        )
-        res = {}
+        if parsed_config_file is None:
+            # This can happen if the yaml loading doesn't succeed properly, e.g., if
+            # the file is empty.
+            warnings.warn(
+                f"Unable to load any settings from {config_file}, using the default "
+                "settings instead."
+            )
+            parsed_config_file = {}
 
-    return res
+        if not isinstance(parsed_config_file, dict):
+            warnings.warn(
+                f"Unable to parse config file {config_file} as a dictionary, using "
+                "the default settings instead."
+            )
+            parsed_config_file = {}
+
+        return parsed_config_file
+
+    def __call__(self) -> dict[str, Any]:
+        return self.parse_config_file()
 
 
 class ServerConfig(BaseSettings):
     """This class stores server config parameters in a way that
     can be easily extended for new config file types.
-
     """
+
+    model_config = SettingsConfigDict(
+        env_prefix="optimade_",
+        extra="allow",
+        env_file_encoding="utf-8",
+        case_sensitive=False,
+    )
 
     debug: bool = Field(
         False,
@@ -137,9 +166,9 @@ class ServerConfig(BaseSettings):
     insert_test_data: bool = Field(
         True,
         description=(
-            "Insert test data into each collection on server initialisation. If true, the "
-            "configured backend will be populated with test data on server start. Should be "
-            "disabled for production usage."
+            "Insert test data into each collection on server initialisation. If true, "
+            "the configured backend will be populated with test data on server start. "
+            "Should be disabled for production usage."
         ),
     )
 
@@ -158,8 +187,13 @@ class ServerConfig(BaseSettings):
 
     mongo_count_timeout: int = Field(
         5,
-        description="""Number of seconds to allow MongoDB to perform a full database count before falling back to `null`.
-This operation can require a full COLLSCAN for empty queries which can be prohibitively slow if the database does not fit into the active set, hence a timeout can drastically speed-up response times.""",
+        description=(
+            "Number of seconds to allow MongoDB to perform a full database count "
+            "before falling back to `null`. This operation can require a full COLLSCAN"
+            " for empty queries which can be prohibitively slow if the database does "
+            "not fit into the active set, hence a timeout can drastically speed-up "
+            "response times."
+        ),
     )
 
     mongo_database: str = Field(
@@ -184,17 +218,18 @@ This operation can require a full COLLSCAN for empty queries which can be prohib
     default_db: str = Field(
         "test_server",
         description=(
-            "ID of /links endpoint resource for the chosen default OPTIMADE implementation (only "
-            "relevant for the index meta-database)"
+            "ID of /links endpoint resource for the chosen default OPTIMADE "
+            "implementation (only relevant for the index meta-database)"
         ),
     )
     root_path: Optional[str] = Field(
         None,
         description=(
-            "Sets the FastAPI app `root_path` parameter. This can be used to serve the API under a"
-            " path prefix behind a proxy or as a sub-application of another FastAPI app. See "
-            "https://fastapi.tiangolo.com/advanced/sub-applications/#technical-details-root_path "
-            "for details."
+            "Sets the FastAPI app `root_path` parameter. This can be used to serve the"
+            " API under a path prefix behind a proxy or as a sub-application of "
+            "another FastAPI app. See "
+            "https://fastapi.tiangolo.com/advanced/sub-applications/#technical-details-root_path"
+            " for details."
         ),
     )
     base_url: Optional[str] = Field(
@@ -206,23 +241,32 @@ This operation can require a full COLLSCAN for empty queries which can be prohib
             version=__version__,
             source_url="https://github.com/Materials-Consortia/optimade-python-tools",
             maintainer={"email": "dev@optimade.org"},
-            issue_tracker="https://github.com/Materials-Consortia/optimade-python-tools/issues",
+            issue_tracker=(
+                "https://github.com/Materials-Consortia/optimade-python-tools/issues"
+            ),
             homepage="https://optimade.org/optimade-python-tools",
         ),
         description="Introspective information about this OPTIMADE implementation",
     )
     index_base_url: Optional[AnyHttpUrl] = Field(
         None,
-        description="An optional link to the base URL for the index meta-database of the provider.",
+        description=(
+            "An optional link to the base URL for the index meta-database of the "
+            "provider."
+        ),
     )
     provider: Provider = Field(
         Provider(
             prefix="exmpl",
             name="Example provider",
-            description="Provider used for examples, not to be assigned to a real database",
+            description=(
+                "Provider used for examples, not to be assigned to a real database"
+            ),
             homepage="https://example.com",
         ),
-        description="General information about the provider of this OPTIMADE implementation",
+        description=(
+            "General information about the provider of this OPTIMADE implementation"
+        ),
     )
     provider_fields: dict[
         Literal["links", "references", "structures"],
@@ -230,15 +274,15 @@ This operation can require a full COLLSCAN for empty queries which can be prohib
     ] = Field(
         {},
         description=(
-            "A list of additional fields to be served with the provider's prefix attached, "
-            "broken down by endpoint."
+            "A list of additional fields to be served with the provider's prefix "
+            "attached, broken down by endpoint."
         ),
     )
     aliases: dict[Literal["links", "references", "structures"], dict[str, str]] = Field(
         {},
         description=(
-            "A mapping between field names in the database with their corresponding OPTIMADE field"
-            " names, broken down by endpoint."
+            "A mapping between field names in the database with their corresponding "
+            "OPTIMADE field names, broken down by endpoint."
         ),
     )
     length_aliases: dict[
@@ -246,19 +290,19 @@ This operation can require a full COLLSCAN for empty queries which can be prohib
     ] = Field(
         {},
         description=(
-            "A mapping between a list property (or otherwise) and an integer property that defines"
-            " the length of that list, for example elements -> nelements. The standard aliases are"
-            " applied first, so this dictionary must refer to the API fields, not the database "
-            "fields."
+            "A mapping between a list property (or otherwise) and an integer property "
+            "that defines the length of that list, for example elements -> nelements. "
+            "The standard aliases are applied first, so this dictionary must refer to "
+            "the API fields, not the database fields."
         ),
     )
     index_links_path: Path = Field(
         Path(__file__).parent.joinpath("index_links.json"),
         description=(
-            "Absolute path to a JSON file containing the MongoDB collecton of links entries "
-            "(documents) to serve under the /links endpoint of the index meta-database. "
-            "NB! As suggested in the previous sentence, these will only be served when using a "
-            "MongoDB-based backend."
+            "Absolute path to a JSON file containing the MongoDB collecton of links "
+            "entries (documents) to serve under the /links endpoint of the index "
+            "meta-database. NB! As suggested in the previous sentence, these will "
+            "only be served when using a MongoDB-based backend."
         ),
     )
 
@@ -266,9 +310,9 @@ This operation can require a full COLLSCAN for empty queries which can be prohib
         False,
         description=(
             "A runtime setting to dynamically switch between index meta-database and "
-            "normal OPTIMADE servers. Used for switching behaviour of e.g., `meta->optimade_schema` "
-            "values in the response. Any provided value may be overridden when used with the reference "
-            "server implementation."
+            "normal OPTIMADE servers. Used for switching behaviour of e.g., "
+            "`meta->optimade_schema` values in the response. Any provided value may "
+            "be overridden when used with the reference server implementation."
         ),
     )
 
@@ -281,13 +325,16 @@ This operation can require a full COLLSCAN for empty queries which can be prohib
 
     custom_landing_page: Optional[Union[str, Path]] = Field(
         None,
-        description="The location of a custom landing page (Jinja template) to use for the API.",
+        description=(
+            "The location of a custom landing page (Jinja template) to use for the API."
+        ),
     )
 
     index_schema_url: Optional[Union[str, AnyHttpUrl]] = Field(
         f"https://schemas.optimade.org/openapi/v{__api_version__}/optimade_index.json",
         description=(
-            "A URL that will be provided in the `meta->schema` field for every response from the index meta-database."
+            "A URL that will be provided in the `meta->schema` field for every "
+            "response from the index meta-database."
         ),
     )
 
@@ -300,31 +347,50 @@ This operation can require a full COLLSCAN for empty queries which can be prohib
     )
     validate_query_parameters: Optional[bool] = Field(
         True,
-        description="If True, the server will check whether the query parameters given in the request are correct.",
+        description=(
+            "If True, the server will check whether the query parameters given in the "
+            "request are correct."
+        ),
     )
 
     validate_api_response: Optional[bool] = Field(
         True,
-        description="""If False, data from the database will not undergo validation before being emitted by the API, and
-        only the mapping of aliases will occur.""",
+        description=(
+            "If False, data from the database will not undergo validation before being"
+            " emitted by the API, and only the mapping of aliases will occur."
+        ),
     )
 
     @field_validator("implementation", mode="before")
     @classmethod
-    def set_implementation_version(cls, v):
+    def set_implementation_version(cls, value: Any) -> dict[str, Any]:
         """Set defaults and modify bypassed value(s)"""
+        if not isinstance(value, dict):
+            if isinstance(value, Implementation):
+                value = value.model_dump()
+            else:
+                raise TypeError(
+                    f"Expected a dict or Implementation instance, got {type(value)}"
+                )
+
         res = {"version": __version__}
-        res.update(v)
+        res.update(value)
         return res
 
-    @model_validator(mode="before")
-    @classmethod
-    def use_real_mongo_override(cls, values):
+    @model_validator(mode="after")
+    def use_real_mongo_override(self) -> "ServerConfig":
         """Overrides the `database_backend` setting with MongoDB and
         raises a deprecation warning.
-
         """
-        use_real_mongo = values.pop("use_real_mongo", None)
+        use_real_mongo = self.use_real_mongo
+
+        # Remove from model
+        del self.use_real_mongo
+
+        # Remove from set of user-defined fields
+        if "use_real_mongo" in self.model_fields_set:
+            self.model_fields_set.remove("use_real_mongo")
+
         if use_real_mongo is not None:
             warnings.warn(
                 "'use_real_mongo' is deprecated, please set the appropriate 'database_backend' "
@@ -333,55 +399,42 @@ This operation can require a full COLLSCAN for empty queries which can be prohib
             )
 
             if use_real_mongo:
-                values["database_backend"] = SupportedBackend.MONGODB
+                self.database_backend = SupportedBackend.MONGODB
 
-        return values
+        return self
 
-    # TODO[pydantic]: We couldn't refactor this class, please create the `model_config` manually.
-    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-config for more information.
-    class Config:
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
         """
-        This is a pydantic model Config object that modifies the behaviour of
-        ServerConfig by adding a prefix to the environment variables that
-        override config file values. It has nothing to do with the OPTIMADE
-        config.
+        **Priority of config settings sources**:
+
+        1. Passed arguments upon initialization of
+            [`ServerConfig`][optimade.server.config.ServerConfig].
+        2. Environment variables, matching the syntax: `"OPTIMADE_"` or `"optimade_"` +
+            `<config_name>`, e.g., `OPTIMADE_LOG_LEVEL=debug` or
+            `optimade_log_dir=~/logs_dir/optimade/`.
+        3. Configuration file (JSON/YAML) taken from:
+            1. Environment variable `OPTIMADE_CONFIG_FILE`.
+            2. Default location (see
+                [DEFAULT_CONFIG_FILE_PATH][optimade.server.config.DEFAULT_CONFIG_FILE_PATH]).
+        4. Settings from secret file (see
+            [pydantic documentation](https://pydantic-docs.helpmanual.io/usage/settings/#secret-support)
+            for more information).
 
         """
-
-        env_prefix = "optimade_"
-        extra = "allow"
-        env_file_encoding = "utf-8"
-
-        @classmethod
-        def customise_sources(
-            cls,
-            init_settings: PydanticBaseSettingsSource,
-            env_settings: PydanticBaseSettingsSource,
-            file_secret_settings: PydanticBaseSettingsSource,
-        ) -> tuple[PydanticBaseSettingsSource, ...]:
-            """
-            **Priority of config settings sources**:
-
-            1. Passed arguments upon initialization of
-               [`ServerConfig`][optimade.server.config.ServerConfig].
-            2. Environment variables, matching the syntax: `"OPTIMADE_"` or `"optimade_"` +
-               `<config_name>`, e.g., `OPTIMADE_LOG_LEVEL=debug` or
-               `optimade_log_dir=~/logs_dir/optimade/`.
-            3. Configuration file (JSON/YAML) taken from:
-               1. Environment variable `OPTIMADE_CONFIG_FILE`.
-               2. Default location (see
-                  [DEFAULT_CONFIG_FILE_PATH][optimade.server.config.DEFAULT_CONFIG_FILE_PATH]).
-            4. Settings from secret file (see
-               [pydantic documentation](https://pydantic-docs.helpmanual.io/usage/settings/#secret-support)
-               for more information).
-
-            """
-            return (
-                init_settings,
-                env_settings,
-                config_file_settings,
-                file_secret_settings,
-            )
+        return (
+            init_settings,
+            env_settings,
+            ConfigFileSettingsSource(settings_cls),
+            file_secret_settings,
+        )
 
 
 CONFIG: ServerConfig = ServerConfig()

--- a/optimade/server/config.py
+++ b/optimade/server/config.py
@@ -1,18 +1,12 @@
-# pylint: disable=no-self-argument
 import json
 import os
 import warnings
 from enum import Enum
 from pathlib import Path
-from typing import Any, Literal, Optional, Union
+from typing import Annotated, Any, Literal, Optional, Union
 
 import yaml
-from pydantic import (  # pylint: disable=no-name-in-module
-    AnyHttpUrl,
-    Field,
-    field_validator,
-    model_validator,
-)
+from pydantic import AnyHttpUrl, Field, field_validator, model_validator
 from pydantic.fields import FieldInfo
 from pydantic_settings import (
     BaseSettings,
@@ -158,208 +152,258 @@ class ServerConfig(BaseSettings):
         case_sensitive=False,
     )
 
-    debug: bool = Field(
-        False,
-        description="Turns on Debug Mode for the OPTIMADE Server implementation",
-    )
-
-    insert_test_data: bool = Field(
-        True,
-        description=(
-            "Insert test data into each collection on server initialisation. If true, "
-            "the configured backend will be populated with test data on server start. "
-            "Should be disabled for production usage."
+    debug: Annotated[
+        bool,
+        Field(
+            description="Turns on Debug Mode for the OPTIMADE Server implementation",
         ),
-    )
+    ] = False
 
-    use_real_mongo: Optional[bool] = Field(
-        None, description="DEPRECATED: force usage of MongoDB over any other backend."
-    )
-
-    database_backend: SupportedBackend = Field(
-        SupportedBackend.MONGOMOCK,
-        description="Which database backend to use out of the supported backends.",
-    )
-
-    elastic_hosts: Optional[Union[str, list[str], dict, list[dict]]] = Field(
-        None, description="Host settings to pass through to the `Elasticsearch` class."
-    )
-
-    mongo_count_timeout: int = Field(
-        5,
-        description=(
-            "Number of seconds to allow MongoDB to perform a full database count "
-            "before falling back to `null`. This operation can require a full COLLSCAN"
-            " for empty queries which can be prohibitively slow if the database does "
-            "not fit into the active set, hence a timeout can drastically speed-up "
-            "response times."
-        ),
-    )
-
-    mongo_database: str = Field(
-        "optimade", description="Mongo database for collection data"
-    )
-    mongo_uri: str = Field("localhost:27017", description="URI for the Mongo server")
-    links_collection: str = Field(
-        "links", description="Mongo collection name for /links endpoint resources"
-    )
-    references_collection: str = Field(
-        "references",
-        description="Mongo collection name for /references endpoint resources",
-    )
-    structures_collection: str = Field(
-        "structures",
-        description="Mongo collection name for /structures endpoint resources",
-    )
-    page_limit: int = Field(20, description="Default number of resources per page")
-    page_limit_max: int = Field(
-        500, description="Max allowed number of resources per page"
-    )
-    default_db: str = Field(
-        "test_server",
-        description=(
-            "ID of /links endpoint resource for the chosen default OPTIMADE "
-            "implementation (only relevant for the index meta-database)"
-        ),
-    )
-    root_path: Optional[str] = Field(
-        None,
-        description=(
-            "Sets the FastAPI app `root_path` parameter. This can be used to serve the"
-            " API under a path prefix behind a proxy or as a sub-application of "
-            "another FastAPI app. See "
-            "https://fastapi.tiangolo.com/advanced/sub-applications/#technical-details-root_path"
-            " for details."
-        ),
-    )
-    base_url: Optional[str] = Field(
-        None, description="Base URL for this implementation"
-    )
-    implementation: Implementation = Field(
-        Implementation(
-            name="OPTIMADE Python Tools",
-            version=__version__,
-            source_url="https://github.com/Materials-Consortia/optimade-python-tools",
-            maintainer={"email": "dev@optimade.org"},
-            issue_tracker=(
-                "https://github.com/Materials-Consortia/optimade-python-tools/issues"
-            ),
-            homepage="https://optimade.org/optimade-python-tools",
-        ),
-        description="Introspective information about this OPTIMADE implementation",
-    )
-    index_base_url: Optional[AnyHttpUrl] = Field(
-        None,
-        description=(
-            "An optional link to the base URL for the index meta-database of the "
-            "provider."
-        ),
-    )
-    provider: Provider = Field(
-        Provider(
-            prefix="exmpl",
-            name="Example provider",
+    insert_test_data: Annotated[
+        bool,
+        Field(
             description=(
-                "Provider used for examples, not to be assigned to a real database"
+                "Insert test data into each collection on server initialisation. If true, "
+                "the configured backend will be populated with test data on server start. "
+                "Should be disabled for production usage."
             ),
-            homepage="https://example.com",
         ),
-        description=(
-            "General information about the provider of this OPTIMADE implementation"
-        ),
-    )
-    provider_fields: dict[
-        Literal["links", "references", "structures"],
-        list[Union[str, dict[Literal["name", "type", "unit", "description"], str]]],
-    ] = Field(
-        {},
-        description=(
-            "A list of additional fields to be served with the provider's prefix "
-            "attached, broken down by endpoint."
-        ),
-    )
-    aliases: dict[Literal["links", "references", "structures"], dict[str, str]] = Field(
-        {},
-        description=(
-            "A mapping between field names in the database with their corresponding "
-            "OPTIMADE field names, broken down by endpoint."
-        ),
-    )
-    length_aliases: dict[
-        Literal["links", "references", "structures"], dict[str, str]
-    ] = Field(
-        {},
-        description=(
-            "A mapping between a list property (or otherwise) and an integer property "
-            "that defines the length of that list, for example elements -> nelements. "
-            "The standard aliases are applied first, so this dictionary must refer to "
-            "the API fields, not the database fields."
-        ),
-    )
-    index_links_path: Path = Field(
-        Path(__file__).parent.joinpath("index_links.json"),
-        description=(
-            "Absolute path to a JSON file containing the MongoDB collecton of links "
-            "entries (documents) to serve under the /links endpoint of the index "
-            "meta-database. NB! As suggested in the previous sentence, these will "
-            "only be served when using a MongoDB-based backend."
-        ),
-    )
+    ] = True
 
-    is_index: Optional[bool] = Field(
-        False,
-        description=(
-            "A runtime setting to dynamically switch between index meta-database and "
-            "normal OPTIMADE servers. Used for switching behaviour of e.g., "
-            "`meta->optimade_schema` values in the response. Any provided value may "
-            "be overridden when used with the reference server implementation."
-        ),
-    )
+    use_real_mongo: Annotated[
+        Optional[bool],
+        Field(description="DEPRECATED: force usage of MongoDB over any other backend."),
+    ] = None
 
-    schema_url: Optional[Union[str, AnyHttpUrl]] = Field(
-        f"https://schemas.optimade.org/openapi/v{__api_version__}/optimade.json",
-        description=(
-            "A URL that will be provided in the `meta->schema` field for every response"
+    database_backend: Annotated[
+        SupportedBackend,
+        Field(
+            description="Which database backend to use out of the supported backends.",
         ),
-    )
+    ] = SupportedBackend.MONGOMOCK
 
-    custom_landing_page: Optional[Union[str, Path]] = Field(
-        None,
-        description=(
-            "The location of a custom landing page (Jinja template) to use for the API."
+    elastic_hosts: Annotated[
+        Optional[Union[str, list[str], dict[str, Any], list[dict[str, Any]]]],
+        Field(
+            description="Host settings to pass through to the `Elasticsearch` class."
         ),
-    )
+    ] = None
 
-    index_schema_url: Optional[Union[str, AnyHttpUrl]] = Field(
-        f"https://schemas.optimade.org/openapi/v{__api_version__}/optimade_index.json",
-        description=(
-            "A URL that will be provided in the `meta->schema` field for every "
-            "response from the index meta-database."
+    mongo_count_timeout: Annotated[
+        int,
+        Field(
+            description=(
+                "Number of seconds to allow MongoDB to perform a full database count "
+                "before falling back to `null`. This operation can require a full COLLSCAN"
+                " for empty queries which can be prohibitively slow if the database does "
+                "not fit into the active set, hence a timeout can drastically speed-up "
+                "response times."
+            ),
         ),
-    )
+    ] = 5
 
-    log_level: LogLevel = Field(
-        LogLevel.INFO, description="Logging level for the OPTIMADE server."
-    )
-    log_dir: Path = Field(
-        Path("/var/log/optimade/"),
-        description="Folder in which log files will be saved.",
-    )
-    validate_query_parameters: Optional[bool] = Field(
-        True,
-        description=(
-            "If True, the server will check whether the query parameters given in the "
-            "request are correct."
+    mongo_database: Annotated[
+        str, Field(description="Mongo database for collection data")
+    ] = "optimade"
+    mongo_uri: Annotated[
+        str, Field(description="URI for the Mongo server")
+    ] = "localhost:27017"
+    links_collection: Annotated[
+        str, Field(description="Mongo collection name for /links endpoint resources")
+    ] = "links"
+    references_collection: Annotated[
+        str,
+        Field(
+            description="Mongo collection name for /references endpoint resources",
         ),
+    ] = "references"
+    structures_collection: Annotated[
+        str,
+        Field(
+            description="Mongo collection name for /structures endpoint resources",
+        ),
+    ] = "structures"
+    page_limit: Annotated[
+        int, Field(description="Default number of resources per page")
+    ] = 20
+    page_limit_max: Annotated[
+        int, Field(description="Max allowed number of resources per page")
+    ] = 500
+    default_db: Annotated[
+        str,
+        Field(
+            description=(
+                "ID of /links endpoint resource for the chosen default OPTIMADE "
+                "implementation (only relevant for the index meta-database)"
+            ),
+        ),
+    ] = "test_server"
+    root_path: Annotated[
+        Optional[str],
+        Field(
+            description=(
+                "Sets the FastAPI app `root_path` parameter. This can be used to serve the"
+                " API under a path prefix behind a proxy or as a sub-application of "
+                "another FastAPI app. See "
+                "https://fastapi.tiangolo.com/advanced/sub-applications/#technical-details-root_path"
+                " for details."
+            ),
+        ),
+    ] = None
+    base_url: Annotated[
+        Optional[str], Field(description="Base URL for this implementation")
+    ] = None
+    implementation: Annotated[
+        Implementation,
+        Field(
+            description="Introspective information about this OPTIMADE implementation",
+        ),
+    ] = Implementation(
+        name="OPTIMADE Python Tools",
+        version=__version__,
+        source_url="https://github.com/Materials-Consortia/optimade-python-tools",
+        maintainer={"email": "dev@optimade.org"},
+        issue_tracker=(
+            "https://github.com/Materials-Consortia/optimade-python-tools/issues"
+        ),
+        homepage="https://optimade.org/optimade-python-tools",
     )
+    index_base_url: Annotated[
+        Optional[AnyHttpUrl],
+        Field(
+            description=(
+                "An optional link to the base URL for the index meta-database of the "
+                "provider."
+            ),
+        ),
+    ] = None
+    provider: Annotated[
+        Provider,
+        Field(
+            description=(
+                "General information about the provider of this OPTIMADE implementation"
+            ),
+        ),
+    ] = Provider(
+        prefix="exmpl",
+        name="Example provider",
+        description=(
+            "Provider used for examples, not to be assigned to a real database"
+        ),
+        homepage="https://example.com",
+    )
+    provider_fields: Annotated[
+        dict[
+            Literal["links", "references", "structures"],
+            list[Union[str, dict[Literal["name", "type", "unit", "description"], str]]],
+        ],
+        Field(
+            description=(
+                "A list of additional fields to be served with the provider's prefix "
+                "attached, broken down by endpoint."
+            ),
+        ),
+    ] = {}
+    aliases: Annotated[
+        dict[Literal["links", "references", "structures"], dict[str, str]],
+        Field(
+            description=(
+                "A mapping between field names in the database with their corresponding "
+                "OPTIMADE field names, broken down by endpoint."
+            ),
+        ),
+    ] = {}
+    length_aliases: Annotated[
+        dict[Literal["links", "references", "structures"], dict[str, str]],
+        Field(
+            description=(
+                "A mapping between a list property (or otherwise) and an integer property "
+                "that defines the length of that list, for example elements -> nelements. "
+                "The standard aliases are applied first, so this dictionary must refer to "
+                "the API fields, not the database fields."
+            ),
+        ),
+    ] = {}
+    index_links_path: Annotated[
+        Path,
+        Field(
+            description=(
+                "Absolute path to a JSON file containing the MongoDB collecton of links "
+                "entries (documents) to serve under the /links endpoint of the index "
+                "meta-database. NB! As suggested in the previous sentence, these will "
+                "only be served when using a MongoDB-based backend."
+            ),
+        ),
+    ] = Path(__file__).parent.joinpath("index_links.json")
 
-    validate_api_response: Optional[bool] = Field(
-        True,
-        description=(
-            "If False, data from the database will not undergo validation before being"
-            " emitted by the API, and only the mapping of aliases will occur."
+    is_index: Annotated[
+        Optional[bool],
+        Field(
+            description=(
+                "A runtime setting to dynamically switch between index meta-database and "
+                "normal OPTIMADE servers. Used for switching behaviour of e.g., "
+                "`meta->optimade_schema` values in the response. Any provided value may "
+                "be overridden when used with the reference server implementation."
+            ),
         ),
-    )
+    ] = False
+
+    schema_url: Annotated[
+        Optional[Union[str, AnyHttpUrl]],
+        Field(
+            description=(
+                "A URL that will be provided in the `meta->schema` field for every response"
+            ),
+        ),
+    ] = f"https://schemas.optimade.org/openapi/v{__api_version__}/optimade.json"
+
+    custom_landing_page: Annotated[
+        Optional[Union[str, Path]],
+        Field(
+            description=(
+                "The location of a custom landing page (Jinja template) to use for the API."
+            ),
+        ),
+    ] = None
+
+    index_schema_url: Annotated[
+        Optional[Union[str, AnyHttpUrl]],
+        Field(
+            description=(
+                "A URL that will be provided in the `meta->schema` field for every "
+                "response from the index meta-database."
+            ),
+        ),
+    ] = f"https://schemas.optimade.org/openapi/v{__api_version__}/optimade_index.json"
+
+    log_level: Annotated[
+        LogLevel, Field(description="Logging level for the OPTIMADE server.")
+    ] = LogLevel.INFO
+    log_dir: Annotated[
+        Path,
+        Field(
+            description="Folder in which log files will be saved.",
+        ),
+    ] = Path("/var/log/optimade/")
+    validate_query_parameters: Annotated[
+        Optional[bool],
+        Field(
+            description=(
+                "If True, the server will check whether the query parameters given in the "
+                "request are correct."
+            ),
+        ),
+    ] = True
+
+    validate_api_response: Annotated[
+        Optional[bool],
+        Field(
+            description=(
+                "If False, data from the database will not undergo validation before being"
+                " emitted by the API, and only the mapping of aliases will occur."
+            ),
+        ),
+    ] = True
 
     @field_validator("implementation", mode="before")
     @classmethod

--- a/optimade/server/entry_collections/entry_collections.py
+++ b/optimade/server/entry_collections/entry_collections.py
@@ -2,7 +2,8 @@ import enum
 import re
 import warnings
 from abc import ABC, abstractmethod
-from typing import Any, Iterable, Optional, Union
+from collections.abc import Iterable
+from typing import Any, Optional, Union
 
 from lark import Transformer
 

--- a/optimade/server/entry_collections/entry_collections.py
+++ b/optimade/server/entry_collections/entry_collections.py
@@ -175,6 +175,7 @@ class EntryCollection(ABC):
         bad_provider_fields = set()
         supported_prefixes = self.resource_mapper.SUPPORTED_PREFIXES
         all_attributes = self.resource_mapper.ALL_ATTRIBUTES
+        print(all_attributes)
         for field in include_fields:
             if field not in all_attributes:
                 if field.startswith("_"):
@@ -283,7 +284,7 @@ class EntryCollection(ABC):
 
         """
 
-        schema = self.resource_cls.model_json_schema()
+        schema = self.resource_cls.model_json_schema(mode="validation")
         attributes = schema["properties"]["attributes"]
         if "allOf" in attributes:
             allOf = attributes.pop("allOf")

--- a/optimade/server/entry_collections/entry_collections.py
+++ b/optimade/server/entry_collections/entry_collections.py
@@ -2,14 +2,14 @@ import enum
 import re
 import warnings
 from abc import ABC, abstractmethod
-from collections.abc import Iterable
-from typing import Any, Optional, Union
+from typing import Any, Iterable, Optional, Union, get_args
 
 from lark import Transformer
+from typing_extensions import _AnnotatedAlias
 
 from optimade.exceptions import BadRequest, Forbidden, NotFound
 from optimade.filterparser import LarkParser
-from optimade.models.entries import EntryResource
+from optimade.models import Attributes, EntryResource
 from optimade.server.config import CONFIG, SupportedBackend
 from optimade.server.mappers import BaseResourceMapper
 from optimade.server.query_params import EntryListingQueryParams, SingleEntryQueryParams
@@ -175,7 +175,6 @@ class EntryCollection(ABC):
         bad_provider_fields = set()
         supported_prefixes = self.resource_mapper.SUPPORTED_PREFIXES
         all_attributes = self.resource_mapper.ALL_ATTRIBUTES
-        print(all_attributes)
         for field in include_fields:
             if field not in all_attributes:
                 if field.startswith("_"):
@@ -283,20 +282,35 @@ class EntryCollection(ABC):
             Property names.
 
         """
+        annotation = self.resource_cls.model_fields["attributes"].annotation
+        for arg in get_args(annotation):
+            if arg not in (None, type(None)):
+                annotation = arg
+                break
 
-        schema = self.resource_cls.model_json_schema(mode="validation")
-        attributes = schema["properties"]["attributes"]
-        if "allOf" in attributes:
-            allOf = attributes.pop("allOf")
-            for dict_ in allOf:
-                attributes.update(dict_)
-        if "$ref" in attributes:
-            path = attributes["$ref"].split("/")[1:]
-            attributes = schema.copy()
-            while path:
-                next_key = path.pop(0)
-                attributes = attributes[next_key]
-        return set(attributes["properties"].keys())
+        if isinstance(annotation, _AnnotatedAlias):
+            annotation = get_args(annotation)[0]
+
+        if not issubclass(annotation, Attributes):
+            raise TypeError(
+                "resource class 'attributes' field must be a subclass of 'EntryResourceAttributes'"
+            )
+
+        return set(annotation.model_fields)
+
+        # schema = self.resource_cls.model_json_schema(mode="validation")
+        # attributes = schema["properties"]["attributes"]
+        # if "allOf" in attributes:
+        #     allOf = attributes.pop("allOf")
+        #     for dict_ in allOf:
+        #         attributes.update(dict_)
+        # if "$ref" in attributes:
+        #     path = attributes["$ref"].split("/")[1:]
+        #     attributes = schema.copy()
+        #     while path:
+        #         next_key = path.pop(0)
+        #         attributes = attributes[next_key]
+        # return set(attributes["properties"].keys())
 
     def handle_query_params(
         self, params: Union[EntryListingQueryParams, SingleEntryQueryParams]

--- a/optimade/server/entry_collections/entry_collections.py
+++ b/optimade/server/entry_collections/entry_collections.py
@@ -283,7 +283,7 @@ class EntryCollection(ABC):
 
         """
 
-        schema = self.resource_cls.schema()
+        schema = self.resource_cls.model_json_schema()
         attributes = schema["properties"]["attributes"]
         if "allOf" in attributes:
             allOf = attributes.pop("allOf")

--- a/optimade/server/main.py
+++ b/optimade/server/main.py
@@ -57,6 +57,7 @@ This specification is generated using [`optimade-python-tools`](https://github.c
     redoc_url=f"{BASE_URL_PREFIXES['major']}/extensions/redoc",
     openapi_url=f"{BASE_URL_PREFIXES['major']}/extensions/openapi.json",
     default_response_class=JSONAPIResponse,
+    separate_input_output_schemas=False,
 )
 
 

--- a/optimade/server/main_index.py
+++ b/optimade/server/main_index.py
@@ -53,6 +53,7 @@ This specification is generated using [`optimade-python-tools`](https://github.c
     redoc_url=f"{BASE_URL_PREFIXES['major']}/extensions/redoc",
     openapi_url=f"{BASE_URL_PREFIXES['major']}/extensions/openapi.json",
     default_response_class=JSONAPIResponse,
+    separate_input_output_schemas=False,
 )
 
 

--- a/optimade/server/mappers/entries.py
+++ b/optimade/server/mappers/entries.py
@@ -343,7 +343,7 @@ class BaseResourceMapper:
         """
         mapping = ((real, alias) for alias, real in cls.all_aliases())
         newdoc = {}
-        reals = {real for alias, real in cls.all_aliases()}
+        reals = {real for _, real in cls.all_aliases()}
         for key in doc:
             if key not in reals:
                 newdoc[key] = doc[key]

--- a/optimade/server/mappers/entries.py
+++ b/optimade/server/mappers/entries.py
@@ -156,7 +156,9 @@ class BaseResourceMapper:
         """Returns the dictionary of attributes defined by the underlying entry resource class."""
         from optimade.server.schemas import retrieve_queryable_properties
 
-        return retrieve_queryable_properties(cls.ENTRY_RESOURCE_CLASS.schema())
+        return retrieve_queryable_properties(
+            cls.ENTRY_RESOURCE_CLASS.model_json_schema()
+        )
 
     @classproperty
     @lru_cache(maxsize=NUM_ENTRY_TYPES)
@@ -166,7 +168,7 @@ class BaseResourceMapper:
 
         """
         return (
-            cls.ENTRY_RESOURCE_CLASS.schema()
+            cls.ENTRY_RESOURCE_CLASS.model_json_schema()
             .get("properties", {})
             .get("type", {})
             .get("default", "")

--- a/optimade/server/mappers/entries.py
+++ b/optimade/server/mappers/entries.py
@@ -156,9 +156,7 @@ class BaseResourceMapper:
         """Returns the dictionary of attributes defined by the underlying entry resource class."""
         from optimade.server.schemas import retrieve_queryable_properties
 
-        return retrieve_queryable_properties(
-            cls.ENTRY_RESOURCE_CLASS.model_json_schema(mode="validation")
-        )
+        return retrieve_queryable_properties(cls.ENTRY_RESOURCE_CLASS)
 
     @classproperty
     @lru_cache(maxsize=NUM_ENTRY_TYPES)
@@ -167,12 +165,10 @@ class BaseResourceMapper:
         to the `type` property of the resource class.
 
         """
-        return (
-            cls.ENTRY_RESOURCE_CLASS.model_json_schema(mode="validation")
-            .get("properties", {})
-            .get("type", {})
-            .get("default", "")
-        )
+        endpoint = cls.ENTRY_RESOURCE_CLASS.model_fields["type"].default
+        if not endpoint and not isinstance(endpoint, str):
+            raise ValueError("Type not set for this entry type!")
+        return endpoint
 
     @classmethod
     @lru_cache(maxsize=NUM_ENTRY_TYPES)

--- a/optimade/server/mappers/entries.py
+++ b/optimade/server/mappers/entries.py
@@ -157,7 +157,7 @@ class BaseResourceMapper:
         from optimade.server.schemas import retrieve_queryable_properties
 
         return retrieve_queryable_properties(
-            cls.ENTRY_RESOURCE_CLASS.model_json_schema()
+            cls.ENTRY_RESOURCE_CLASS.model_json_schema(mode="validation")
         )
 
     @classproperty
@@ -168,7 +168,7 @@ class BaseResourceMapper:
 
         """
         return (
-            cls.ENTRY_RESOURCE_CLASS.model_json_schema()
+            cls.ENTRY_RESOURCE_CLASS.model_json_schema(mode="validation")
             .get("properties", {})
             .get("type", {})
             .get("default", "")

--- a/optimade/server/middleware.py
+++ b/optimade/server/middleware.py
@@ -402,7 +402,7 @@ class AddWarnings(BaseHTTPMiddleware):
             new_warning = Warnings(title=title, detail=detail)
 
         # Add new warning to self._warnings
-        self._warnings.append(new_warning.dict(exclude_unset=True))
+        self._warnings.append(new_warning.model_dump(exclude_unset=True))
 
         # Show warning message as normal in sys.stderr
         warnings._showwarnmsg_impl(  # type: ignore[attr-defined]

--- a/optimade/server/query_params.py
+++ b/optimade/server/query_params.py
@@ -234,7 +234,7 @@ class EntryListingQueryParams(BaseQueryParams):
                 description="RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`.",
                 # ge=1,  # This constraint is only 'RECOMMENDED' in the specification, so should not be included here or in the OpenAPI schema
             ),
-        ] = 1,
+        ] = None,  # type: ignore[assignment]
         page_cursor: Annotated[
             int,
             Query(
@@ -247,13 +247,13 @@ class EntryListingQueryParams(BaseQueryParams):
             Query(
                 description="RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.\nExample: Fetch up to 100 structures above sort-field value 4000 (in this example, server chooses to fetch results sorted by increasing `id`, so `page_above` value refers to an `id` value): `/structures?page_above=4000&page_limit=100`.",
             ),
-        ] = "",
+        ] = None,  # type: ignore[assignment]
         page_below: Annotated[
             str,
             Query(
                 description="RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.",
             ),
-        ] = "",
+        ] = None,  # type: ignore[assignment]
         include: Annotated[
             str,
             Query(

--- a/optimade/server/query_params.py
+++ b/optimade/server/query_params.py
@@ -1,9 +1,10 @@
 from abc import ABC
 from collections.abc import Iterable
+from typing import Annotated
 from warnings import warn
 
 from fastapi import Query
-from pydantic import EmailStr  # pylint: disable=no-name-in-module
+from pydantic import EmailStr
 
 from optimade.exceptions import BadRequest
 from optimade.server.config import CONFIG
@@ -181,65 +182,91 @@ class EntryListingQueryParams(BaseQueryParams):
     def __init__(
         self,
         *,
-        filter: str = Query(  # pylint: disable=redefined-builtin
-            "",
-            description="A filter string, in the format described in section API Filtering Format Specification of the specification.",
-        ),
-        response_format: str = Query(
-            "json",
-            description="The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`",
-        ),
-        email_address: EmailStr = Query(
-            "",
-            description="An email address of the user making the request.\nThe email SHOULD be that of a person and not an automatic system.\nExample: `http://example.com/v1/structures?email_address=user@example.com`",
-        ),
-        response_fields: str = Query(
-            "",
-            description="A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`",
-            pattern=r"([a-z_][a-z_0-9]*(,[a-z_][a-z_0-9]*)*)?",
-        ),
-        sort: str = Query(
-            "",
-            description='If supporting sortable queries, an implementation MUST use the `sort` query parameter with format as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-sorting).\n\nAn implementation MAY support multiple sort fields for a single query.\nIf it does, it again MUST conform to the JSON API 1.0 specification.\n\nIf an implementation supports sorting for an entry listing endpoint, then the `/info/<entries>` endpoint MUST include, for each field name `<fieldname>` in its `data.properties.<fieldname>` response value that can be used for sorting, the key `sortable` with value `true`.\nIf a field name under an entry listing endpoint supporting sorting cannot be used for sorting, the server MUST either leave out the `sortable` key or set it equal to `false` for the specific field name.\nThe set of field names, with `sortable` equal to `true` are allowed to be used in the "sort fields" list according to its definition in the JSON API 1.0 specification.\nThe field `sortable` is in addition to each property description and other OPTIONAL fields.\nAn example is shown in the section Entry Listing Info Endpoints.',
-            pattern=r"([a-z_][a-z_0-9]*(,[a-z_][a-z_0-9]*)*)?",
-        ),
-        page_limit: int = Query(
-            CONFIG.page_limit,
-            description="Sets a numerical limit on the number of entries returned.\nSee [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-pagination).\nThe API implementation MUST return no more than the number specified.\nIt MAY return fewer.\nThe database MAY have a maximum limit and not accept larger numbers (in which case an error code -- 403 Forbidden -- MUST be returned).\nThe default limit value is up to the API implementation to decide.\nExample: `http://example.com/optimade/v1/structures?page_limit=100`",
-            ge=0,
-        ),
-        page_offset: int = Query(
-            0,
-            description="RECOMMENDED for use with _offset-based_ pagination: using `page_offset` and `page_limit` is RECOMMENDED.\nExample: Skip 50 structures and fetch up to 100: `/structures?page_offset=50&page_limit=100`.",
-            ge=0,
-        ),
-        page_number: int = Query(
-            None,
-            description="RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`.",
-            # ge=1,  # This constraint is only 'RECOMMENDED' in the specification, so should not be included here or in the OpenAPI schema
-        ),
-        page_cursor: int = Query(
-            0,
-            description="RECOMMENDED for use with _cursor-based_ pagination: using `page_cursor` and `page_limit` is RECOMMENDED.",
-            ge=0,
-        ),
-        page_above: str = Query(
-            None,
-            description="RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.\nExample: Fetch up to 100 structures above sort-field value 4000 (in this example, server chooses to fetch results sorted by increasing `id`, so `page_above` value refers to an `id` value): `/structures?page_above=4000&page_limit=100`.",
-        ),
-        page_below: str = Query(
-            None,
-            description="RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.",
-        ),
-        include: str = Query(
-            "references",
-            description='A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of "relationship paths", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`.',
-        ),
-        api_hint: str = Query(
-            "",
-            description="If the client provides the parameter, the value SHOULD have the format `vMAJOR` or `vMAJOR.MINOR`, where MAJOR is a major version and MINOR is a minor version of the API. For example, if a client appends `api_hint=v1.0` to the query string, the hint provided is for major version 1 and minor version 0.",
-            pattern=r"(v[0-9]+(\.[0-9]+)?)?",
-        ),
+        filter: Annotated[
+            str,
+            Query(  # pylint: disable=redefined-builtin
+                description="A filter string, in the format described in section API Filtering Format Specification of the specification.",
+            ),
+        ] = "",
+        response_format: Annotated[
+            str,
+            Query(
+                description="The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`",
+            ),
+        ] = "json",
+        email_address: Annotated[
+            EmailStr,
+            Query(
+                description="An email address of the user making the request.\nThe email SHOULD be that of a person and not an automatic system.\nExample: `http://example.com/v1/structures?email_address=user@example.com`",
+            ),
+        ] = "",
+        response_fields: Annotated[
+            str,
+            Query(
+                description="A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`",
+                pattern=r"([a-z_][a-z_0-9]*(,[a-z_][a-z_0-9]*)*)?",
+            ),
+        ] = "",
+        sort: Annotated[
+            str,
+            Query(
+                description='If supporting sortable queries, an implementation MUST use the `sort` query parameter with format as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-sorting).\n\nAn implementation MAY support multiple sort fields for a single query.\nIf it does, it again MUST conform to the JSON API 1.0 specification.\n\nIf an implementation supports sorting for an entry listing endpoint, then the `/info/<entries>` endpoint MUST include, for each field name `<fieldname>` in its `data.properties.<fieldname>` response value that can be used for sorting, the key `sortable` with value `true`.\nIf a field name under an entry listing endpoint supporting sorting cannot be used for sorting, the server MUST either leave out the `sortable` key or set it equal to `false` for the specific field name.\nThe set of field names, with `sortable` equal to `true` are allowed to be used in the "sort fields" list according to its definition in the JSON API 1.0 specification.\nThe field `sortable` is in addition to each property description and other OPTIONAL fields.\nAn example is shown in the section Entry Listing Info Endpoints.',
+                pattern=r"([a-z_][a-z_0-9]*(,[a-z_][a-z_0-9]*)*)?",
+            ),
+        ] = "",
+        page_limit: Annotated[
+            int,
+            Query(
+                description="Sets a numerical limit on the number of entries returned.\nSee [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-pagination).\nThe API implementation MUST return no more than the number specified.\nIt MAY return fewer.\nThe database MAY have a maximum limit and not accept larger numbers (in which case an error code -- 403 Forbidden -- MUST be returned).\nThe default limit value is up to the API implementation to decide.\nExample: `http://example.com/optimade/v1/structures?page_limit=100`",
+                ge=0,
+            ),
+        ] = CONFIG.page_limit,
+        page_offset: Annotated[
+            int,
+            Query(
+                description="RECOMMENDED for use with _offset-based_ pagination: using `page_offset` and `page_limit` is RECOMMENDED.\nExample: Skip 50 structures and fetch up to 100: `/structures?page_offset=50&page_limit=100`.",
+                ge=0,
+            ),
+        ] = 0,
+        page_number: Annotated[
+            int,
+            Query(
+                description="RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`.",
+                # ge=1,  # This constraint is only 'RECOMMENDED' in the specification, so should not be included here or in the OpenAPI schema
+            ),
+        ] = 1,
+        page_cursor: Annotated[
+            int,
+            Query(
+                description="RECOMMENDED for use with _cursor-based_ pagination: using `page_cursor` and `page_limit` is RECOMMENDED.",
+                ge=0,
+            ),
+        ] = 0,
+        page_above: Annotated[
+            str,
+            Query(
+                description="RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.\nExample: Fetch up to 100 structures above sort-field value 4000 (in this example, server chooses to fetch results sorted by increasing `id`, so `page_above` value refers to an `id` value): `/structures?page_above=4000&page_limit=100`.",
+            ),
+        ] = "",
+        page_below: Annotated[
+            str,
+            Query(
+                description="RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.",
+            ),
+        ] = "",
+        include: Annotated[
+            str,
+            Query(
+                description='A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of "relationship paths", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`.',
+            ),
+        ] = "references",
+        api_hint: Annotated[
+            str,
+            Query(
+                description="If the client provides the parameter, the value SHOULD have the format `vMAJOR` or `vMAJOR.MINOR`, where MAJOR is a major version and MINOR is a minor version of the API. For example, if a client appends `api_hint=v1.0` to the query string, the hint provided is for major version 1 and minor version 0.",
+                pattern=r"(v[0-9]+(\.[0-9]+)?)?",
+            ),
+        ] = "",
     ):
         self.filter = filter
         self.response_format = response_format
@@ -302,28 +329,38 @@ class SingleEntryQueryParams(BaseQueryParams):
     def __init__(
         self,
         *,
-        response_format: str = Query(
-            "json",
-            description="The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`",
-        ),
-        email_address: EmailStr = Query(
-            "",
-            description="An email address of the user making the request.\nThe email SHOULD be that of a person and not an automatic system.\nExample: `http://example.com/v1/structures?email_address=user@example.com`",
-        ),
-        response_fields: str = Query(
-            "",
-            description="A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`",
-            pattern=r"([a-z_][a-z_0-9]*(,[a-z_][a-z_0-9]*)*)?",
-        ),
-        include: str = Query(
-            "references",
-            description='A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of "relationship paths", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`.',
-        ),
-        api_hint: str = Query(
-            "",
-            description="If the client provides the parameter, the value SHOULD have the format `vMAJOR` or `vMAJOR.MINOR`, where MAJOR is a major version and MINOR is a minor version of the API. For example, if a client appends `api_hint=v1.0` to the query string, the hint provided is for major version 1 and minor version 0.",
-            pattern=r"(v[0-9]+(\.[0-9]+)?)?",
-        ),
+        response_format: Annotated[
+            str,
+            Query(
+                description="The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`",
+            ),
+        ] = "json",
+        email_address: Annotated[
+            EmailStr,
+            Query(
+                description="An email address of the user making the request.\nThe email SHOULD be that of a person and not an automatic system.\nExample: `http://example.com/v1/structures?email_address=user@example.com`",
+            ),
+        ] = "",
+        response_fields: Annotated[
+            str,
+            Query(
+                description="A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`",
+                pattern=r"([a-z_][a-z_0-9]*(,[a-z_][a-z_0-9]*)*)?",
+            ),
+        ] = "",
+        include: Annotated[
+            str,
+            Query(
+                description='A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of "relationship paths", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`.',
+            ),
+        ] = "references",
+        api_hint: Annotated[
+            str,
+            Query(
+                description="If the client provides the parameter, the value SHOULD have the format `vMAJOR` or `vMAJOR.MINOR`, where MAJOR is a major version and MINOR is a minor version of the API. For example, if a client appends `api_hint=v1.0` to the query string, the hint provided is for major version 1 and minor version 0.",
+                pattern=r"(v[0-9]+(\.[0-9]+)?)?",
+            ),
+        ] = "",
     ):
         self.response_format = response_format
         self.email_address = email_address

--- a/optimade/server/routers/index_info.py
+++ b/optimade/server/routers/index_info.py
@@ -32,8 +32,12 @@ def get_info(request: Request) -> IndexInfoResponse:
             schema=CONFIG.index_schema_url,
         ),
         data=IndexInfoResource(
-            id=IndexInfoResource.model_json_schema()["properties"]["id"]["default"],
-            type=IndexInfoResource.model_json_schema()["properties"]["type"]["default"],
+            id=IndexInfoResource.model_json_schema(mode="validation")["properties"][
+                "id"
+            ]["default"],
+            type=IndexInfoResource.model_json_schema(mode="validation")["properties"][
+                "type"
+            ]["default"],
             attributes=IndexInfoAttributes(
                 api_version=f"{__api_version__}",
                 available_api_versions=[
@@ -50,9 +54,9 @@ def get_info(request: Request) -> IndexInfoResponse:
             relationships={
                 "default": IndexRelationship(
                     data={
-                        "type": RelatedLinksResource.model_json_schema()["properties"][
-                            "type"
-                        ]["default"],
+                        "type": RelatedLinksResource.model_json_schema(
+                            mode="validation"
+                        )["properties"]["type"]["default"],
                         "id": CONFIG.default_db,
                     }
                 )

--- a/optimade/server/routers/index_info.py
+++ b/optimade/server/routers/index_info.py
@@ -32,8 +32,8 @@ def get_info(request: Request) -> IndexInfoResponse:
             schema=CONFIG.index_schema_url,
         ),
         data=IndexInfoResource(
-            id=IndexInfoResource.schema()["properties"]["id"]["default"],
-            type=IndexInfoResource.schema()["properties"]["type"]["default"],
+            id=IndexInfoResource.model_json_schema()["properties"]["id"]["default"],
+            type=IndexInfoResource.model_json_schema()["properties"]["type"]["default"],
             attributes=IndexInfoAttributes(
                 api_version=f"{__api_version__}",
                 available_api_versions=[
@@ -50,9 +50,9 @@ def get_info(request: Request) -> IndexInfoResponse:
             relationships={
                 "default": IndexRelationship(
                     data={
-                        "type": RelatedLinksResource.schema()["properties"]["type"][
-                            "default"
-                        ],
+                        "type": RelatedLinksResource.model_json_schema()["properties"][
+                            "type"
+                        ]["default"],
                         "id": CONFIG.default_db,
                     }
                 )

--- a/optimade/server/routers/index_info.py
+++ b/optimade/server/routers/index_info.py
@@ -32,12 +32,8 @@ def get_info(request: Request) -> IndexInfoResponse:
             schema=CONFIG.index_schema_url,
         ),
         data=IndexInfoResource(
-            id=IndexInfoResource.model_json_schema(mode="validation")["properties"][
-                "id"
-            ]["default"],
-            type=IndexInfoResource.model_json_schema(mode="validation")["properties"][
-                "type"
-            ]["default"],
+            id=IndexInfoResource.model_fields["id"].default,
+            type=IndexInfoResource.model_fields["type"].default,
             attributes=IndexInfoAttributes(
                 api_version=f"{__api_version__}",
                 available_api_versions=[
@@ -54,9 +50,7 @@ def get_info(request: Request) -> IndexInfoResponse:
             relationships={
                 "default": IndexRelationship(
                     data={
-                        "type": RelatedLinksResource.model_json_schema(
-                            mode="validation"
-                        )["properties"]["type"]["default"],
+                        "type": RelatedLinksResource.model_fields["type"].default,
                         "id": CONFIG.default_db,
                     }
                 )

--- a/optimade/server/routers/info.py
+++ b/optimade/server/routers/info.py
@@ -30,12 +30,8 @@ def get_info(request: Request) -> InfoResponse:
         """Cached closure that generates the info response for the implementation."""
 
         return BaseInfoResource(
-            id=BaseInfoResource.model_json_schema(mode="validation")["properties"][
-                "id"
-            ]["default"],
-            type=BaseInfoResource.model_json_schema(mode="validation")["properties"][
-                "type"
-            ]["default"],
+            id=BaseInfoResource.model_fields["id"].default,
+            type=BaseInfoResource.model_fields["type"].default,
             attributes=BaseInfoAttributes(
                 api_version=__api_version__,
                 available_api_versions=[
@@ -72,31 +68,34 @@ def get_entry_info(request: Request, entry: str) -> EntryInfoResponse:
         """Cached closure that generates the entry info response for the given type.
 
         Parameters:
-            entry: The OPTIMADE type to generate the info response for, e.g., `"structures"`.
-                Must be a key in `ENTRY_INFO_SCHEMAS`.
+            entry: The OPTIMADE type to generate the info response for, e.g.,
+                `"structures"`. Must be a key in `ENTRY_INFO_SCHEMAS`.
 
         """
         valid_entry_info_endpoints = ENTRY_INFO_SCHEMAS.keys()
         if entry not in valid_entry_info_endpoints:
             raise StarletteHTTPException(
                 status_code=404,
-                detail=f"Entry info not found for {entry}, valid entry info endpoints are: {', '.join(valid_entry_info_endpoints)}",
+                detail=(
+                    f"Entry info not found for {entry}, valid entry info endpoints "
+                    f"are: {', '.join(valid_entry_info_endpoints)}"
+                ),
             )
 
-        schema = ENTRY_INFO_SCHEMAS[entry](mode="validation")
+        schema = ENTRY_INFO_SCHEMAS[entry]
         queryable_properties = {"id", "type", "attributes"}
         properties = retrieve_queryable_properties(
             schema, queryable_properties, entry_type=entry
         )
 
-        output_fields_by_format = {"json": list(properties.keys())}
+        output_fields_by_format = {"json": list(properties)}
 
         return EntryInfoResource(
-            formats=list(output_fields_by_format.keys()),
-            description=schema.get("description", "Entry Resources"),
+            formats=list(output_fields_by_format),
+            description=getattr(schema, "__doc__", "Entry Resources"),
             properties=properties,
             output_fields_by_format=output_fields_by_format,
-            schema=CONFIG.schema_url,
+            # schema=CONFIG.schema_url,  # I think this should be removed?
         )
 
     return EntryInfoResponse(

--- a/optimade/server/routers/info.py
+++ b/optimade/server/routers/info.py
@@ -95,7 +95,6 @@ def get_entry_info(request: Request, entry: str) -> EntryInfoResponse:
             description=getattr(schema, "__doc__", "Entry Resources"),
             properties=properties,
             output_fields_by_format=output_fields_by_format,
-            # schema=CONFIG.schema_url,  # I think this should be removed?
         )
 
     return EntryInfoResponse(

--- a/optimade/server/routers/info.py
+++ b/optimade/server/routers/info.py
@@ -30,8 +30,8 @@ def get_info(request: Request) -> InfoResponse:
         """Cached closure that generates the info response for the implementation."""
 
         return BaseInfoResource(
-            id=BaseInfoResource.schema()["properties"]["id"]["default"],
-            type=BaseInfoResource.schema()["properties"]["type"]["default"],
+            id=BaseInfoResource.model_json_schema()["properties"]["id"]["default"],
+            type=BaseInfoResource.model_json_schema()["properties"]["type"]["default"],
             attributes=BaseInfoAttributes(
                 api_version=__api_version__,
                 available_api_versions=[

--- a/optimade/server/routers/info.py
+++ b/optimade/server/routers/info.py
@@ -30,8 +30,12 @@ def get_info(request: Request) -> InfoResponse:
         """Cached closure that generates the info response for the implementation."""
 
         return BaseInfoResource(
-            id=BaseInfoResource.model_json_schema()["properties"]["id"]["default"],
-            type=BaseInfoResource.model_json_schema()["properties"]["type"]["default"],
+            id=BaseInfoResource.model_json_schema(mode="validation")["properties"][
+                "id"
+            ]["default"],
+            type=BaseInfoResource.model_json_schema(mode="validation")["properties"][
+                "type"
+            ]["default"],
             attributes=BaseInfoAttributes(
                 api_version=__api_version__,
                 available_api_versions=[
@@ -79,7 +83,7 @@ def get_entry_info(request: Request, entry: str) -> EntryInfoResponse:
                 detail=f"Entry info not found for {entry}, valid entry info endpoints are: {', '.join(valid_entry_info_endpoints)}",
             )
 
-        schema = ENTRY_INFO_SCHEMAS[entry]()
+        schema = ENTRY_INFO_SCHEMAS[entry](mode="validation")
         queryable_properties = {"id", "type", "attributes"}
         properties = retrieve_queryable_properties(
             schema, queryable_properties, entry_type=entry

--- a/optimade/server/routers/links.py
+++ b/optimade/server/routers/links.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, Request
 
@@ -26,7 +26,7 @@ links_coll = create_collection(
     tags=["Links"],
     responses=ERROR_RESPONSES,
 )
-def get_links(request: Request, params: EntryListingQueryParams = Depends()) -> Any:
-    return get_entries(
-        collection=links_coll, response=LinksResponse, request=request, params=params
-    )
+def get_links(
+    request: Request, params: Annotated[EntryListingQueryParams, Depends()]
+) -> dict[str, Any]:
+    return get_entries(collection=links_coll, request=request, params=params)

--- a/optimade/server/routers/references.py
+++ b/optimade/server/routers/references.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, Request
 
@@ -25,17 +25,18 @@ references_coll = create_collection(
 
 @router.get(
     "/references",
-    response_model=ReferenceResponseMany if CONFIG.validate_api_response else dict,
+    response_model=ReferenceResponseMany
+    if CONFIG.validate_api_response
+    else dict[str, Any],
     response_model_exclude_unset=True,
     tags=["References"],
     responses=ERROR_RESPONSES,
 )
 def get_references(
-    request: Request, params: EntryListingQueryParams = Depends()
-) -> Any:
+    request: Request, params: Annotated[EntryListingQueryParams, Depends()]
+) -> dict[str, Any]:
     return get_entries(
         collection=references_coll,
-        response=ReferenceResponseMany,
         request=request,
         params=params,
     )
@@ -43,18 +44,21 @@ def get_references(
 
 @router.get(
     "/references/{entry_id:path}",
-    response_model=ReferenceResponseOne if CONFIG.validate_api_response else dict,
+    response_model=ReferenceResponseOne
+    if CONFIG.validate_api_response
+    else dict[str, Any],
     response_model_exclude_unset=True,
     tags=["References"],
     responses=ERROR_RESPONSES,
 )
 def get_single_reference(
-    request: Request, entry_id: str, params: SingleEntryQueryParams = Depends()
-) -> Any:
+    request: Request,
+    entry_id: str,
+    params: Annotated[SingleEntryQueryParams, Depends()],
+) -> dict[str, Any]:
     return get_single_entry(
         collection=references_coll,
         entry_id=entry_id,
-        response=ReferenceResponseOne,
         request=request,
         params=params,
     )

--- a/optimade/server/routers/structures.py
+++ b/optimade/server/routers/structures.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, Request
 
@@ -25,17 +25,18 @@ structures_coll = create_collection(
 
 @router.get(
     "/structures",
-    response_model=StructureResponseMany if CONFIG.validate_api_response else dict,
+    response_model=StructureResponseMany
+    if CONFIG.validate_api_response
+    else dict[str, Any],
     response_model_exclude_unset=True,
     tags=["Structures"],
     responses=ERROR_RESPONSES,
 )
 def get_structures(
-    request: Request, params: EntryListingQueryParams = Depends()
-) -> Any:
+    request: Request, params: Annotated[EntryListingQueryParams, Depends()]
+) -> dict[str, Any]:
     return get_entries(
         collection=structures_coll,
-        response=StructureResponseMany,
         request=request,
         params=params,
     )
@@ -43,18 +44,21 @@ def get_structures(
 
 @router.get(
     "/structures/{entry_id:path}",
-    response_model=StructureResponseOne if CONFIG.validate_api_response else dict,
+    response_model=StructureResponseOne
+    if CONFIG.validate_api_response
+    else dict[str, Any],
     response_model_exclude_unset=True,
     tags=["Structures"],
     responses=ERROR_RESPONSES,
 )
 def get_single_structure(
-    request: Request, entry_id: str, params: SingleEntryQueryParams = Depends()
-) -> Any:
+    request: Request,
+    entry_id: str,
+    params: Annotated[SingleEntryQueryParams, Depends()],
+) -> dict[str, Any]:
     return get_single_entry(
         collection=structures_coll,
         entry_id=entry_id,
-        response=StructureResponseOne,
         request=request,
         params=params,
     )

--- a/optimade/server/routers/utils.py
+++ b/optimade/server/routers/utils.py
@@ -193,7 +193,7 @@ def get_included_relationships(
 
     included: dict[
         str,
-        Union[list[EntryResource], EntryResource, list[dict[str, Any]], dict[str, Any]],
+        Union[list[EntryResource], list[dict[str, Any]]],
     ] = {}
     for entry_type in endpoint_includes:
         compound_filter = " OR ".join(
@@ -212,7 +212,7 @@ def get_included_relationships(
         ref_results, _, _, _, _ = ENTRY_COLLECTIONS[entry_type].find(params)
         if ref_results is None:
             ref_results = []
-        included[entry_type] = ref_results
+        included[entry_type] = ref_results  # type: ignore[assignment]
 
     # flatten dict by endpoint to list
     return [obj for endp in included.values() for obj in endp]

--- a/optimade/server/routers/utils.py
+++ b/optimade/server/routers/utils.py
@@ -117,7 +117,7 @@ def handle_response_fields(
     while results:
         new_entry = results.pop(0)
         try:
-            new_entry = new_entry.dict(exclude_unset=True, by_alias=True)  # type: ignore[union-attr]
+            new_entry = new_entry.model_dump(exclude_unset=True, by_alias=True)  # type: ignore[union-attr]
         except AttributeError:
             pass
 
@@ -183,7 +183,7 @@ def get_included_relationships(
             continue
 
         if not isinstance(relationships, dict):
-            relationships = relationships.dict()
+            relationships = relationships.model_dump()
 
         for entry_type in ENTRY_COLLECTIONS:
             # Skip entry type if it is not in `include_param`

--- a/optimade/server/routers/versions.py
+++ b/optimade/server/routers/versions.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Request
+from fastapi import APIRouter
 from fastapi.responses import Response
 
 from optimade.server.routers.utils import BASE_URL_PREFIXES
@@ -15,7 +15,7 @@ class CsvResponse(Response):
     tags=["Versions"],
     response_class=CsvResponse,
 )
-def get_versions(request: Request):
+def get_versions() -> CsvResponse:
     """Respond with the text/csv representation for the served versions."""
     version = BASE_URL_PREFIXES["major"].replace("/v", "")
     response = f"version\n{version}"

--- a/optimade/server/schemas.py
+++ b/optimade/server/schemas.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:  # pragma: no cover
         str,
         dict[
             Literal["description", "unit", "queryable", "support", "sortable", "type"],
-            Optional[Union[str, SupportLevel, bool]],
+            Optional[Union[str, SupportLevel, bool, DataType]],
         ],
     ]
 

--- a/optimade/server/schemas.py
+++ b/optimade/server/schemas.py
@@ -11,8 +11,8 @@ from optimade.models import (
 __all__ = ("ENTRY_INFO_SCHEMAS", "ERROR_RESPONSES", "retrieve_queryable_properties")
 
 ENTRY_INFO_SCHEMAS: dict[str, Callable[[], dict]] = {
-    "structures": StructureResource.schema,
-    "references": ReferenceResource.schema,
+    "structures": StructureResource.model_json_schema,
+    "references": ReferenceResource.model_json_schema,
 }
 """This dictionary is used to define the `/info/<entry_type>` endpoints."""
 
@@ -57,6 +57,36 @@ def retrieve_queryable_properties(
     properties = {}
     for name, value in schema["properties"].items():
         if not queryable_properties or name in queryable_properties:
+            if name in properties:
+                continue
+
+            if "allOf" in value:
+                for dict_ in value["allOf"]:
+                    value.update(dict_)
+
+            if "anyOf" in value:
+                dict_to_use = {}
+                # Go through anyOf and find the first dict that is not type=null, going
+                # first for the reference type, if it exists.
+                # Then go through anyOf again and find the first dict that is not
+                # type=null and not a reference.
+
+                # This makes the reference type the fallback.
+                # It should support anyOf types of just {reference, null} as well as
+                # {reference, type, null}.
+                for dict_ in value["anyOf"]:
+                    if dict_.get("type", "") == "null":
+                        continue
+                    if "$ref" in dict_:
+                        dict_to_use = dict_
+                        break
+                for dict_ in value["anyOf"]:
+                    if dict_.get("type", "") == "null" or "$ref" in dict_:
+                        continue
+                    else:
+                        dict_to_use = dict_
+                value.update(dict_to_use)
+
             if "$ref" in value:
                 path = value["$ref"].split("/")[1:]
                 sub_schema = schema.copy()

--- a/optimade/server/schemas.py
+++ b/optimade/server/schemas.py
@@ -1,4 +1,5 @@
-from typing import TYPE_CHECKING, Any, Iterable, Optional
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Any, Optional
 
 from pydantic import BaseModel, TypeAdapter
 

--- a/optimade/server/schemas.py
+++ b/optimade/server/schemas.py
@@ -1,7 +1,6 @@
 from typing import TYPE_CHECKING, Iterable, Optional, get_args
 
 from pydantic import BaseModel, TypeAdapter
-from typing_extensions import _AnnotatedAlias
 
 from optimade.models import (
     DataType,
@@ -10,6 +9,7 @@ from optimade.models import (
     ReferenceResource,
     StructureResource,
 )
+from optimade.models.types import AnnotatedType, OptionalType, UnionType
 
 if TYPE_CHECKING:  # pragma: no cover
     from typing import Literal, Union
@@ -84,12 +84,13 @@ def retrieve_queryable_properties(
             # If the field is a Union, get the first non-None type (this includes
             # Optional[T])
             annotation = value.annotation
-            for arg in get_args(annotation):
-                if arg not in (None, type(None)):
-                    annotation = arg
-                    break
+            if isinstance(annotation, (OptionalType, UnionType)):
+                for arg in get_args(annotation):
+                    if arg not in (None, type(None)):
+                        annotation = arg
+                        break
 
-            if isinstance(annotation, _AnnotatedAlias):
+            if isinstance(annotation, AnnotatedType):
                 annotation = get_args(annotation)[0]
 
             # Ensure that the annotation is a builtin type

--- a/optimade/validator/config.py
+++ b/optimade/validator/config.py
@@ -34,7 +34,7 @@ __all__ = ("ValidatorConfig", "VALIDATOR_CONFIG")
 
 _ENTRY_SCHEMAS = {
     endp: retrieve_queryable_properties(
-        ENTRY_INFO_SCHEMAS[endp](), ("id", "type", "attributes")
+        ENTRY_INFO_SCHEMAS[endp](mode="validation"), ("id", "type", "attributes")
     )
     for endp in ENTRY_INFO_SCHEMAS
 }

--- a/optimade/validator/config.py
+++ b/optimade/validator/config.py
@@ -10,7 +10,8 @@ the hardcoded values.
 from collections.abc import Container
 from typing import Any
 
-from pydantic import BaseSettings, Field
+from pydantic import Field
+from pydantic_settings import BaseSettings
 
 from optimade.models import (
     DataType,

--- a/optimade/validator/config.py
+++ b/optimade/validator/config.py
@@ -34,7 +34,7 @@ __all__ = ("ValidatorConfig", "VALIDATOR_CONFIG")
 
 _ENTRY_SCHEMAS = {
     endp: retrieve_queryable_properties(
-        ENTRY_INFO_SCHEMAS[endp](mode="validation"), ("id", "type", "attributes")
+        ENTRY_INFO_SCHEMAS[endp], ("id", "type", "attributes")
     )
     for endp in ENTRY_INFO_SCHEMAS
 }

--- a/optimade/validator/utils.py
+++ b/optimade/validator/utils.py
@@ -17,8 +17,7 @@ import sys
 import time
 import traceback as tb
 import urllib.parse
-from collections.abc import Callable
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 import requests
 from pydantic import Field, ValidationError

--- a/optimade/validator/utils.py
+++ b/optimade/validator/utils.py
@@ -11,14 +11,14 @@ used by the validator. The two main features being:
    themselves.
 
 """
-
 import dataclasses
 import json
 import sys
 import time
 import traceback as tb
 import urllib.parse
-from typing import Any, Callable, Optional
+from collections.abc import Callable
+from typing import Any, Optional
 
 import requests
 from pydantic import Field, ValidationError

--- a/optimade/validator/validator.py
+++ b/optimade/validator/validator.py
@@ -973,7 +973,7 @@ class ImplementationValidator:
                 request=request_str,
             )
             if deserialized:
-                return deserialized.dict()
+                return deserialized.model_dump()
 
         return False
 

--- a/optimade/validator/validator.py
+++ b/optimade/validator/validator.py
@@ -13,7 +13,7 @@ import random
 import re
 import sys
 import urllib.parse
-from typing import Any, Optional, Union
+from typing import Any, Literal, Optional, Union
 
 import requests
 
@@ -953,7 +953,9 @@ class ImplementationValidator:
 
         return True, f"{prop} passed filter tests"
 
-    def _test_info_or_links_endpoint(self, request_str: str) -> Union[bool, dict]:
+    def _test_info_or_links_endpoint(
+        self, request_str: str
+    ) -> Union[Literal[False], dict]:
         """Requests an info or links endpoint and attempts to deserialize
         the response.
 

--- a/optimade_config.json
+++ b/optimade_config.json
@@ -6,6 +6,7 @@
         "name": "Example implementation",
         "source_url": "https://github.com/Materials-Consortia/optimade-python-tools",
         "issue_tracker": "https://github.com/Materials-Consortia/optimade-python-tools/issues",
+        "homepage": "https://optimade.org/optimade-python-tools",
         "maintainer": {"email": "dev@optimade.org"}
     },
     "provider": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ docs = [
     "mkdocs~=1.4",
     "mkdocs-awesome-pages-plugin~=2.8",
     "mkdocs-material~=9.0",
-    "mkdocstrings[python-legacy]~=0.20",
+    "mkdocstrings[python]~=0.20",
 ]
 
 testing = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,7 +141,6 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 plugins = "pydantic.mypy"
 ignore_missing_imports = true
 follow_imports = "skip"
-check-untyped-defs = true
 
 [tool.pytest.ini_options]
 filterwarnings = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ server = [
     "uvicorn[standard]~=0.19",
     "fastapi>=0.103.1",
     "pyyaml~=6.0",
+    "typing-extensions~=4.8",
     "optimade[mongo]",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,8 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
     "lark~=1.1",
-    "pydantic~=1.10,>=1.10.2,!=1.10.7",
-    "email_validator>=1.2",
+    "pydantic[email]~=2.0",
+    "pydantic-settings~=2.0",
     "requests~=2.28",
 ]
 
@@ -157,6 +157,7 @@ filterwarnings = [
     "ignore:.*has an unrecognised prefix.*:",
     "ignore:.*pkg_resources is deprecated as an API*:DeprecationWarning",
     "ignore:.*Deprecated call to `pkg_resources.declare_namespace*:DeprecationWarning",
+    "ignore:.*:pydantic.warnings.PydanticDeprecatedSince20",
 ]
 testpaths = "tests"
 addopts = "-rs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,11 +85,8 @@ cif = ["numpy>=1.20"]
 # we don't support pydantic v2 yet, but pymatgen has a (uncessary IMO) tight coupling to mp-api which now enforces it
 # as "true" users of pydantic, if we can't update our stuff to v2 (including all the fieldinfo hacks) then we will
 # probably just have to hard pin or remove pymatgen support
-pymatgen = [
-    "pymatgen>=2022",
-    "mp-api<=0.36",
-    "emmet-core<=0.68"
-]
+# UPDATE: As of v2023.9.25, pymatgen no longer depends on mp-api.
+pymatgen = ["pymatgen>=2022"]
 jarvis = ["jarvis-tools>=2023.1.8"]
 client = ["optimade[cif]"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,6 +141,7 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 plugins = "pydantic.mypy"
 ignore_missing_imports = true
 follow_imports = "skip"
+check-untyped-defs = true
 
 [tool.pytest.ini_options]
 filterwarnings = [
@@ -158,7 +159,6 @@ filterwarnings = [
     "ignore:.*has an unrecognised prefix.*:",
     "ignore:.*pkg_resources is deprecated as an API*:DeprecationWarning",
     "ignore:.*Deprecated call to `pkg_resources.declare_namespace*:DeprecationWarning",
-    "ignore:.*:pydantic.warnings.PydanticDeprecatedSince20",
 ]
 testpaths = "tests"
 addopts = "-rs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,6 @@ server = [
     "uvicorn[standard]~=0.19",
     "fastapi>=0.103.1",
     "pyyaml~=6.0",
-    "typing-extensions~=4.8",
     "optimade[mongo]",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ server = [
 # Client minded
 aiida = ["aiida-core~=2.1"]
 
-http_client = [
+http-client = [
     "httpx~=0.23",
     "rich~=13.0",
     "click~=8.1",
@@ -117,10 +117,14 @@ dev = [
    "invoke~=2.0",
    "types-all==1.0.0",
    "ruff~=0.0",
-   "optimade[docs,testing,client,http_client]"
+   "optimade[docs,testing,client,http-client]"
 ]
 
-all = ["optimade[dev,elastic,aiida,ase,pymatgen,jarvis,http_client,client]"]
+http_client = [
+   "optimade[http-client]"
+]
+
+all = ["optimade[dev,elastic,aiida,ase,pymatgen,jarvis,http-client,client]"]
 
 
 [tool.ruff]

--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -1,7 +1,5 @@
 aiida-core==2.4.0
 ase==3.22.1
-emmet_core==0.68.0
 jarvis-tools==2023.9.20
-mp-api==0.36.1
 numpy>=1.20
-pymatgen==2023.9.10
+pymatgen==2023.10.11

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -2,4 +2,4 @@ mike==1.1.2
 mkdocs==1.5.3
 mkdocs-awesome-pages-plugin==2.9.2
 mkdocs-material==9.4.2
-mkdocstrings[python-legacy]==0.23.0
+mkdocstrings[python]==0.23.0

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -3,4 +3,3 @@ elasticsearch-dsl==7.4.0
 fastapi==0.103.1
 mongomock==4.1.2
 pymongo==4.5.0
-typing-extensions==4.8.0

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -3,3 +3,4 @@ elasticsearch-dsl==7.4.0
 fastapi==0.103.1
 mongomock==4.1.2
 pymongo==4.5.0
+typing-extensions==4.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-email_validator==2.0.0.post2
 lark==1.1.7
-pydantic==1.10.9
+pydantic[email]==2.3.0
+pydantic_settings==2.0.3
 pyyaml==6.0
 requests==2.31.0
 uvicorn==0.23.2

--- a/tasks.py
+++ b/tasks.py
@@ -3,7 +3,7 @@ import os
 import re
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Union
 
 from invoke import task
 from jsondiff import diff
@@ -15,7 +15,9 @@ if TYPE_CHECKING:
 TOP_DIR = Path(__file__).parent.resolve()
 
 
-def update_file(filename: str, sub_line: tuple[str, str], strip: Optional[str] = None):
+def update_file(
+    filename: Union[Path, str], sub_line: tuple[str, str], strip: Optional[str] = None
+):
     """Utility function for tasks to read, update, and write files"""
     with open(filename) as handle:
         lines = [
@@ -273,7 +275,7 @@ def create_api_reference_docs(context, pre_clean=False, pre_commit=False):
         # Check if there have been any changes.
         # List changes if yes.
         if TYPE_CHECKING:
-            context: "Context" = context
+            context: "Context" = context  # type: ignore[no-redef]
 
         # NOTE: grep returns an exit code of 1 if it doesn't find anything
         # (which will be good in this case).

--- a/tests/adapters/references/conftest.py
+++ b/tests/adapters/references/conftest.py
@@ -1,26 +1,35 @@
-import json
-from pathlib import Path
-from random import choice
+from typing import TYPE_CHECKING
 
 import pytest
 
-from optimade.adapters.references import Reference
+if TYPE_CHECKING:
+    from typing import Any
+
+    from optimade.adapters.references import Reference
 
 
 @pytest.fixture
-def RAW_REFERENCES():
+def RAW_REFERENCES() -> "list[dict[str, Any]]":
     """Read and return raw_references.json"""
-    with open(Path(__file__).parent.joinpath("raw_test_references.json")) as raw_data:
-        return json.load(raw_data)
+    import json
+    from pathlib import Path
+
+    return json.loads(
+        Path(__file__).parent.joinpath("raw_test_references.json").read_bytes()
+    )
 
 
 @pytest.fixture
-def raw_reference(RAW_REFERENCES):
+def raw_reference(RAW_REFERENCES: "list[dict[str, Any]]") -> "dict[str, Any]":
     """Return random raw reference from raw_references.json"""
+    from random import choice
+
     return choice(RAW_REFERENCES)
 
 
 @pytest.fixture
-def reference(raw_reference):
+def reference(raw_reference: "dict[str, Any]") -> "Reference":
     """Create and return adapters.Reference"""
+    from optimade.adapters.references import Reference
+
     return Reference(raw_reference)

--- a/tests/adapters/references/test_references.py
+++ b/tests/adapters/references/test_references.py
@@ -1,26 +1,35 @@
 """Test Reference adapter"""
+from typing import TYPE_CHECKING
+
 import pytest
 
-from optimade.adapters import Reference
-from optimade.models import ReferenceResource
+if TYPE_CHECKING:
+    from typing import Any, Union
+
+    from optimade.adapters.references import Reference
 
 
-def test_instantiate(RAW_REFERENCES):
+def test_instantiate(RAW_REFERENCES: "list[dict[str, Any]]") -> None:
     """Try instantiating Reference for all raw test references"""
+    from optimade.adapters.references import Reference
+    from optimade.models.references import ReferenceResource
+
     for reference in RAW_REFERENCES:
         new_Reference = Reference(reference)
         assert isinstance(new_Reference.entry, ReferenceResource)
 
 
-def test_setting_entry(caplog, RAW_REFERENCES):
+def test_setting_entry(RAW_REFERENCES: "list[dict[str, Any]]") -> None:
     """Make sure entry can only be set once"""
+    from optimade.adapters.references import Reference
+
     reference = Reference(RAW_REFERENCES[0])
-    reference.entry = RAW_REFERENCES[1]
-    assert "entry can only be set once and is already set." in caplog.text
+    with pytest.raises(AttributeError):
+        reference.entry = RAW_REFERENCES[1]
 
 
 @pytest.mark.skip("Currently, there are no conversion types available for references")
-def test_convert(reference):
+def test_convert(reference: "Reference") -> None:
     """Test convert() works
     Choose currently known entry type - must be updated if no longer available.
     """
@@ -40,15 +49,16 @@ def test_convert(reference):
     assert converted_reference == reference._converted[chosen_type]
 
 
-def test_convert_wrong_format(reference):
+def test_convert_wrong_format(reference: "Reference") -> None:
     """Test AttributeError is raised if format does not exist"""
-    nonexistant_format = 0
+    nonexistant_format: "Union[str, int]" = 0
     right_wrong_format_found = False
     while not right_wrong_format_found:
         if str(nonexistant_format) not in reference._type_converters:
             nonexistant_format = str(nonexistant_format)
             right_wrong_format_found = True
         else:
+            assert isinstance(nonexistant_format, int)
             nonexistant_format += 1
 
     with pytest.raises(
@@ -58,7 +68,7 @@ def test_convert_wrong_format(reference):
         reference.convert(nonexistant_format)
 
 
-def test_getattr_order(reference):
+def test_getattr_order(reference: "Reference") -> None:
     """The order of getting an attribute should be:
     1. `as_<entry type format>`
     2. `<entry type attribute>`

--- a/tests/adapters/structures/conftest.py
+++ b/tests/adapters/structures/conftest.py
@@ -1,47 +1,64 @@
-import json
-from pathlib import Path
-from random import choice
+from typing import TYPE_CHECKING
 
 import pytest
 
-from optimade.adapters.structures import Structure
+if TYPE_CHECKING:
+    from typing import Any
+
+    from optimade.adapters.structures import Structure
 
 
 @pytest.fixture
-def RAW_STRUCTURES() -> list[dict]:
+def RAW_STRUCTURES() -> "list[dict[str, Any]]":
     """Read and return raw_structures.json"""
-    with open(Path(__file__).parent.joinpath("raw_test_structures.json")) as raw_data:
-        return json.load(raw_data)
+    import json
+    from pathlib import Path
+
+    return json.loads(
+        Path(__file__).parent.joinpath("raw_test_structures.json").read_bytes()
+    )
 
 
 @pytest.fixture
-def SPECIAL_SPECIES_STRUCTURES() -> list[dict]:
+def SPECIAL_SPECIES_STRUCTURES() -> "list[dict[str, Any]]":
     """Read and return special_species.json"""
-    with open(Path(__file__).parent.joinpath("special_species.json")) as raw_data:
-        return json.load(raw_data)
+    import json
+    from pathlib import Path
+
+    return json.loads(
+        Path(__file__).parent.joinpath("special_species.json").read_bytes()
+    )
 
 
 @pytest.fixture
-def raw_structure(RAW_STRUCTURES) -> dict:
+def raw_structure(RAW_STRUCTURES: "list[dict[str, Any]]") -> "dict[str, Any]":
     """Return random raw structure from raw_structures.json"""
+    from random import choice
+
     return choice(RAW_STRUCTURES)
 
 
 @pytest.fixture
-def structure(raw_structure) -> Structure:
+def structure(raw_structure: "dict[str, Any]") -> "Structure":
     """Create and return adapters.Structure"""
+    from optimade.adapters.structures import Structure
+
     return Structure(raw_structure)
 
 
 @pytest.fixture
-def structures(RAW_STRUCTURES) -> list[Structure]:
+def structures(RAW_STRUCTURES: "list[dict[str, Any]]") -> "list[Structure]":
     """Create and return list of adapters.Structure"""
+    from optimade.adapters.structures import Structure
+
     return [Structure(_) for _ in RAW_STRUCTURES]
 
 
 @pytest.fixture
-def null_lattice_vector_structure(raw_structure) -> Structure:
+def null_lattice_vector_structure(raw_structure: "dict[str, Any]") -> "Structure":
     """Create and return adapters.Structure with lattice_vectors that have None values"""
+    from optimade.adapters.structures import Structure
+
     raw_structure["attributes"]["lattice_vectors"][0] = [None] * 3
     raw_structure["attributes"]["dimension_types"][0] = 0
     raw_structure["attributes"]["nperiodic_dimensions"] = sum(
@@ -51,6 +68,9 @@ def null_lattice_vector_structure(raw_structure) -> Structure:
 
 
 @pytest.fixture
-def null_species_structure(raw_structure) -> Structure:
+def null_species_structure(raw_structure: "dict[str, Any]") -> "Structure":
+    """Create and return Structure with species that have None values"""
+    from optimade.adapters.structures import Structure
+
     raw_structure["attributes"]["species"] = None
     return Structure(raw_structure)

--- a/tests/adapters/structures/special_species.json
+++ b/tests/adapters/structures/special_species.json
@@ -46,7 +46,7 @@
         ],
         "nsites": 1,
         "species_at_sites": [
-        "Ac"
+            "Ac"
         ],
         "species": [
         {

--- a/tests/adapters/structures/test_ase.py
+++ b/tests/adapters/structures/test_ase.py
@@ -59,7 +59,7 @@ def test_extra_info_keys(RAW_STRUCTURES):
     assert atoms.info["another_key"] == [1, 2, 3]
     assert atoms.info["_key_without_ase_prefix"] == [4, 5, 6]
 
-    roundtrip_structure = Structure.ingest_from(atoms).attributes.dict()
+    roundtrip_structure = Structure.ingest_from(atoms).attributes.model_dump()
     assert roundtrip_structure["_ase_key"] == "some value"
     assert roundtrip_structure["_ase_another_key"] == [1, 2, 3]
 

--- a/tests/adapters/structures/test_structures.py
+++ b/tests/adapters/structures/test_structures.py
@@ -178,7 +178,7 @@ def compare_lossy_conversion(
                 "numpy not found, some cases of conversion tests will be skipped"
             )
         )
-        np = None  # type: ignore[assignment]
+        np = None
 
     lossy_keys = (
         "chemical_formula_descriptive",

--- a/tests/adapters/structures/test_structures.py
+++ b/tests/adapters/structures/test_structures.py
@@ -138,11 +138,12 @@ def test_common_converters(raw_structure, RAW_STRUCTURES):
     """Test common converters"""
     structure = Structure(raw_structure)
 
-    assert structure.as_json == StructureResource(**raw_structure).json()
-    assert structure.as_dict == StructureResource(**raw_structure).dict()
+    assert structure.as_json == StructureResource(**raw_structure).model_dump_json()
+    assert structure.as_dict == StructureResource(**raw_structure).model_dump()
 
-    # Since calling .dict() and .json() will return also all default-valued properties,
-    # the raw structure should at least be a sub-set of the resource's full list of properties.
+    # Since calling .model_dump() and .model_dump_json() will return also all
+    # default-valued properties, the raw structure should at least be a sub-set of the
+    # resource's full list of properties.
     for raw_structure in RAW_STRUCTURES:
         raw_structure_property_set = set(raw_structure.keys())
         resource_property_set = set(Structure(raw_structure).as_dict.keys())
@@ -209,7 +210,7 @@ def test_two_way_conversion(RAW_STRUCTURES, format):
             continue
         reconverted_structure = Structure.ingest_from(
             converted_structure, format
-        ).entry.dict()
+        ).entry.model_dump()
         compare_lossy_conversion(
             structure["attributes"], reconverted_structure["attributes"]
         )
@@ -227,7 +228,7 @@ def test_two_way_conversion_with_implicit_type(RAW_STRUCTURES, format):
             continue
         reconverted_structure = Structure.ingest_from(
             converted_structure, format=None
-        ).entry.dict()
+        ).entry.model_dump()
 
         compare_lossy_conversion(
             structure["attributes"], reconverted_structure["attributes"]

--- a/tests/adapters/structures/test_utils.py
+++ b/tests/adapters/structures/test_utils.py
@@ -123,7 +123,9 @@ def test_scaled_cell_consistency(structures):
 def test_species_from_species_at_sites():
     """Test that species can be inferred from species_at_sites"""
     species_at_sites = ["Si"]
-    assert [d.dict() for d in species_from_species_at_sites(species_at_sites)] == [
+    assert [
+        d.model_dump() for d in species_from_species_at_sites(species_at_sites)
+    ] == [
         {
             "name": "Si",
             "concentration": [1.0],
@@ -137,7 +139,7 @@ def test_species_from_species_at_sites():
 
     species_at_sites = ["Si", "Si", "O", "O", "O", "O"]
     assert sorted(
-        [d.dict() for d in species_from_species_at_sites(species_at_sites)],
+        [d.model_dump() for d in species_from_species_at_sites(species_at_sites)],
         key=lambda _: _["name"],
     ) == sorted(
         [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,9 +5,13 @@ from typing import TYPE_CHECKING
 import pytest
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from typing import Protocol
 
     from optimade.server.mappers import BaseResourceMapper
+
+    class MapperInner(Protocol):
+        def __call__(self, name: str) -> type[BaseResourceMapper]:
+            ...
 
 
 def pytest_configure(config):
@@ -23,14 +27,14 @@ def top_dir() -> Path:
 
 
 @pytest.fixture(scope="module")
-def mapper() -> "Callable[[str], BaseResourceMapper]":
+def mapper() -> "MapperInner":
     """Mapper-factory to import a mapper from optimade.server.mappers"""
     from optimade.server import mappers
 
-    def _mapper(name: str) -> mappers.BaseResourceMapper:
+    def _mapper(name: str) -> type[mappers.BaseResourceMapper]:
         """Return named resource mapper"""
         try:
-            res: mappers.BaseResourceMapper = getattr(mappers, name)
+            res: type[mappers.BaseResourceMapper] = getattr(mappers, name)
         except AttributeError:
             pytest.fail(f"Could not retrieve {name!r} from optimade.server.mappers.")
         return res

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,6 @@ def mapper() -> "Callable[[str], BaseResourceMapper]":
             res: mappers.BaseResourceMapper = getattr(mappers, name)
         except AttributeError:
             pytest.fail(f"Could not retrieve {name!r} from optimade.server.mappers.")
-        else:
-            return res
+        return res
 
     return _mapper

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,13 @@
 import os
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from optimade.server.mappers import BaseResourceMapper
 
 
 def pytest_configure(config):
@@ -17,14 +23,14 @@ def top_dir() -> Path:
 
 
 @pytest.fixture(scope="module")
-def mapper():
+def mapper() -> "Callable[[str], BaseResourceMapper]":
     """Mapper-factory to import a mapper from optimade.server.mappers"""
     from optimade.server import mappers
 
-    def _mapper(name: str) -> mappers.BaseResourceMapper:  # type: ignore[return]
+    def _mapper(name: str) -> mappers.BaseResourceMapper:
         """Return named resource mapper"""
         try:
-            res = getattr(mappers, name)
+            res: mappers.BaseResourceMapper = getattr(mappers, name)
         except AttributeError:
             pytest.fail(f"Could not retrieve {name!r} from optimade.server.mappers.")
         else:

--- a/tests/filtertransformers/test_base.py
+++ b/tests/filtertransformers/test_base.py
@@ -13,7 +13,7 @@ def test_quantity_builder(mapper: "Callable[[str], type[BaseResourceMapper]]") -
     class DummyTransformer(BaseTransformer):
         pass
 
-    class AwkwardMapper(mapper("StructureMapper")):  # type: ignore[misc]
+    class AwkwardMapper(mapper("StructureMapper")):
         ALIASES = (("elements", "my_elements"), ("nelements", "nelem"))
         LENGTH_ALIASES = (
             ("chemsys", "nelements"),

--- a/tests/filtertransformers/test_base.py
+++ b/tests/filtertransformers/test_base.py
@@ -1,11 +1,19 @@
-from optimade.filtertransformers import BaseTransformer
+"""Tests for optimade.filtertransformers.BaseTransformer"""
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from optimade.server.mappers import BaseResourceMapper
 
 
-def test_quantity_builder(mapper):
+def test_quantity_builder(mapper: "Callable[[str], type[BaseResourceMapper]]") -> None:
+    from optimade.filtertransformers.base_transformer import BaseTransformer, Quantity
+
     class DummyTransformer(BaseTransformer):
         pass
 
-    class AwkwardMapper(mapper("StructureMapper")):
+    class AwkwardMapper(mapper("StructureMapper")):  # type: ignore[misc]
         ALIASES = (("elements", "my_elements"), ("nelements", "nelem"))
         LENGTH_ALIASES = (
             ("chemsys", "nelements"),
@@ -18,9 +26,14 @@ def test_quantity_builder(mapper):
     t = DummyTransformer(mapper=m)
 
     assert "_exmpl_chemsys" in t.quantities
+    assert isinstance(t.quantities["_exmpl_chemsys"], Quantity)
     assert t.quantities["_exmpl_chemsys"].name == "_exmpl_chemsys"
     assert t.quantities["_exmpl_chemsys"].backend_field == "chemsys"
+
+    assert isinstance(t.quantities["_exmpl_chemsys"].length_quantity, Quantity)
     assert t.quantities["_exmpl_chemsys"].length_quantity.name == "nelements"
     assert t.quantities["_exmpl_chemsys"].length_quantity.backend_field == "nelem"
 
+    assert isinstance(t.quantities["elements"], Quantity)
+    assert isinstance(t.quantities["elements"].length_quantity, Quantity)
     assert t.quantities["elements"].length_quantity.backend_field == "nelem"

--- a/tests/filtertransformers/test_base.py
+++ b/tests/filtertransformers/test_base.py
@@ -2,7 +2,7 @@
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from typing import Callable
 
     from optimade.server.mappers import BaseResourceMapper
 

--- a/tests/models/test_structures.py
+++ b/tests/models/test_structures.py
@@ -3,14 +3,12 @@ import itertools
 from typing import TYPE_CHECKING
 
 import pytest
-from pydantic import ValidationError
 
-from optimade.models.structures import CORRELATED_STRUCTURE_FIELDS, StructureResource
 from optimade.warnings import MissingExpectedField
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-    from typing import Any, Dict, List, Optional, Tuple
+    from collections.abc import Callable, Generator
+    from typing import Any, Optional
 
     from optimade.server.mappers import BaseResourceMapper
 
@@ -18,11 +16,13 @@ MAPPER = "StructureMapper"
 
 
 @pytest.mark.filterwarnings("ignore", category=MissingExpectedField)
-def test_good_structure_with_missing_data(good_structure: "Dict[str, Any]") -> None:
+def test_good_structure_with_missing_data(good_structure: "dict[str, Any]") -> None:
     """Check deserialization of well-formed structure used
     as example data with all combinations of null values
     in non-mandatory fields.
     """
+    from optimade.models.structures import StructureResource
+
     structure = {field: good_structure[field] for field in good_structure}
 
     # Have to include `assemblies` here, although it is only optional,
@@ -45,10 +45,14 @@ def test_good_structure_with_missing_data(good_structure: "Dict[str, Any]") -> N
 
 
 def test_more_good_structures(
-    good_structures: "List[Dict[str, Any]]",
+    good_structures: "list[dict[str, Any]]",
     mapper: "Callable[[str], BaseResourceMapper]",
 ) -> None:
     """Check well-formed structures with specific edge-cases"""
+    from pydantic import ValidationError
+
+    from optimade.models.structures import StructureResource
+
     for index, structure in enumerate(good_structures):
         try:
             StructureResource(**mapper(MAPPER).map_back(structure))
@@ -61,7 +65,7 @@ def test_more_good_structures(
 
 
 def test_bad_structures(
-    bad_structures: "List[Dict[str, Any]]",
+    bad_structures: "list[dict[str, Any]]",
     mapper: "Callable[[str], BaseResourceMapper]",
 ) -> None:
     """Check badly formed structures.
@@ -71,6 +75,10 @@ def test_bad_structures(
     https://docs.pydantic.dev/latest/concepts/validators/#handling-errors-in-validators
     for more information.
     """
+    from pydantic import ValidationError
+
+    from optimade.models.structures import StructureResource
+
     with pytest.warns(MissingExpectedField):
         for index, structure in enumerate(bad_structures):
             # This is for helping devs finding any errors that may occur
@@ -196,13 +204,17 @@ deformities = (
 
 @pytest.mark.parametrize("deformity", deformities)
 def test_structure_fatal_deformities(
-    good_structure: "Dict[str, Any]", deformity: "Optional[Tuple[Dict[str, str], str]]"
+    good_structure: "dict[str, Any]", deformity: "Optional[tuple[dict[str, str], str]]"
 ) -> None:
     """Make specific checks upon performing single invalidating deformations
     of the data of a good structure.
 
     """
     import re
+
+    from pydantic import ValidationError
+
+    from optimade.models.structures import StructureResource
 
     if deformity is None:
         StructureResource(**good_structure)
@@ -214,18 +226,22 @@ def test_structure_fatal_deformities(
         StructureResource(**good_structure)
 
 
-minor_deformities = (
-    {f: None} for f in {f for _ in CORRELATED_STRUCTURE_FIELDS for f in _}
-)
+def _minor_deformities() -> "Generator[dict[str, Any], None, None]":
+    """Generate minor deformities from correlated structure fields"""
+    from optimade.models.structures import CORRELATED_STRUCTURE_FIELDS
+
+    return ({f: None} for f in set(f for _ in CORRELATED_STRUCTURE_FIELDS for f in _))
 
 
-@pytest.mark.parametrize("deformity", minor_deformities)
+@pytest.mark.parametrize("deformity", _minor_deformities())
 def test_structure_minor_deformities(
-    good_structure: "Dict[str, Any]", deformity: "Optional[Tuple[Dict[str, str], str]]"
+    good_structure: "dict[str, Any]", deformity: "Optional[dict[str, Any]]"
 ) -> None:
     """Make specific checks upon performing single minor invalidations
     of the data of a good structure that should emit warnings.
     """
+    from optimade.models.structures import StructureResource
+
     if deformity is None:
         StructureResource(**good_structure)
     else:

--- a/tests/models/test_structures.py
+++ b/tests/models/test_structures.py
@@ -230,7 +230,7 @@ def _minor_deformities() -> "Generator[dict[str, Any], None, None]":
     """Generate minor deformities from correlated structure fields"""
     from optimade.models.structures import CORRELATED_STRUCTURE_FIELDS
 
-    return ({f: None} for f in set(f for _ in CORRELATED_STRUCTURE_FIELDS for f in _))
+    return ({f: None} for f in {f for _ in CORRELATED_STRUCTURE_FIELDS for f in _})
 
 
 @pytest.mark.parametrize("deformity", _minor_deformities())

--- a/tests/models/test_utils.py
+++ b/tests/models/test_utils.py
@@ -71,8 +71,8 @@ def test_compatible_strict_optimade_field() -> None:
             sortable=True,
         )
 
-    optimade_schema = CorrectModelWithOptimadeField.schema()
-    strict_schema = CorrectModelWithStrictField.schema()
+    optimade_schema = CorrectModelWithOptimadeField.model_json_schema()
+    strict_schema = CorrectModelWithStrictField.model_json_schema()
     strict_schema["title"] = optimade_schema["title"]
     assert strict_schema == optimade_schema
 
@@ -87,7 +87,7 @@ def test_formula_regexp() -> None:
     from optimade.models.utils import CHEMICAL_FORMULA_REGEXP
 
     class DummyModel(BaseModel):
-        formula: str = Field(regex=CHEMICAL_FORMULA_REGEXP)
+        formula: str = Field(pattern=CHEMICAL_FORMULA_REGEXP)
 
     good_formulae = (
         "AgCl",

--- a/tests/models/test_utils.py
+++ b/tests/models/test_utils.py
@@ -75,8 +75,8 @@ def test_compatible_strict_optimade_field() -> None:
             sortable=True,
         )
 
-    optimade_schema = CorrectModelWithOptimadeField.model_json_schema()
-    strict_schema = CorrectModelWithStrictField.model_json_schema()
+    optimade_schema = CorrectModelWithOptimadeField.model_json_schema(mode="validation")
+    strict_schema = CorrectModelWithStrictField.model_json_schema(mode="validation")
     strict_schema["title"] = optimade_schema["title"]
     assert strict_schema == optimade_schema
 

--- a/tests/models/test_utils.py
+++ b/tests/models/test_utils.py
@@ -43,6 +43,10 @@ def test_compatible_strict_optimade_field() -> None:
     produce the same schemas when given the same arguments.
 
     """
+    from optimade.models.utils import (
+        OPTIMADE_SCHEMA_EXTENSION_KEYS,
+        OPTIMADE_SCHEMA_EXTENSION_PREFIX,
+    )
 
     class CorrectModelWithStrictField(BaseModel):
         # check that unit and uniqueItems are passed through
@@ -51,7 +55,7 @@ def test_compatible_strict_optimade_field() -> None:
             support=SupportLevel.MUST,
             queryable=SupportLevel.OPTIONAL,
             description="Unit test to make sure that StrictField allows through OptimadeField keys",
-            pattern="^structures$",
+            # pattern="^structures$",  # pattern is only allowed for string type
             unit="stringiness",
             uniqueItems=True,
             sortable=True,
@@ -65,7 +69,7 @@ def test_compatible_strict_optimade_field() -> None:
             support="must",
             queryable="optional",
             description="Unit test to make sure that StrictField allows through OptimadeField keys",
-            pattern="^structures$",
+            # pattern="^structures$",  # pattern is only allowed for string type
             uniqueItems=True,
             unit="stringiness",
             sortable=True,
@@ -75,6 +79,23 @@ def test_compatible_strict_optimade_field() -> None:
     strict_schema = CorrectModelWithStrictField.model_json_schema()
     strict_schema["title"] = optimade_schema["title"]
     assert strict_schema == optimade_schema
+
+    assert "uniqueItems" in strict_schema["properties"]["good_field"]
+    assert (
+        "uniqueItems"
+        in CorrectModelWithStrictField.model_fields["good_field"].json_schema_extra
+    )
+
+    for key in OPTIMADE_SCHEMA_EXTENSION_KEYS:
+        assert key not in strict_schema["properties"]["good_field"]
+        assert (
+            f"{OPTIMADE_SCHEMA_EXTENSION_PREFIX}{key}"
+            in CorrectModelWithStrictField.model_fields["good_field"].json_schema_extra
+        )
+        assert (
+            f"{OPTIMADE_SCHEMA_EXTENSION_PREFIX}{key}"
+            in strict_schema["properties"]["good_field"]
+        )
 
 
 def test_formula_regexp() -> None:

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -179,7 +179,7 @@ def check_response(get_good_response):
                 for key in warn:
                     assert response["meta"]["warnings"][ind][key] == warn[key]
         else:
-            assert "warnings" not in response["meta"]
+            assert "warnings" not in response["meta"], response["meta"]["warnings"]
 
         return response
 

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -5,7 +5,7 @@ import pytest
 from optimade.warnings import OptimadeWarning
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from typing import Callable
 
     from requests import Response
 

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -1,12 +1,19 @@
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 import pytest
 
 from optimade.warnings import OptimadeWarning
 
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from requests import Response
+
+    from .utils import OptimadeTestClient
+
 
 @pytest.fixture(scope="session")
-def client():
+def client() -> "OptimadeTestClient":
     """Return TestClient for the regular OPTIMADE server"""
     from .utils import client_factory
 
@@ -14,7 +21,7 @@ def client():
 
 
 @pytest.fixture(scope="session")
-def index_client():
+def index_client() -> "OptimadeTestClient":
     """Return TestClient for the index OPTIMADE server"""
     from .utils import client_factory
 
@@ -22,7 +29,9 @@ def index_client():
 
 
 @pytest.fixture(scope="session", params=["regular"])
-def client_with_empty_extension_endpoint(request):
+def client_with_empty_extension_endpoint(
+    request: pytest.FixtureRequest,
+) -> "OptimadeTestClient":
     """Return TestClient for the regular OPTIMADE server with an additional
     empty test endpoint added at `/extensions/test_empty_body`.
     """
@@ -32,7 +41,7 @@ def client_with_empty_extension_endpoint(request):
 
 
 @pytest.fixture(scope="session", params=["regular", "index"])
-def both_clients(request):
+def both_clients(request: pytest.FixtureRequest) -> "OptimadeTestClient":
     """Return TestClient for both the regular and index OPTIMADE server"""
     from .utils import client_factory
 
@@ -40,7 +49,7 @@ def both_clients(request):
 
 
 @pytest.fixture(scope="session", params=["regular", "index"])
-def both_fake_remote_clients(request):
+def both_fake_remote_clients(request: pytest.FixtureRequest) -> "OptimadeTestClient":
     """Return TestClient for both the regular and index OPTIMADE server, with
     the additional option `raise_server_exceptions` set to `False`, to mimic a
     remote webserver.
@@ -52,7 +61,9 @@ def both_fake_remote_clients(request):
 
 
 @pytest.fixture
-def get_good_response(client, index_client):
+def get_good_response(
+    client: "OptimadeTestClient", index_client: "OptimadeTestClient"
+) -> "Callable[[str, Union[str, OptimadeTestClient], bool], Union[dict, Response]]":
     """Get response with some sanity checks, expecting '200 OK'"""
     import json
 

--- a/tests/server/entry_collections/test_entry_collections.py
+++ b/tests/server/entry_collections/test_entry_collections.py
@@ -21,6 +21,6 @@ def test_get_attribute_fields():
 
     for entry_name, attributes_model in entry_name_attributes.items():
         assert (
-            set(attributes_model.__fields__.keys())
+            set(attributes_model.model_fields.keys())
             == ENTRY_COLLECTIONS[entry_name].get_attribute_fields()
         )

--- a/tests/server/middleware/test_warnings.py
+++ b/tests/server/middleware/test_warnings.py
@@ -1,7 +1,15 @@
 """Test `AddWarning` middleware."""
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pytest import WarningsRecorder
+
+    from ..utils import OptimadeTestClient
 
 
-def test_showwarning_overload(both_clients, recwarn):
+def test_showwarning_overload(
+    both_clients: "OptimadeTestClient", recwarn: "WarningsRecorder"
+) -> None:
     """Make sure warnings.showwarning can be overloaded correctly"""
     import warnings
 
@@ -25,7 +33,7 @@ def test_showwarning_overload(both_clients, recwarn):
     # Make sure a "normal" warning is treated as usual
     warnings.warn(warning_message, UserWarning)
     assert len(add_warning_middleware._warnings) == 1
-    assert len(recwarn.list) == 2
+    assert len(recwarn.list) == 2, ", ".join(str(_) for _ in recwarn.list)
     assert recwarn.pop(OptimadeWarning)
     assert recwarn.pop(UserWarning)
 

--- a/tests/server/routers/test_utils.py
+++ b/tests/server/routers/test_utils.py
@@ -20,7 +20,7 @@ def mocked_providers_list_response(
         https://stackoverflow.com/questions/15753390/how-can-i-mock-requests-and-the-response
     """
     try:
-        from optimade.server.data import providers  # type: ignore[attr-defined]
+        from optimade.server.data import providers
     except ImportError:
         pytest.fail(
             "Cannot import providers from optimade.server.data, "

--- a/tests/server/test_client.py
+++ b/tests/server/test_client.py
@@ -1,6 +1,4 @@
 """This module uses the reference test server to test the OPTIMADE client."""
-
-
 import json
 import warnings
 from functools import partial
@@ -480,7 +478,7 @@ def test_list_properties(
 
     results = cli.list_properties("structures")
     for database in results:
-        assert len(results[database]) == 22
+        assert len(results[database]) == 22, str(results[database])
 
     results = cli.search_property("structures", "site")
     for database in results:

--- a/tests/server/test_config.py
+++ b/tests/server/test_config.py
@@ -2,9 +2,13 @@
 import json
 import os
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .utils import OptimadeTestClient
 
 
-def test_env_variable():
+def test_env_variable() -> None:
     """Set OPTIMADE_DEBUG environment variable and check CONFIG picks up on it correctly"""
     from optimade.server.config import ServerConfig
 
@@ -25,7 +29,7 @@ def test_env_variable():
             assert os.getenv("OPTIMADE_DEBUG") is None
 
 
-def test_default_config_path(top_dir):
+def test_default_config_path(top_dir: Path) -> None:
     """Make sure the default config path works
     Expected default config path: PATH/TO/USER/HOMEDIR/.optimade.json
     """
@@ -75,7 +79,7 @@ def test_default_config_path(top_dir):
             os.environ["OPTIMADE_CONFIG_FILE"] = org_env_var
 
 
-def test_debug_is_respected_when_off(both_clients):
+def test_debug_is_respected_when_off(both_clients: "OptimadeTestClient") -> None:
     """Make sure traceback is toggleable according to debug mode - here OFF
 
     TODO: This should be moved to a separate test file that tests the exception handlers.
@@ -102,7 +106,7 @@ def test_debug_is_respected_when_off(both_clients):
         CONFIG.debug = org_value
 
 
-def test_debug_is_respected_when_on(both_clients):
+def test_debug_is_respected_when_on(both_clients: "OptimadeTestClient") -> None:
     """Make sure traceback is toggleable according to debug mode - here ON
 
     TODO: This should be moved to a separate test file that tests the exception handlers.
@@ -128,7 +132,7 @@ def test_debug_is_respected_when_on(both_clients):
         CONFIG.debug = org_value
 
 
-def test_yaml_config_file():
+def test_yaml_config_file() -> None:
     """Test loading a YAML config file
 
     First, pass a correctly formatted YAML file that only includes a single YAML document.

--- a/tests/server/test_schemas.py
+++ b/tests/server/test_schemas.py
@@ -1,45 +1,50 @@
-from optimade.server.schemas import ENTRY_INFO_SCHEMAS, retrieve_queryable_properties
+"""Tests for optimade.server.schemas"""
 
 
-def test_schemas():
+def test_schemas() -> None:
     """Test that the default `ENTRY_INFO_SCHEMAS` contain
     all the required information about the OPTIMADE properties
     after dereferencing.
 
     """
+    from optimade.models.entries import EntryResourceAttributes
+    from optimade.server.schemas import (
+        ENTRY_INFO_SCHEMAS,
+        retrieve_queryable_properties,
+    )
+
     for entry in ("Structures", "References"):
-        schema = ENTRY_INFO_SCHEMAS[entry.lower()](mode="validation")
+        schema = ENTRY_INFO_SCHEMAS[entry.lower()]
 
         top_level_props = ("id", "type", "attributes")
         properties = retrieve_queryable_properties(schema, top_level_props)
 
-        fields = list(
-            schema["definitions"][f"{entry[:-1]}ResourceAttributes"][
-                "properties"
-            ].keys()
-        )
+        attributes_annotation = schema.model_fields["attributes"].annotation
+        assert issubclass(attributes_annotation, EntryResourceAttributes)
+        fields = list(attributes_annotation.model_fields)
         fields += ["id", "type"]
 
         # Check all fields are present
         assert all(field in properties for field in fields)
-
-        # Check that there are no references to definitions remaining
-        assert "$ref" not in properties
-        assert not any("$ref" in properties[field] for field in properties)
 
         # Check that all expected keys are present for OPTIMADE fields
         for key in ("type", "sortable", "queryable", "description"):
             assert all(key in properties[field] for field in properties)
 
 
-def test_provider_field_schemas():
+def test_provider_field_schemas() -> None:
     """Tests that the default configured provider fields that have descriptions
     are dereferenced appropriately.
 
     """
+    from optimade.server.schemas import (
+        ENTRY_INFO_SCHEMAS,
+        retrieve_queryable_properties,
+    )
+
     entry = "structures"
     test_field = "chemsys"
-    schema = ENTRY_INFO_SCHEMAS[entry](mode="validation")
+    schema = ENTRY_INFO_SCHEMAS[entry]
     top_level_props = ("id", "type", "attributes")
     properties = retrieve_queryable_properties(schema, top_level_props, entry)
     name = f"_exmpl_{test_field}"

--- a/tests/server/test_schemas.py
+++ b/tests/server/test_schemas.py
@@ -1,7 +1,7 @@
 """Tests for optimade.server.schemas"""
 
 
-def test_schemas() -> None:
+def test_retrieve_queryable_properties() -> None:
     """Test that the default `ENTRY_INFO_SCHEMAS` contain
     all the required information about the OPTIMADE properties
     after dereferencing.
@@ -30,6 +30,9 @@ def test_schemas() -> None:
         # Check that all expected keys are present for OPTIMADE fields
         for key in ("type", "sortable", "queryable", "description"):
             assert all(key in properties[field] for field in properties)
+
+        # Check that all fields are queryable
+        assert all(properties[field]["queryable"] for field in properties)
 
 
 def test_provider_field_schemas() -> None:

--- a/tests/server/test_schemas.py
+++ b/tests/server/test_schemas.py
@@ -8,7 +8,7 @@ def test_schemas():
 
     """
     for entry in ("Structures", "References"):
-        schema = ENTRY_INFO_SCHEMAS[entry.lower()]()
+        schema = ENTRY_INFO_SCHEMAS[entry.lower()](mode="validation")
 
         top_level_props = ("id", "type", "attributes")
         properties = retrieve_queryable_properties(schema, top_level_props)
@@ -39,7 +39,7 @@ def test_provider_field_schemas():
     """
     entry = "structures"
     test_field = "chemsys"
-    schema = ENTRY_INFO_SCHEMAS[entry]()
+    schema = ENTRY_INFO_SCHEMAS[entry](mode="validation")
     top_level_props = ("id", "type", "attributes")
     properties = retrieve_queryable_properties(schema, top_level_props, entry)
     name = f"_exmpl_{test_field}"

--- a/tests/server/test_server_validation.py
+++ b/tests/server/test_server_validation.py
@@ -1,14 +1,18 @@
 import dataclasses
 import json
+from typing import TYPE_CHECKING
 
 import pytest
 
 from optimade.validator import ImplementationValidator
 
+if TYPE_CHECKING:
+    from .utils import OptimadeTestClient
+
 pytestmark = pytest.mark.filterwarnings("ignore")
 
 
-def test_with_validator(both_fake_remote_clients):
+def test_with_validator(both_fake_remote_clients: "OptimadeTestClient") -> None:
     from optimade.server.main_index import app
 
     validator = ImplementationValidator(
@@ -20,7 +24,9 @@ def test_with_validator(both_fake_remote_clients):
     assert validator.valid
 
 
-def test_with_validator_skip_optional(both_fake_remote_clients):
+def test_with_validator_skip_optional(
+    both_fake_remote_clients: "OptimadeTestClient",
+) -> None:
     from optimade.server.main_index import app
 
     validator = ImplementationValidator(
@@ -33,7 +39,9 @@ def test_with_validator_skip_optional(both_fake_remote_clients):
     assert validator.valid
 
 
-def test_with_validator_json_response(both_fake_remote_clients, capsys):
+def test_with_validator_json_response(
+    both_fake_remote_clients: "OptimadeTestClient", capsys: pytest.CaptureFixture
+) -> None:
     """Test that the validator writes compliant JSON when requested."""
     from optimade.server.main_index import app
 
@@ -56,7 +64,9 @@ def test_with_validator_json_response(both_fake_remote_clients, capsys):
     assert validator.valid
 
 
-def test_as_type_with_validator(client, capsys):
+def test_as_type_with_validator(
+    client: "OptimadeTestClient", capsys: pytest.CaptureFixture
+) -> None:
     from unittest.mock import Mock, patch
 
     test_urls = {
@@ -87,7 +97,7 @@ def test_as_type_with_validator(client, capsys):
             assert dataclasses.asdict(validator.results) == json_response
 
 
-def test_query_value_formatting(client):
+def test_query_value_formatting() -> None:
     from optimade.models.optimade_json import DataType
 
     format_value_fn = ImplementationValidator._format_test_value
@@ -103,7 +113,9 @@ def test_query_value_formatting(client):
 
 
 @pytest.mark.parametrize("server", ["regular", "index"])
-def test_versioned_base_urls(client, index_client, server: str):
+def test_versioned_base_urls(
+    client: "OptimadeTestClient", index_client: "OptimadeTestClient", server: str
+) -> None:
     """Test all expected versioned base URLs responds with 200
 
     This depends on the routers for each kind of server.
@@ -137,7 +149,9 @@ def test_versioned_base_urls(client, index_client, server: str):
 
 
 @pytest.mark.parametrize("server", ["regular", "index"])
-def test_meta_schema_value_obeys_index(client, index_client, server: str):
+def test_meta_schema_value_obeys_index(
+    client: "OptimadeTestClient", index_client: "OptimadeTestClient", server: str
+) -> None:
     """Test that the reported `meta->schema` is correct for index/non-index
     servers.
     """

--- a/tests/server/utils.py
+++ b/tests/server/utils.py
@@ -1,19 +1,34 @@
 import json
 import re
 import warnings
-from collections.abc import Iterable
-from typing import Optional, Union
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 import httpx
 import pytest
 import requests
 from fastapi.testclient import TestClient
-from starlette import testclient
 
-import optimade.models.jsonapi as jsonapi
 from optimade import __api_version__
 from optimade.models import ResponseMeta
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from typing import Optional, Protocol, Type, Union
+
+    from starlette import testclient
+
+    import optimade.models.jsonapi as jsonapi
+
+    class ClientFactoryInner(Protocol):
+        def __call__(
+            self,
+            version: "Optional[str]" = None,
+            server: str = "regular",
+            raise_server_exceptions: bool = True,
+            add_empty_endpoint: bool = False,
+        ) -> "OptimadeTestClient":
+            ...
 
 
 class OptimadeTestClient(TestClient):
@@ -26,7 +41,7 @@ class OptimadeTestClient(TestClient):
 
     def __init__(
         self,
-        app: Union[testclient.ASGI2App, testclient.ASGI3App],
+        app: "Union[testclient.ASGI2App, testclient.ASGI3App]",
         base_url: str = "http://example.org",
         raise_server_exceptions: bool = True,
         root_path: str = "",
@@ -75,14 +90,13 @@ class OptimadeTestClient(TestClient):
 class BaseEndpointTests:
     """Base class for common tests of endpoints"""
 
-    request_str: Optional[str] = None
-    response_cls: Optional[type[jsonapi.Response]] = None
-
-    response: Optional[httpx.Response] = None
-    json_response: Optional[dict] = None
+    request_str: "Optional[str]" = None
+    response_cls: "Optional[Type[jsonapi.Response]]" = None
+    response: "Optional[httpx.Response]" = None
+    json_response: "Optional[dict]" = None
 
     @staticmethod
-    def check_keys(keys: list, response_subset: Iterable):
+    def check_keys(keys: list, response_subset: "Iterable[str]"):
         for key in keys:
             assert (
                 key in response_subset
@@ -102,8 +116,7 @@ class BaseEndpointTests:
             "required"
         ]
         meta_optional_keys = list(
-            set(ResponseMeta.model_json_schema(mode="validation")["properties"].keys())
-            - set(meta_required_keys)
+            set(ResponseMeta.model_fields) - set(meta_required_keys)
         )
         implemented_optional_keys = [
             "time_stamp",
@@ -111,7 +124,7 @@ class BaseEndpointTests:
             "provider",
             "data_available",
             "implementation",
-            "schema",
+            # "optimade_schema",
             # TODO: These keys are not implemented in the example server implementations
             # Add them in when they are.
             # "last_id",
@@ -164,11 +177,11 @@ class IndexEndpointTests(BaseEndpointTests):
         self.json_response = None
 
 
-def client_factory():
+def client_factory() -> "ClientFactoryInner":
     """Return TestClient for OPTIMADE server"""
 
     def inner(
-        version: Optional[str] = None,
+        version: "Optional[str]" = None,
         server: str = "regular",
         raise_server_exceptions: bool = True,
         add_empty_endpoint: bool = False,
@@ -226,10 +239,9 @@ def client_factory():
 class NoJsonEndpointTests:
     """A simplified mixin class for tests on non-JSON endpoints."""
 
-    request_str: Optional[str] = None
-    response_cls: Optional[type] = None
-
-    response: Optional[httpx.Response] = None
+    request_str: "Optional[str]" = None
+    response_cls: "Optional[Type]" = None
+    response: "Optional[httpx.Response]" = None
 
     @pytest.fixture(autouse=True)
     def get_response(self, both_clients):

--- a/tests/server/utils.py
+++ b/tests/server/utils.py
@@ -98,9 +98,10 @@ class BaseEndpointTests:
     def test_meta_response(self):
         """General test for `meta` property in response"""
         assert "meta" in self.json_response
-        meta_required_keys = ResponseMeta.schema()["required"]
+        meta_required_keys = ResponseMeta.model_json_schema()["required"]
         meta_optional_keys = list(
-            set(ResponseMeta.schema()["properties"].keys()) - set(meta_required_keys)
+            set(ResponseMeta.model_json_schema()["properties"].keys())
+            - set(meta_required_keys)
         )
         implemented_optional_keys = [
             "time_stamp",

--- a/tests/server/utils.py
+++ b/tests/server/utils.py
@@ -98,9 +98,11 @@ class BaseEndpointTests:
     def test_meta_response(self):
         """General test for `meta` property in response"""
         assert "meta" in self.json_response
-        meta_required_keys = ResponseMeta.model_json_schema()["required"]
+        meta_required_keys = ResponseMeta.model_json_schema(mode="validation")[
+            "required"
+        ]
         meta_optional_keys = list(
-            set(ResponseMeta.model_json_schema()["properties"].keys())
+            set(ResponseMeta.model_json_schema(mode="validation")["properties"].keys())
             - set(meta_required_keys)
         )
         implemented_optional_keys = [


### PR DESCRIPTION
This PR contains my WIP attempts to migrate to pydantic v2.

As we were doing some hacky stuff with pydantic internals, this process is not straightforward. 

The three current stumbling blocks are 
a) how we define `StrictField` and `OptimadeField` to do injection/removal of certain keys from the final JSONSchema/OpenAPI schemas, which is currently completely broken by the new pydantic-core.
b) complicated `Class Config` instances we currently use (only deprecated at the moment, so can get away with this for a bit longer) -- I've modified some already and they seem to work
c) the standard issues supporting pymatgen as a dependency (waiting for their sub-deps to update)

Outside of that, this PR basically:

- [x] refactors settings around the new `pydantic_settings` package
- [x] switches out `regex` for `pattern`
- [x] runs `bump-pydantic` to update several validators
- [x] changes all validators to use the new v2 format
- [x] defines some types in a more pydantic way, using `Annotated`