### PR TITLE
Add option for custom landing pages

### DIFF
--- a/optimade/server/config.py
+++ b/optimade/server/config.py
@@ -273,6 +273,11 @@ class ServerConfig(BaseSettings):
         ),
     )
 
+    custom_landing_page: Optional[Union[str, Path]] = Field(
+        None,
+        description="The location of a custom landing page (Jinja template) to use for the API.",
+    )
+
     index_schema_url: Optional[Union[str, AnyHttpUrl]] = Field(
         f"https://schemas.optimade.org/openapi/v{__api_version__}/optimade_index.json",
         description=(

--- a/optimade/server/routers/landing.py
+++ b/optimade/server/routers/landing.py
@@ -30,9 +30,11 @@ def render_landing_page(url: str) -> HTMLResponse:
     major_version = __api_version__.split(".")[0]
     versioned_url = f"{get_base_url(url)}/v{major_version}/"
 
-    template_dir = Path(__file__).parent.joinpath("static").resolve()
-
-    html = (template_dir / "landing_page.html").read_text()
+    if CONFIG.custom_landing_page:
+        html = Path(CONFIG.custom_landing_page).resolve().read_text()
+    else:
+        template_dir = Path(__file__).parent.joinpath("static").resolve()
+        html = (template_dir / "landing_page.html").read_text()
 
     # Build a dictionary that maps the old Jinja keys to the new simplified replacements
     replacements = {


### PR DESCRIPTION
It can be quite useful to host a custom landing page that is more informative than our default. This PR allows for the specification of the path of any Jinja2 template.

We could consider passing the whole app context to the template, but perhaps this is overkill for now, and having hardcoded values in the custom template can get you a long way.