### PR TITLE
Add mp-api and emmet pins to avoid premature pydantic v2 upgrade

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ cif = ["numpy>=1.20"]
 # we don't support pydantic v2 yet, but pymatgen has a (uncessary IMO) tight coupling to mp-api which now enforces it
 # as "true" users of pydantic, if we can't update our stuff to v2 (including all the fieldinfo hacks) then we will
 # probably just have to hard pin or remove pymatgen support
-pymatgen = ["pymatgen>=2022", "mp-api<=0.36"]
+pymatgen = ["pymatgen>=2022", "mp-api<=0.36", "emmet-core<=0.68"]
 jarvis = ["jarvis-tools>=2023.1.8"]
 client = ["optimade[cif]"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,11 @@ cif = ["numpy>=1.20"]
 # we don't support pydantic v2 yet, but pymatgen has a (uncessary IMO) tight coupling to mp-api which now enforces it
 # as "true" users of pydantic, if we can't update our stuff to v2 (including all the fieldinfo hacks) then we will
 # probably just have to hard pin or remove pymatgen support
-pymatgen = ["pymatgen>=2022", "mp-api<=0.36", "emmet-core<=0.68"]
+pymatgen = [
+    "pymatgen>=2022",
+    "mp-api<=0.36",
+    "emmet-core<=0.68"
+]
 jarvis = ["jarvis-tools>=2023.1.8"]
 client = ["optimade[cif]"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,10 @@ http_client = [
 
 ase = ["ase~=3.22"]
 cif = ["numpy>=1.20"]
-pymatgen = ["pymatgen>=2022"]
+# we don't support pydantic v2 yet, but pymatgen has a (uncessary IMO) tight coupling to mp-api which now enforces it
+# as "true" users of pydantic, if we can't update our stuff to v2 (including all the fieldinfo hacks) then we will
+# probably just have to hard pin or remove pymatgen support
+pymatgen = ["pymatgen>=2022", "mp-api<=0.36"]
 jarvis = ["jarvis-tools>=2023.1.8"]
 client = ["optimade[cif]"]
 

--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -1,5 +1,6 @@
 aiida-core==2.4.0
 ase==3.22.1
 jarvis-tools==2023.8.10
+mp-api==0.36.1
 numpy>=1.20
 pymatgen==2023.9.10

--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -1,5 +1,6 @@
 aiida-core==2.4.0
 ase==3.22.1
+emmet_core==0.68.0
 jarvis-tools==2023.8.10
 mp-api==0.36.1
 numpy>=1.20

--- a/tests/adapters/structures/utils.py
+++ b/tests/adapters/structures/utils.py
@@ -9,6 +9,6 @@ def get_min_ver(dependency: str) -> str:
         for line in setup_file.readlines():
             min_ver = re.findall(rf'"{dependency}((=|!|<|>|~)=|>|<)(.+)"', line)
             if min_ver:
-                return min_ver[0][2].split(";")[0].split(",")[0]
+                return min_ver[0][2].split(";")[0].split(",")[0].strip('"')
         else:
             raise RuntimeError(f"Cannot find {dependency} dependency in pyproject.toml")


### PR DESCRIPTION
c.f. https://github.com/Materials-Consortia/optimade-python-tools/pull/1745#issuecomment-1737815676