### PR TITLE
Modernize all Python 3.8 annotations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,10 @@ jobs:
       with:
         submodules: true
 
-    - name: Set up Python 3.10
+    - name: Set up Python 3.9
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.9'
         cache: 'pip'
         cache-dependency-path: |
           requirements*.txt
@@ -56,10 +56,10 @@ jobs:
       with:
         submodules: true
 
-    - name: Set up Python 3.10
+    - name: Set up Python 3.9
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.9'
         cache: 'pip'
         cache-dependency-path: |
           requirements*.txt
@@ -227,27 +227,27 @@ jobs:
       run: pytest -rs -vvv --cov=./optimade/ --cov-report=xml --cov-append tests/adapters/
 
     - name: Run tests for validator only to assess coverage (mongomock)
-      if: matrix.python-version == 3.10
+      if: matrix.python-version == 3.9
       run: pytest -rs --cov=./optimade/ --cov-report=xml:validator_cov.xml --cov-append tests/server/test_server_validation.py
       env:
         OPTIMADE_DATABASE_BACKEND: 'mongomock'
 
     - name: Run tests for validator only to assess coverage (Elasticsearch)
-      if: matrix.python-version == 3.10
+      if: matrix.python-version == 3.9
       run: pytest -rs --cov=./optimade/ --cov-report=xml:validator_cov.xml --cov-append tests/server/test_server_validation.py
       env:
         OPTIMADE_DATABASE_BACKEND: 'elastic'
         OPTIMADE_INSERT_TEST_DATA: false # Must be specified as previous steps will have already inserted the test data
 
     - name: Run tests for validator only to assess coverage (MongoDB)
-      if: matrix.python-version == 3.10
+      if: matrix.python-version == 3.9
       run: pytest -rs --cov=./optimade/ --cov-report=xml:validator_cov.xml --cov-append tests/server/test_server_validation.py
       env:
         OPTIMADE_DATABASE_BACKEND: 'mongodb'
         OPTIMADE_INSERT_TEST_DATA: false # Must be specified as previous steps will have already inserted the test data
 
     - name: Run the OPTIMADE Client CLI
-      if: matrix.python-version == 3.10
+      if: matrix.python-version == 3.9
       run: |
         coverage run --append --source optimade optimade/client/cli.py \
            --filter 'nsites = 1' \
@@ -275,7 +275,7 @@ jobs:
         coverage xml
 
     - name: Upload coverage to Codecov
-      if: matrix.python-version == '3.10' && github.repository == 'Materials-Consortia/optimade-python-tools'
+      if: matrix.python-version == '3.9' && github.repository == 'Materials-Consortia/optimade-python-tools'
       uses: codecov/codecov-action@v3
       with:
         name: project
@@ -283,7 +283,7 @@ jobs:
         flags: project
 
     - name: Upload validator coverage to Codecov
-      if: matrix.python-version == '3.10' && github.repository == 'Materials-Consortia/optimade-python-tools'
+      if: matrix.python-version == '3.9' && github.repository == 'Materials-Consortia/optimade-python-tools'
       uses: codecov/codecov-action@v3
       with:
         name: validator
@@ -300,7 +300,7 @@ jobs:
 
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.9'
         cache: 'pip'
         cache-dependency-path: |
           requirements*.txt
@@ -330,10 +330,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: Set up Python 3.10
+    - name: Set up Python 3.9
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.9'
         cache: 'pip'
         cache-dependency-path: |
           requirements*.txt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       name: Blacken
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
     - id: check-symlinks
     - id: check-yaml
@@ -30,7 +30,7 @@ repos:
       args: ["--py39-plus"]
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: 'v0.0.291'
+    rev: 'v0.0.292'
     hooks:
     - id: ruff
       args: [--fix]
@@ -52,7 +52,7 @@ repos:
       description: Update the API Reference documentation whenever a Python file is touched in the code base.
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.5.1
+    rev: v1.6.0
     hooks:
       - id: mypy
         name: "MyPy"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
     rev: 'v0.0.292'
     hooks:
     - id: ruff
-      args: [--fix]
+      args: [--fix, --exit-non-zero-on-fix]
 
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: python3.10
+  python: python3.9
 
 repos:
   - repo: https://github.com/ambv/black
@@ -22,6 +22,12 @@ repos:
       files: ^requirements.*\.txt$
     - id: trailing-whitespace
       args: [--markdown-linebreak-ext=md]
+
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.15.0
+    hooks:
+    - id: pyupgrade
+      args: ["--py39-plus"]
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: 'v0.0.291'

--- a/optimade/adapters/base.py
+++ b/optimade/adapters/base.py
@@ -19,7 +19,7 @@ resources can be converted to for [`ReferenceResource`][optimade.models.referenc
 and [`StructureResource`][optimade.models.structures.StructureResource]s, respectively.
 """
 import re
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
+from typing import Any, Callable, Optional, Union
 
 from pydantic import BaseModel  # pylint: disable=no-name-in-module
 
@@ -42,10 +42,10 @@ class EntryAdapter:
 
     """
 
-    ENTRY_RESOURCE: Type[EntryResource] = EntryResource
-    _type_converters: Dict[str, Callable] = {}
-    _type_ingesters: Dict[str, Callable] = {}
-    _type_ingesters_by_type: Dict[str, Type] = {}
+    ENTRY_RESOURCE: type[EntryResource] = EntryResource
+    _type_converters: dict[str, Callable] = {}
+    _type_ingesters: dict[str, Callable] = {}
+    _type_ingesters_by_type: dict[str, type] = {}
 
     def __init__(self, entry: dict) -> None:
         """
@@ -53,7 +53,7 @@ class EntryAdapter:
             entry (dict): A JSON OPTIMADE single resource entry.
         """
         self._entry: Optional[EntryResource] = None
-        self._converted: Dict[str, Any] = {}
+        self._converted: dict[str, Any] = {}
 
         self.entry: EntryResource = entry  # type: ignore[assignment]
 
@@ -164,7 +164,7 @@ class EntryAdapter:
 
     @staticmethod
     def _get_model_attributes(
-        starting_instances: Union[Tuple[BaseModel, ...], List[BaseModel]], name: str
+        starting_instances: Union[tuple[BaseModel, ...], list[BaseModel]], name: str
     ) -> Any:
         """Helper method for retrieving the OPTIMADE model's attribute, supporting "."-nested attributes"""
         for res in starting_instances:

--- a/optimade/adapters/references/adapter.py
+++ b/optimade/adapters/references/adapter.py
@@ -1,5 +1,3 @@
-from typing import Type
-
 from optimade.adapters.base import EntryAdapter
 from optimade.models import ReferenceResource
 
@@ -21,4 +19,4 @@ class Reference(EntryAdapter):
 
     """
 
-    ENTRY_RESOURCE: Type[ReferenceResource] = ReferenceResource
+    ENTRY_RESOURCE: type[ReferenceResource] = ReferenceResource

--- a/optimade/adapters/structures/adapter.py
+++ b/optimade/adapters/structures/adapter.py
@@ -1,4 +1,4 @@
-from typing import Callable, Dict, Type
+from typing import Callable
 
 from optimade.adapters.base import EntryAdapter
 from optimade.models import StructureResource
@@ -44,8 +44,8 @@ class Structure(EntryAdapter):
 
     """
 
-    ENTRY_RESOURCE: Type[StructureResource] = StructureResource
-    _type_converters: Dict[str, Callable] = {
+    ENTRY_RESOURCE: type[StructureResource] = StructureResource
+    _type_converters: dict[str, Callable] = {
         "aiida_structuredata": get_aiida_structure_data,
         "ase": get_ase_atoms,
         "cif": get_cif,
@@ -55,12 +55,12 @@ class Structure(EntryAdapter):
         "jarvis": get_jarvis_atoms,
     }
 
-    _type_ingesters: Dict[str, Callable] = {
+    _type_ingesters: dict[str, Callable] = {
         "pymatgen": from_pymatgen,
         "ase": from_ase_atoms,
     }
 
-    _type_ingesters_by_type: Dict[str, Type] = {
+    _type_ingesters_by_type: dict[str, type] = {
         "pymatgen": PymatgenStructure,
         "ase": ASEAtoms,
     }

--- a/optimade/adapters/structures/aiida.py
+++ b/optimade/adapters/structures/aiida.py
@@ -7,7 +7,7 @@ For more information on the AiiDA code see [their website](http://www.aiida.net)
 
 This conversion function relies on the [`aiida-core`](https://github.com/aiidateam/aiida-core) package.
 """
-from typing import List, Optional
+from typing import Optional
 from warnings import warn
 
 from optimade.adapters.structures.utils import pad_cell, species_from_species_at_sites
@@ -48,7 +48,7 @@ def get_aiida_structure_data(optimade_structure: OptimadeStructure) -> Structure
     structure = StructureData(cell=lattice_vectors)
 
     # If species not provided, infer data from species_at_sites
-    species: Optional[List[OptimadeStructureSpecies]] = attributes.species
+    species: Optional[list[OptimadeStructureSpecies]] = attributes.species
     if not species:
         species = species_from_species_at_sites(attributes.species_at_sites)  # type: ignore[arg-type]
 

--- a/optimade/adapters/structures/ase.py
+++ b/optimade/adapters/structures/ase.py
@@ -7,7 +7,6 @@ This conversion function relies on the ASE code.
 
 For more information on the ASE code see [their documentation](https://wiki.fysik.dtu.dk/ase/).
 """
-from typing import Dict
 
 from optimade.adapters.exceptions import ConversionError
 from optimade.adapters.structures.utils import (
@@ -66,7 +65,7 @@ def get_ase_atoms(optimade_structure: OptimadeStructure) -> Atoms:
     if not species:
         species = species_from_species_at_sites(attributes.species_at_sites)  # type: ignore[arg-type]
 
-    optimade_species: Dict[str, OptimadeStructureSpecies] = {_.name: _ for _ in species}
+    optimade_species: dict[str, OptimadeStructureSpecies] = {_.name: _ for _ in species}
 
     # Since we've made sure there are no species with more than 1 chemical symbol,
     # asking for index 0 will always work.

--- a/optimade/adapters/structures/cif.py
+++ b/optimade/adapters/structures/cif.py
@@ -16,7 +16,6 @@ Note:
 
 This conversion function relies on the [NumPy](https://numpy.org/) library.
 """
-from typing import Dict
 
 from optimade.adapters.structures.utils import (
     cell_to_cellpar,
@@ -123,11 +122,11 @@ def get_cif(  # pylint: disable=too-many-locals,too-many-branches
     else:
         sites = attributes.cartesian_site_positions
 
-    species: Dict[str, OptimadeStructureSpecies] = {
+    species: dict[str, OptimadeStructureSpecies] = {
         species.name: species for species in attributes.species  # type: ignore[union-attr]
     }
 
-    symbol_occurences: Dict[str, int] = {}
+    symbol_occurences: dict[str, int] = {}
     for site_number in range(attributes.nsites):  # type: ignore[arg-type]
         species_name = attributes.species_at_sites[site_number]  # type: ignore[index]
         site = sites[site_number]

--- a/optimade/adapters/structures/proteindatabank.py
+++ b/optimade/adapters/structures/proteindatabank.py
@@ -21,7 +21,6 @@ These conversion functions both rely on the [NumPy](https://numpy.org/) library.
 Warning:
     Currently, the PDBx/mmCIF conversion function is not parsing as a complete PDBx/mmCIF file.
 """
-from typing import Dict
 
 try:
     import numpy as np
@@ -164,7 +163,7 @@ def get_pdbx_mmcif(  # pylint: disable=too-many-locals
     else:
         sites = attributes.cartesian_site_positions
 
-    species: Dict[str, OptimadeStructureSpecies] = {
+    species: dict[str, OptimadeStructureSpecies] = {
         species.name: species for species in attributes.species  # type: ignore[union-attr]
     }
 
@@ -240,7 +239,7 @@ def get_pdb(  # pylint: disable=too-many-locals
 
     pdb += "MODEL     1\n"
 
-    species: Dict[str, OptimadeStructureSpecies] = {
+    species: dict[str, OptimadeStructureSpecies] = {
         species.name: species
         for species in attributes.species  # type:ignore[union-attr]
     }

--- a/optimade/adapters/structures/pymatgen.py
+++ b/optimade/adapters/structures/pymatgen.py
@@ -7,7 +7,7 @@ This conversion function relies on the [pymatgen](https://github.com/materialspr
 
 For more information on the pymatgen code see [their documentation](https://pymatgen.org).
 """
-from typing import Dict, List, Optional, Union
+from typing import Optional, Union
 
 from optimade.adapters.structures.utils import (
     species_from_species_at_sites,
@@ -105,9 +105,9 @@ def _get_molecule(optimade_structure: OptimadeStructure) -> Molecule:
 
 def _pymatgen_species(
     nsites: int,
-    species: Optional[List[OptimadeStructureSpecies]],
-    species_at_sites: List[str],
-) -> List[Dict[str, float]]:
+    species: Optional[list[OptimadeStructureSpecies]],
+    species_at_sites: list[str],
+) -> list[dict[str, float]]:
     """
     Create list of {"symbol": "concentration"} per site for values to pymatgen species parameters.
     Remove vacancies, if they are present.

--- a/optimade/adapters/structures/utils.py
+++ b/optimade/adapters/structures/utils.py
@@ -3,7 +3,8 @@ Utility functions to help the conversion functions along.
 
 Most of these functions rely on the [NumPy](https://numpy.org/) library.
 """
-from typing import Iterable, List, Optional, Tuple, Type
+from collections.abc import Iterable
+from typing import Optional
 
 from optimade.models.structures import Species as OptimadeStructureSpecies
 from optimade.models.structures import Vector3D
@@ -19,7 +20,7 @@ except ImportError:
     NUMPY_NOT_FOUND = "NumPy not found, cannot convert structure to your desired format"
 
 
-def valid_lattice_vector(lattice_vec: Tuple[Vector3D, Vector3D, Vector3D]):
+def valid_lattice_vector(lattice_vec: tuple[Vector3D, Vector3D, Vector3D]):
     if len(lattice_vec) != 3:
         return False
     for vector in lattice_vec:
@@ -31,8 +32,8 @@ def valid_lattice_vector(lattice_vec: Tuple[Vector3D, Vector3D, Vector3D]):
 
 
 def scaled_cell(
-    cell: Tuple[Vector3D, Vector3D, Vector3D]
-) -> Tuple[Vector3D, Vector3D, Vector3D]:
+    cell: tuple[Vector3D, Vector3D, Vector3D]
+) -> tuple[Vector3D, Vector3D, Vector3D]:
     """Return a scaled 3x3 cell from cartesian 3x3 cell (`lattice_vectors`).
     This 3x3 matrix can be used to calculate the fractional coordinates from the cartesian_site_positions.
 
@@ -62,8 +63,8 @@ def scaled_cell(
 
 
 def fractional_coordinates(
-    cell: Tuple[Vector3D, Vector3D, Vector3D], cartesian_positions: List[Vector3D]
-) -> List[Vector3D]:
+    cell: tuple[Vector3D, Vector3D, Vector3D], cartesian_positions: list[Vector3D]
+) -> list[Vector3D]:
     """Returns fractional coordinates and wraps coordinates to `[0,1[`.
 
     Note:
@@ -101,8 +102,8 @@ def fractional_coordinates(
 
 
 def cell_to_cellpar(
-    cell: Tuple[Vector3D, Vector3D, Vector3D], radians: bool = False
-) -> List[float]:
+    cell: tuple[Vector3D, Vector3D, Vector3D], radians: bool = False
+) -> list[float]:
     """Returns the cell parameters `[a, b, c, alpha, beta, gamma]`.
 
     Angles are in degrees unless `radian=True` is used.
@@ -161,10 +162,10 @@ def unit_vector(x: Vector3D) -> Vector3D:
 
 
 def cellpar_to_cell(
-    cellpar: List[float],
-    ab_normal: Tuple[int, int, int] = (0, 0, 1),
-    a_direction: Optional[Tuple[int, int, int]] = None,
-) -> List[Vector3D]:
+    cellpar: list[float],
+    ab_normal: tuple[int, int, int] = (0, 0, 1),
+    a_direction: Optional[tuple[int, int, int]] = None,
+) -> list[Vector3D]:
     """Return a 3x3 cell matrix from `cellpar=[a,b,c,alpha,beta,gamma]`.
 
     Angles must be in degrees.
@@ -277,9 +278,9 @@ def cellpar_to_cell(
 def _pad_iter_of_iters(
     iterable: Iterable[Iterable],
     padding: Optional[float] = None,
-    outer: Optional[Type] = None,
-    inner: Optional[Type] = None,
-) -> Tuple[Iterable[Iterable], bool]:
+    outer: Optional[type] = None,
+    inner: Optional[type] = None,
+) -> tuple[Iterable[Iterable], bool]:
     """Turn any null/None values into a float in given iterable of iterables"""
     try:
         padding = float(padding)  # type: ignore[arg-type]
@@ -306,7 +307,7 @@ def _pad_iter_of_iters(
 
 
 def pad_cell(
-    lattice_vectors: Tuple[Vector3D, Vector3D, Vector3D],
+    lattice_vectors: tuple[Vector3D, Vector3D, Vector3D],
     padding: Optional[float] = None,
 ) -> tuple:  # Setting this properly makes MkDocs fail.
     """Turn any `null`/`None` values into a `float` in given `tuple` of
@@ -333,8 +334,8 @@ def pad_cell(
 
 
 def species_from_species_at_sites(
-    species_at_sites: List[str],
-) -> List[OptimadeStructureSpecies]:
+    species_at_sites: list[str],
+) -> list[OptimadeStructureSpecies]:
     """When a list of species dictionaries is not provided, this function
     can be used to infer the species from the provided species_at_sites.
 
@@ -357,7 +358,7 @@ def species_from_species_at_sites(
     ]
 
 
-def elements_ratios_from_species_at_sites(species_at_sites: List[str]) -> List[float]:
+def elements_ratios_from_species_at_sites(species_at_sites: list[str]) -> list[float]:
     """Compute the OPTIMADE `elements_ratios` field from `species_at_sites` in the case where `species_at_sites` refers
     to sites wholly occupied by the given elements, e.g., not arbitrary species labels or with partial/mixed occupancy.
 

--- a/optimade/client/cli.py
+++ b/optimade/client/cli.py
@@ -166,13 +166,13 @@ def _get(
         base_urls=base_url,
         use_async=use_async,
         max_results_per_provider=max_results_per_provider,
-        include_providers=set(_.strip() for _ in include_providers.split(","))
+        include_providers={_.strip() for _ in include_providers.split(",")}
         if include_providers
         else None,
-        exclude_providers=set(_.strip() for _ in exclude_providers.split(","))
+        exclude_providers={_.strip() for _ in exclude_providers.split(",")}
         if exclude_providers
         else None,
-        exclude_databases=set(_.strip() for _ in exclude_databases.split(","))
+        exclude_databases={_.strip() for _ in exclude_databases.split(",")}
         if exclude_databases
         else None,
         silent=silent,
@@ -211,13 +211,15 @@ def _get(
 
     if not output_file:
         if pretty_print:
-            rich.print_json(data=results, indent=2, default=lambda _: _.dict())
+            rich.print_json(data=results, indent=2, default=lambda _: _.asdict())
         else:
-            sys.stdout.write(json.dumps(results, indent=2, default=lambda _: _.dict()))
+            sys.stdout.write(
+                json.dumps(results, indent=2, default=lambda _: _.asdict())
+            )
 
     if output_file:
         with open(output_file, "w") as f:
-            json.dump(results, f, indent=2, default=lambda _: _.dict())
+            json.dump(results, f, indent=2, default=lambda _: _.asdict())
 
 
 if __name__ == "__main__":

--- a/optimade/client/client.py
+++ b/optimade/client/client.py
@@ -10,18 +10,8 @@ import functools
 import json
 import time
 from collections import defaultdict
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Iterable,
-    List,
-    Optional,
-    Set,
-    Tuple,
-    Type,
-    Union,
-)
+from collections.abc import Iterable
+from typing import Any, Callable, Optional, Union
 from urllib.parse import urlparse
 
 # External deps that are only used in the client code
@@ -70,12 +60,12 @@ class OptimadeClient:
     base_urls: Union[str, Iterable[str]]
     """A list (or any iterable) of OPTIMADE base URLs to query."""
 
-    all_results: Dict[str, Dict[str, Dict[str, QueryResults]]] = defaultdict(dict)
+    all_results: dict[str, dict[str, dict[str, QueryResults]]] = defaultdict(dict)
     """A nested dictionary keyed by endpoint and OPTIMADE filter string that contains
     the results from each base URL for that particular filter.
     """
 
-    count_results: Dict[str, Dict[str, Dict[str, int]]] = defaultdict(dict)
+    count_results: dict[str, dict[str, dict[str, int]]] = defaultdict(dict)
     """A nested dictionary keyed by endpoint and OPTIMADE filter string that contains
     the number of results from each base URL for that particular filter.
     """
@@ -85,12 +75,12 @@ class OptimadeClient:
     download all.
     """
 
-    property_lists: Dict[str, Dict[str, List[str]]] = defaultdict(dict)
+    property_lists: dict[str, dict[str, list[str]]] = defaultdict(dict)
     """A dictionary containing list of properties served by each database,
     broken down by entry type, then database.
     """
 
-    headers: Dict = {"User-Agent": f"optimade-python-tools/{__version__}"}
+    headers: dict = {"User-Agent": f"optimade-python-tools/{__version__}"}
     """Additional HTTP headers."""
 
     http_timeout: httpx.Timeout = httpx.Timeout(10.0, read=1000.0)
@@ -102,7 +92,7 @@ class OptimadeClient:
     use_async: bool
     """Whether or not to make all requests asynchronously using asyncio."""
 
-    callbacks: Optional[List[Callable[[str, Dict], Union[None, Dict]]]] = None
+    callbacks: Optional[list[Callable[[str, dict], Union[None, dict]]]] = None
     """A list of callbacks to execute after each successful request, used
     to e.g., write to a file, add results to a database or perform additional
     filtering.
@@ -121,13 +111,13 @@ class OptimadeClient:
     silent: bool
     """Whether to disable progress bar printing."""
 
-    _excluded_providers: Optional[Set[str]] = None
+    _excluded_providers: Optional[set[str]] = None
     """A set of providers IDs excluded from future queries."""
 
-    _included_providers: Optional[Set[str]] = None
+    _included_providers: Optional[set[str]] = None
     """A set of providers IDs included from future queries."""
 
-    _excluded_databases: Optional[Set[str]] = None
+    _excluded_databases: Optional[set[str]] = None
     """A set of child database URLs excluded from future queries."""
 
     __current_endpoint: Optional[str] = None
@@ -135,7 +125,7 @@ class OptimadeClient:
     chosen endpoint. Should be reset to `None` outside of all `get()` calls."""
 
     _http_client: Optional[
-        Union[Type[httpx.AsyncClient], Type[requests.Session]]
+        Union[type[httpx.AsyncClient], type[requests.Session]]
     ] = None
     """Override the HTTP client class, primarily used for testing."""
 
@@ -148,18 +138,18 @@ class OptimadeClient:
         self,
         base_urls: Optional[Union[str, Iterable[str]]] = None,
         max_results_per_provider: int = 1000,
-        headers: Optional[Dict] = None,
+        headers: Optional[dict] = None,
         http_timeout: Optional[Union[httpx.Timeout, float]] = None,
         max_attempts: int = 5,
         use_async: bool = True,
         silent: bool = False,
-        exclude_providers: Optional[List[str]] = None,
-        include_providers: Optional[List[str]] = None,
-        exclude_databases: Optional[List[str]] = None,
+        exclude_providers: Optional[list[str]] = None,
+        include_providers: Optional[list[str]] = None,
+        exclude_databases: Optional[list[str]] = None,
         http_client: Optional[
-            Union[Type[httpx.AsyncClient], Type[requests.Session]]
+            Union[type[httpx.AsyncClient], type[requests.Session]]
         ] = None,
-        callbacks: Optional[List[Callable[[str, Dict], Union[None, Dict]]]] = None,
+        callbacks: Optional[list[Callable[[str, dict], Union[None, dict]]]] = None,
     ):
         """Create the OPTIMADE client object.
 
@@ -284,9 +274,9 @@ class OptimadeClient:
         self,
         filter: Optional[str] = None,
         endpoint: Optional[str] = None,
-        response_fields: Optional[List[str]] = None,
+        response_fields: Optional[list[str]] = None,
         sort: Optional[str] = None,
-    ) -> Dict[str, Dict[str, Dict[str, Dict]]]:
+    ) -> dict[str, dict[str, dict[str, dict]]]:
         """Gets the results from the endpoint and filter across the
         defined OPTIMADE APIs.
 
@@ -338,11 +328,11 @@ class OptimadeClient:
                 sort=sort,
             )
             self.all_results[endpoint][filter] = results
-            return {endpoint: {filter: {k: results[k].dict() for k in results}}}
+            return {endpoint: {filter: {k: results[k].asdict() for k in results}}}
 
     def count(
         self, filter: Optional[str] = None, endpoint: Optional[str] = None
-    ) -> Dict[str, Dict[str, Dict[str, Optional[int]]]]:
+    ) -> dict[str, dict[str, dict[str, Optional[int]]]]:
         """Counts the number of results for the filter, requiring
         only 1 request per provider by making use of the `meta->data_returned`
         key.
@@ -405,7 +395,7 @@ class OptimadeClient:
     def list_properties(
         self,
         entry_type: str,
-    ) -> Dict[str, List[str]]:
+    ) -> dict[str, list[str]]:
         """Returns the list of properties reported at `/info/<entry_type>`
         for the given entry type, for each database.
 
@@ -437,7 +427,7 @@ class OptimadeClient:
             )
         return self.property_lists[entry_type]
 
-    def search_property(self, query: str, entry_type: str) -> Dict[str, List[str]]:
+    def search_property(self, query: str, entry_type: str) -> dict[str, list[str]]:
         """Searches for the query substring within the listed properties
         served by each database.
 
@@ -453,7 +443,7 @@ class OptimadeClient:
         if not self.property_lists:
             self.list_properties(entry_type=entry_type)
 
-        matching_properties: Dict[str, Dict[str, List[str]]] = {
+        matching_properties: dict[str, dict[str, list[str]]] = {
             entry_type: defaultdict(list)
         }
         if entry_type in self.property_lists:
@@ -469,9 +459,9 @@ class OptimadeClient:
         endpoint: str,
         page_limit: Optional[int],
         paginate: bool,
-        response_fields: Optional[List[str]],
+        response_fields: Optional[list[str]],
         sort: Optional[str],
-    ) -> Dict[str, QueryResults]:
+    ) -> dict[str, QueryResults]:
         """Executes the queries over the base URLs either asynchronously or
         serially, depending on the `self.use_async` setting.
 
@@ -535,11 +525,11 @@ class OptimadeClient:
         endpoint: str,
         filter: str,
         base_url: str,
-        response_fields: Optional[List[str]] = None,
+        response_fields: Optional[list[str]] = None,
         sort: Optional[str] = None,
         page_limit: Optional[int] = None,
         paginate: bool = True,
-    ) -> Dict[str, QueryResults]:
+    ) -> dict[str, QueryResults]:
         """Executes the query synchronously on one API.
 
         Parameters:
@@ -582,11 +572,11 @@ class OptimadeClient:
         self,
         endpoint: str,
         filter: str,
-        response_fields: Optional[List[str]] = None,
+        response_fields: Optional[list[str]] = None,
         sort: Optional[str] = None,
         page_limit: Optional[int] = None,
         paginate: bool = True,
-    ) -> Dict[str, QueryResults]:
+    ) -> dict[str, QueryResults]:
         """Executes the query asynchronously across all defined APIs.
 
         Parameters:
@@ -626,10 +616,10 @@ class OptimadeClient:
         endpoint: str,
         filter: str,
         page_limit: Optional[int] = None,
-        response_fields: Optional[List[str]] = None,
+        response_fields: Optional[list[str]] = None,
         sort: Optional[str] = None,
         paginate: bool = True,
-    ) -> Dict[str, QueryResults]:
+    ) -> dict[str, QueryResults]:
         """Executes the query synchronously across all defined APIs.
 
         Parameters:
@@ -670,11 +660,11 @@ class OptimadeClient:
         endpoint: str,
         filter: str,
         base_url: str,
-        response_fields: Optional[List[str]] = None,
+        response_fields: Optional[list[str]] = None,
         sort: Optional[str] = None,
         page_limit: Optional[int] = None,
         paginate: bool = True,
-    ) -> Dict[str, QueryResults]:
+    ) -> dict[str, QueryResults]:
         """Executes the query asynchronously on one API.
 
         !!! note
@@ -725,11 +715,11 @@ class OptimadeClient:
         endpoint: str,
         filter: str,
         base_url: str,
-        response_fields: Optional[List[str]] = None,
+        response_fields: Optional[list[str]] = None,
         sort: Optional[str] = None,
         page_limit: Optional[int] = None,
         paginate: bool = True,
-    ) -> Dict[str, QueryResults]:
+    ) -> dict[str, QueryResults]:
         """See [`OptimadeClient.get_one_async`][optimade.client.OptimadeClient.get_one_async]."""
         next_url, _task = self._setup(
             endpoint=endpoint,
@@ -785,9 +775,9 @@ class OptimadeClient:
         base_url: str,
         sort: Optional[str] = None,
         page_limit: Optional[int] = None,
-        response_fields: Optional[List[str]] = None,
+        response_fields: Optional[list[str]] = None,
         paginate: bool = True,
-    ) -> Dict[str, QueryResults]:
+    ) -> dict[str, QueryResults]:
         """See [`OptimadeClient.get_one`][optimade.client.OptimadeClient.get_one]."""
         next_url, _task = self._setup(
             endpoint=endpoint,
@@ -846,9 +836,9 @@ class OptimadeClient:
         base_url: str,
         filter: str,
         page_limit: Optional[int],
-        response_fields: Optional[List[str]],
+        response_fields: Optional[list[str]],
         sort: Optional[str],
-    ) -> Tuple[str, TaskID]:
+    ) -> tuple[str, TaskID]:
         """Constructs the first query URL and creates the progress bar task.
 
         Returns:
@@ -876,7 +866,7 @@ class OptimadeClient:
         endpoint: Optional[str] = "structures",
         version: Optional[str] = None,
         filter: Optional[str] = None,
-        response_fields: Optional[List[str]] = None,
+        response_fields: Optional[list[str]] = None,
         sort: Optional[str] = None,
         page_limit: Optional[int] = None,
     ) -> str:
@@ -957,7 +947,7 @@ class OptimadeClient:
 
     def _handle_response(
         self, response: Union[httpx.Response, requests.Response], _task: TaskID
-    ) -> Tuple[Dict[str, Any], str]:
+    ) -> tuple[dict[str, Any], str]:
         """Handle the response from the server.
 
         Parameters:
@@ -1036,8 +1026,8 @@ class OptimadeClient:
             )
 
     def _execute_callbacks(
-        self, results: Dict, response: Union[httpx.Response, requests.Response]
-    ) -> Union[None, Dict]:
+        self, results: dict, response: Union[httpx.Response, requests.Response]
+    ) -> Union[None, dict]:
         """Execute any callbacks registered with the client.
 
         Parameters:

--- a/optimade/client/utils.py
+++ b/optimade/client/utils.py
@@ -1,7 +1,7 @@
 import sys
 from contextlib import contextmanager
 from dataclasses import asdict, dataclass, field
-from typing import Dict, List, Set, Union
+from typing import Union
 
 from rich.console import Console
 from rich.progress import (
@@ -34,22 +34,22 @@ class TooManyRequestsException(RecoverableHTTPError):
 class QueryResults:
     """A container dataclass for the results from a given query."""
 
-    data: Union[Dict, List[Dict]] = field(default_factory=list, init=False)  # type: ignore[assignment]
-    errors: List[str] = field(default_factory=list, init=False)
-    links: Dict = field(default_factory=dict, init=False)
-    included: List[Dict] = field(default_factory=list, init=False)
-    meta: Dict = field(default_factory=dict, init=False)
+    data: Union[dict, list[dict]] = field(default_factory=list, init=False)  # type: ignore[assignment]
+    errors: list[str] = field(default_factory=list, init=False)
+    links: dict = field(default_factory=dict, init=False)
+    included: list[dict] = field(default_factory=list, init=False)
+    meta: dict = field(default_factory=dict, init=False)
 
     @property
-    def included_index(self) -> Set[str]:
+    def included_index(self) -> set[str]:
         if not getattr(self, "_included_index", None):
-            self._included_index: Set[str] = set()
+            self._included_index: set[str] = set()
         return self._included_index
 
-    def dict(self):
+    def asdict(self):
         return asdict(self)
 
-    def update(self, page_results: Dict) -> None:
+    def update(self, page_results: dict) -> None:
         """Combine the results from one page with the existing results for a given query.
 
         Parameters:

--- a/optimade/exceptions.py
+++ b/optimade/exceptions.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from typing import Any, Dict, Optional, Tuple, Type
+from typing import Any, Optional
 
 __all__ = (
     "OptimadeHTTPException",
@@ -34,7 +34,7 @@ class OptimadeHTTPException(Exception, ABC):
     status_code: int
     title: str
     detail: Optional[str] = None
-    headers: Optional[Dict[str, Any]] = None
+    headers: Optional[dict[str, Any]] = None
 
     def __init__(
         self, detail: Optional[str] = None, headers: Optional[dict] = None
@@ -104,7 +104,7 @@ class NotImplementedResponse(OptimadeHTTPException):
 
 
 """A tuple of the possible errors that can be returned by an OPTIMADE API."""
-POSSIBLE_ERRORS: Tuple[Type[OptimadeHTTPException], ...] = (
+POSSIBLE_ERRORS: tuple[type[OptimadeHTTPException], ...] = (
     BadRequest,
     Forbidden,
     NotFound,

--- a/optimade/filterparser/lark_parser.py
+++ b/optimade/filterparser/lark_parser.py
@@ -5,7 +5,7 @@ into `Lark.Tree` objects for use by the filter transformers.
 """
 
 from pathlib import Path
-from typing import Dict, Optional, Tuple
+from typing import Optional
 
 from lark import Lark, Tree
 
@@ -20,7 +20,7 @@ class ParserError(Exception):
     """
 
 
-def get_versions() -> Dict[Tuple[int, int, int], Dict[str, Path]]:
+def get_versions() -> dict[tuple[int, int, int], dict[str, Path]]:
     """Find grammar files within this package's grammar directory,
     returning a dictionary broken down by scraped grammar version
     (major, minor, patch) and variant (a string tag).
@@ -29,10 +29,10 @@ def get_versions() -> Dict[Tuple[int, int, int], Dict[str, Path]]:
         A mapping from version, variant to grammar file name.
 
     """
-    dct: Dict[Tuple[int, int, int], Dict[str, Path]] = {}
+    dct: dict[tuple[int, int, int], dict[str, Path]] = {}
     for filename in Path(__file__).parent.joinpath("../grammar").glob("*.lark"):
         tags = filename.stem.lstrip("v").split(".")
-        version: Tuple[int, int, int] = (int(tags[0]), int(tags[1]), int(tags[2]))
+        version: tuple[int, int, int] = (int(tags[0]), int(tags[1]), int(tags[2]))
         variant: str = "default" if len(tags) == 3 else str(tags[-1])
         if version not in dct:
             dct[version] = {}
@@ -50,7 +50,7 @@ class LarkParser:
     """
 
     def __init__(
-        self, version: Optional[Tuple[int, int, int]] = None, variant: str = "default"
+        self, version: Optional[tuple[int, int, int]] = None, variant: str = "default"
     ):
         """For a given version and variant, try to load the corresponding grammar.
 

--- a/optimade/filtertransformers/base_transformer.py
+++ b/optimade/filtertransformers/base_transformer.py
@@ -7,7 +7,7 @@ for turning filters parsed by lark into backend-specific queries.
 
 import abc
 import warnings
-from typing import Any, Dict, Optional, Type
+from typing import Any, Optional
 
 from lark import Transformer, Tree, v_args
 
@@ -79,8 +79,8 @@ class BaseTransformer(Transformer, abc.ABC):
 
     """
 
-    mapper: Optional[Type[BaseResourceMapper]] = None
-    operator_map: Dict[str, Optional[str]] = {
+    mapper: Optional[type[BaseResourceMapper]] = None
+    operator_map: dict[str, Optional[str]] = {
         "<": None,
         "<=": None,
         ">": None,
@@ -100,11 +100,11 @@ class BaseTransformer(Transformer, abc.ABC):
         "!=": "!=",
     }
 
-    _quantity_type: Type[Quantity] = Quantity
+    _quantity_type: type[Quantity] = Quantity
     _quantities = None
 
     def __init__(
-        self, mapper: Optional[Type[BaseResourceMapper]] = None
+        self, mapper: Optional[type[BaseResourceMapper]] = None
     ):  # pylint: disable=super-init-not-called
         """Initialise the transformer object, optionally loading in a
         resource mapper for use when post-processing.
@@ -113,7 +113,7 @@ class BaseTransformer(Transformer, abc.ABC):
         self.mapper = mapper
 
     @property
-    def backend_mapping(self) -> Dict[str, Quantity]:
+    def backend_mapping(self) -> dict[str, Quantity]:
         """A mapping between backend field names (aliases) and the corresponding
         [`Quantity`][optimade.filtertransformers.base_transformer.Quantity] object.
         """
@@ -122,7 +122,7 @@ class BaseTransformer(Transformer, abc.ABC):
         }
 
     @property
-    def quantities(self) -> Dict[str, Quantity]:
+    def quantities(self) -> dict[str, Quantity]:
         """A mapping from the OPTIMADE field name to the corresponding
         [`Quantity`][optimade.filtertransformers.base_transformer.Quantity] objects.
         """
@@ -132,10 +132,10 @@ class BaseTransformer(Transformer, abc.ABC):
         return self._quantities
 
     @quantities.setter
-    def quantities(self, quantities: Dict[str, Quantity]) -> None:
+    def quantities(self, quantities: dict[str, Quantity]) -> None:
         self._quantities = quantities
 
-    def _build_quantities(self) -> Dict[str, Quantity]:
+    def _build_quantities(self) -> dict[str, Quantity]:
         """Creates a dictionary of field names mapped to
         [`Quantity`][optimade.filtertransformers.base_transformer.Quantity] objects from the
         fields registered by the mapper.

--- a/optimade/filtertransformers/elasticsearch.py
+++ b/optimade/filtertransformers/elasticsearch.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, Type, Union
+from typing import Optional, Union
 
 from elasticsearch_dsl import Field, Integer, Keyword, Q, Text
 from lark import v_args
@@ -97,12 +97,12 @@ class ElasticTransformer(BaseTransformer):
         ">=": "gte",
     }
 
-    _quantity_type: Type[ElasticsearchQuantity] = ElasticsearchQuantity
+    _quantity_type: type[ElasticsearchQuantity] = ElasticsearchQuantity
 
     def __init__(
         self,
-        mapper: Type[BaseResourceMapper],
-        quantities: Optional[Dict[str, Quantity]] = None,
+        mapper: type[BaseResourceMapper],
+        quantities: Optional[dict[str, Quantity]] = None,
     ):
         if quantities is not None:
             self.quantities = quantities
@@ -143,7 +143,7 @@ class ElasticTransformer(BaseTransformer):
                 return quantity
 
         if nested is not None:
-            return "%s.%s" % (nested.backend_field, quantity.name)  # type: ignore[union-attr]
+            return f"{nested.backend_field}.{quantity.name}"  # type: ignore[union-attr]
 
         return quantity.backend_field  # type: ignore[union-attr, return-value]
 

--- a/optimade/filtertransformers/mongo.py
+++ b/optimade/filtertransformers/mongo.py
@@ -7,7 +7,7 @@ which takes the parsed filter and converts it to a valid pymongo/BSON query.
 import copy
 import itertools
 import warnings
-from typing import Any, Dict, List, Union
+from typing import Any, Union
 
 from lark import Token, v_args
 
@@ -56,7 +56,7 @@ class MongoTransformer(BaseTransformer):
         "$nin": "$in",
     }
 
-    def postprocess(self, query: Dict[str, Any]):
+    def postprocess(self, query: dict[str, Any]):
         """Used to post-process the nested dictionary of the parsed query."""
         query = self._apply_relationship_filtering(query)
         query = self._apply_length_operators(query)
@@ -229,7 +229,7 @@ class MongoTransformer(BaseTransformer):
         # property_zip_addon: ":" property (":" property)*
         raise NotImplementedError("Correlated list queries are not supported.")
 
-    def _recursive_expression_phrase(self, arg: List) -> Dict[str, Any]:
+    def _recursive_expression_phrase(self, arg: list) -> dict[str, Any]:
         """Helper function for parsing `expression_phrase`. Recursively sorts out
         the correct precedence for `$not`, `$and` and `$or`.
 
@@ -242,7 +242,7 @@ class MongoTransformer(BaseTransformer):
 
         """
 
-        def handle_not_and(arg: Dict[str, List]) -> Dict[str, List]:
+        def handle_not_and(arg: dict[str, list]) -> dict[str, list]:
             """Handle the case of `~(A & B) -> (~A | ~B)`.
 
             We have to check for the special case in which the "and" was created
@@ -271,7 +271,7 @@ class MongoTransformer(BaseTransformer):
                 ]
             }
 
-        def handle_not_or(arg: Dict[str, List]) -> Dict[str, List]:
+        def handle_not_or(arg: dict[str, list]) -> dict[str, list]:
             """Handle the case of ~(A | B) -> (~A & ~B).
 
             !!! note
@@ -568,7 +568,7 @@ class MongoTransformer(BaseTransformer):
         )
 
 
-def recursive_postprocessing(filter_: Union[Dict, List], condition, replacement):
+def recursive_postprocessing(filter_: Union[dict, list], condition, replacement):
     """Recursively descend into the query, checking each dictionary
     (contained in a list, or as an entry in another dictionary) for
     the condition passed. If the condition is true, apply the

--- a/optimade/models/baseinfo.py
+++ b/optimade/models/baseinfo.py
@@ -1,6 +1,6 @@
 # pylint: disable=no-self-argument,no-name-in-module
 import re
-from typing import Dict, List, Optional
+from typing import Optional
 
 from pydantic import AnyHttpUrl, BaseModel, Field, root_validator, validator
 
@@ -64,18 +64,18 @@ class BaseInfoAttributes(BaseModel):
 The version number string MUST NOT be prefixed by, e.g., "v".
 Examples: `1.0.0`, `1.0.0-rc.2`.""",
     )
-    available_api_versions: List[AvailableApiVersion] = StrictField(
+    available_api_versions: list[AvailableApiVersion] = StrictField(
         ...,
         description="A list of dictionaries of available API versions at other base URLs",
     )
-    formats: List[str] = StrictField(
+    formats: list[str] = StrictField(
         default=["json"], description="List of available output formats."
     )
-    available_endpoints: List[str] = StrictField(
+    available_endpoints: list[str] = StrictField(
         ...,
         description="List of available endpoints (i.e., the string to be appended to the versioned base URL).",
     )
-    entry_types_by_format: Dict[str, List[str]] = StrictField(
+    entry_types_by_format: dict[str, list[str]] = StrictField(
         ..., description="Available entry endpoints as a function of output formats."
     )
     is_index: Optional[bool] = StrictField(

--- a/optimade/models/entries.py
+++ b/optimade/models/entries.py
@@ -1,6 +1,6 @@
 # pylint: disable=line-too-long,no-self-argument
 from datetime import datetime
-from typing import Dict, List, Optional
+from typing import Optional
 
 from pydantic import BaseModel, validator  # pylint: disable=no-name-in-module
 
@@ -184,18 +184,18 @@ E.g., for the entry resource `structures`, the `species` property is defined as 
 
 
 class EntryInfoResource(BaseModel):
-    formats: List[str] = StrictField(
+    formats: list[str] = StrictField(
         ..., description="List of output formats available for this type of entry."
     )
 
     description: str = StrictField(..., description="Description of the entry.")
 
-    properties: Dict[str, EntryInfoProperty] = StrictField(
+    properties: dict[str, EntryInfoProperty] = StrictField(
         ...,
         description="A dictionary describing queryable properties for this entry type, where each key is a property name.",
     )
 
-    output_fields_by_format: Dict[str, List[str]] = StrictField(
+    output_fields_by_format: dict[str, list[str]] = StrictField(
         ...,
         description="Dictionary of available output fields for this entry type, where the keys are the values of the `formats` list and the values are the keys of the `properties` dictionary.",
     )

--- a/optimade/models/index_metadb.py
+++ b/optimade/models/index_metadb.py
@@ -1,6 +1,6 @@
 # pylint: disable=no-self-argument
 from enum import Enum
-from typing import Dict, Union
+from typing import Union
 
 from pydantic import BaseModel, Field  # pylint: disable=no-name-in-module
 
@@ -52,7 +52,7 @@ class IndexInfoResource(BaseInfoResource):
 
     attributes: IndexInfoAttributes = Field(...)
     relationships: Union[
-        None, Dict[DefaultRelationship, IndexRelationship]
+        None, dict[DefaultRelationship, IndexRelationship]
     ] = StrictField(  # type: ignore[assignment]
         ...,
         title="Relationships",

--- a/optimade/models/jsonapi.py
+++ b/optimade/models/jsonapi.py
@@ -1,7 +1,7 @@
 """This module should reproduce JSON API v1.0 https://jsonapi.org/format/1.0/"""
 # pylint: disable=no-self-argument
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional, Type, Union
+from typing import Any, Optional, Union
 
 from pydantic import (  # pylint: disable=no-name-in-module
     AnyUrl,
@@ -168,7 +168,7 @@ class BaseResource(BaseModel):
 
     class Config:
         @staticmethod
-        def schema_extra(schema: Dict[str, Any], model: Type["BaseResource"]) -> None:
+        def schema_extra(schema: dict[str, Any], model: type["BaseResource"]) -> None:
             """Ensure `id` and `type` are the first two entries in the list required properties.
 
             Note:
@@ -227,7 +227,7 @@ class Relationship(BaseModel):
         None,
         description="a links object containing at least one of the following: self, related",
     )
-    data: Optional[Union[BaseResource, List[BaseResource]]] = StrictField(
+    data: Optional[Union[BaseResource, list[BaseResource]]] = StrictField(
         None, description="Resource linkage"
     )
     meta: Optional[Meta] = StrictField(
@@ -323,17 +323,17 @@ describing relationships between the resource and other JSON API resources.""",
 class Response(BaseModel):
     """A top-level response"""
 
-    data: Optional[Union[None, Resource, List[Resource]]] = StrictField(
+    data: Optional[Union[None, Resource, list[Resource]]] = StrictField(
         None, description="Outputted Data", uniqueItems=True
     )
     meta: Optional[Meta] = StrictField(
         None,
         description="A meta object containing non-standard information related to the Success",
     )
-    errors: Optional[List[Error]] = StrictField(
+    errors: Optional[list[Error]] = StrictField(
         None, description="A list of unique errors", uniqueItems=True
     )
-    included: Optional[List[Resource]] = StrictField(
+    included: Optional[list[Resource]] = StrictField(
         None, description="A list of unique included resources", uniqueItems=True
     )
     links: Optional[ToplevelLinks] = StrictField(

--- a/optimade/models/optimade_json.py
+++ b/optimade/models/optimade_json.py
@@ -2,7 +2,7 @@
 # pylint: disable=no-self-argument,no-name-in-module
 from datetime import datetime
 from enum import Enum
-from typing import Any, Dict, List, Optional, Type, Union
+from typing import Any, Optional, Union
 
 from pydantic import AnyHttpUrl, AnyUrl, BaseModel, EmailStr, root_validator
 
@@ -43,7 +43,7 @@ class DataType(Enum):
     @classmethod
     def get_values(cls):
         """Get OPTIMADE data types (enum values) as a (sorted) list"""
-        return sorted((_.value for _ in cls))
+        return sorted(_.value for _ in cls)
 
     @classmethod
     def from_python_type(cls, python_type: Union[type, str, object]):
@@ -156,7 +156,7 @@ class Warnings(OptimadeError):
 
     class Config:
         @staticmethod
-        def schema_extra(schema: Dict[str, Any], model: Type["Warnings"]) -> None:
+        def schema_extra(schema: dict[str, Any], model: type["Warnings"]) -> None:
             """Update OpenAPI JSON schema model for `Warning`.
 
             * Ensure `type` is in the list required properties and in the correct place.
@@ -317,7 +317,7 @@ Hence, if the `meta` field of the JSON API links object is provided and contains
         None, description="a dictionary describing the server implementation"
     )
 
-    warnings: Optional[List[Warnings]] = StrictField(
+    warnings: Optional[list[Warnings]] = StrictField(
         None,
         description="""A list of warning resource objects representing non-critical errors or warnings.
 A warning resource object is defined similarly to a [JSON API error object](http://jsonapi.org/format/1.0/#error-objects), but MUST also include the field `type`, which MUST have the value `"warning"`.
@@ -372,5 +372,5 @@ class Relationship(jsonapi.Relationship):
     """Similar to normal JSON API relationship, but with addition of OPTIONAL meta field for a resource."""
 
     data: Optional[
-        Union[BaseRelationshipResource, List[BaseRelationshipResource]]
+        Union[BaseRelationshipResource, list[BaseRelationshipResource]]
     ] = StrictField(None, description="Resource linkage", uniqueItems=True)

--- a/optimade/models/references.py
+++ b/optimade/models/references.py
@@ -1,5 +1,5 @@
 # pylint: disable=line-too-long,no-self-argument
-from typing import List, Optional
+from typing import Optional
 
 from pydantic import AnyUrl, BaseModel, validator  # pylint: disable=no-name-in-module
 
@@ -42,14 +42,14 @@ class ReferenceResourceAttributes(EntryResourceAttributes):
 
     """
 
-    authors: Optional[List[Person]] = OptimadeField(
+    authors: Optional[list[Person]] = OptimadeField(
         None,
         description="List of person objects containing the authors of the reference.",
         support=SupportLevel.OPTIONAL,
         queryable=SupportLevel.OPTIONAL,
     )
 
-    editors: Optional[List[Person]] = OptimadeField(
+    editors: Optional[list[Person]] = OptimadeField(
         None,
         description="List of person objects containing the editors of the reference.",
         support=SupportLevel.OPTIONAL,

--- a/optimade/models/responses.py
+++ b/optimade/models/responses.py
@@ -1,5 +1,5 @@
 # pylint: disable=no-self-argument
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Optional, Union
 
 from pydantic import Field, root_validator
 
@@ -34,7 +34,7 @@ class ErrorResponse(Response):
     meta: ResponseMeta = StrictField(
         ..., description="A meta object containing non-standard information."
     )
-    errors: List[OptimadeError] = StrictField(
+    errors: list[OptimadeError] = StrictField(
         ...,
         description="A list of OPTIMADE-specific JSON API error objects, where the field detail MUST be present.",
         uniqueItems=True,
@@ -66,23 +66,23 @@ class InfoResponse(Success):
 
 
 class EntryResponseOne(Success):
-    data: Union[EntryResource, Dict[str, Any], None] = Field(...)  # type: ignore[assignment]
-    included: Optional[Union[List[EntryResource], List[Dict[str, Any]]]] = Field(  # type: ignore[assignment]
+    data: Union[EntryResource, dict[str, Any], None] = Field(...)  # type: ignore[assignment]
+    included: Optional[Union[list[EntryResource], list[dict[str, Any]]]] = Field(  # type: ignore[assignment]
         None, uniqueItems=True
     )
 
 
 class EntryResponseMany(Success):
-    data: Union[List[EntryResource], List[Dict[str, Any]]] = Field(  # type: ignore[assignment]
+    data: Union[list[EntryResource], list[dict[str, Any]]] = Field(  # type: ignore[assignment]
         ..., uniqueItems=True
     )
-    included: Optional[Union[List[EntryResource], List[Dict[str, Any]]]] = Field(  # type: ignore[assignment]
+    included: Optional[Union[list[EntryResource], list[dict[str, Any]]]] = Field(  # type: ignore[assignment]
         None, uniqueItems=True
     )
 
 
 class LinksResponse(EntryResponseMany):
-    data: Union[List[LinksResource], List[Dict[str, Any]]] = StrictField(
+    data: Union[list[LinksResource], list[dict[str, Any]]] = StrictField(
         ...,
         description="List of unique OPTIMADE links resource objects.",
         uniqueItems=True,
@@ -90,13 +90,13 @@ class LinksResponse(EntryResponseMany):
 
 
 class StructureResponseOne(EntryResponseOne):
-    data: Union[StructureResource, Dict[str, Any], None] = StrictField(
+    data: Union[StructureResource, dict[str, Any], None] = StrictField(
         ..., description="A single structures entry resource."
     )
 
 
 class StructureResponseMany(EntryResponseMany):
-    data: Union[List[StructureResource], List[Dict[str, Any]]] = StrictField(
+    data: Union[list[StructureResource], list[dict[str, Any]]] = StrictField(
         ...,
         description="List of unique OPTIMADE structures entry resource objects.",
         uniqueItems=True,
@@ -104,13 +104,13 @@ class StructureResponseMany(EntryResponseMany):
 
 
 class ReferenceResponseOne(EntryResponseOne):
-    data: Union[ReferenceResource, Dict[str, Any], None] = StrictField(
+    data: Union[ReferenceResource, dict[str, Any], None] = StrictField(
         ..., description="A single references entry resource."
     )
 
 
 class ReferenceResponseMany(EntryResponseMany):
-    data: Union[List[ReferenceResource], List[Dict[str, Any]]] = StrictField(
+    data: Union[list[ReferenceResource], list[dict[str, Any]]] = StrictField(
         ...,
         description="List of unique OPTIMADE references entry resource objects.",
         uniqueItems=True,

--- a/optimade/models/structures.py
+++ b/optimade/models/structures.py
@@ -2,7 +2,7 @@
 import re
 import warnings
 from enum import Enum, IntEnum
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 from pydantic import BaseModel, conlist, root_validator, validator
 
@@ -84,7 +84,7 @@ class Species(BaseModel):
         queryable=SupportLevel.OPTIONAL,
     )
 
-    chemical_symbols: List[str] = OptimadeField(
+    chemical_symbols: list[str] = OptimadeField(
         ...,
         description="""MUST be a list of strings of all chemical elements composing this species. Each item of the list MUST be one of the following:
 
@@ -97,7 +97,7 @@ If any one entry in the `species` list has a `chemical_symbols` list that is lon
         queryable=SupportLevel.OPTIONAL,
     )
 
-    concentration: List[float] = OptimadeField(
+    concentration: list[float] = OptimadeField(
         ...,
         description="""MUST be a list of floats, with same length as `chemical_symbols`. The numbers represent the relative concentration of the corresponding chemical symbol in this species. The numbers SHOULD sum to one. Cases in which the numbers do not sum to one typically fall only in the following two categories:
 
@@ -109,7 +109,7 @@ Note that concentrations are uncorrelated between different site (even of the sa
         queryable=SupportLevel.OPTIONAL,
     )
 
-    mass: Optional[List[float]] = OptimadeField(
+    mass: Optional[list[float]] = OptimadeField(
         None,
         description="""If present MUST be a list of floats expressed in a.m.u.
 Elements denoting vacancies MUST have masses equal to 0.""",
@@ -127,14 +127,14 @@ Note: With regards to "source database", we refer to the immediate source being 
         queryable=SupportLevel.OPTIONAL,
     )
 
-    attached: Optional[List[str]] = OptimadeField(
+    attached: Optional[list[str]] = OptimadeField(
         None,
         description="""If provided MUST be a list of length 1 or more of strings of chemical symbols for the elements attached to this site, or "X" for a non-chemical element.""",
         support=SupportLevel.OPTIONAL,
         queryable=SupportLevel.OPTIONAL,
     )
 
-    nattached: Optional[List[int]] = OptimadeField(
+    nattached: Optional[list[int]] = OptimadeField(
         None,
         description="""If provided MUST be a list of length 1 or more of integers indicating the number of attached atoms of the kind specified in the value of the :field:`attached` key.""",
         support=SupportLevel.OPTIONAL,
@@ -210,7 +210,7 @@ class Assembly(BaseModel):
 
     """
 
-    sites_in_groups: List[List[int]] = OptimadeField(
+    sites_in_groups: list[list[int]] = OptimadeField(
         ...,
         description="""Index of the sites (0-based) that belong to each group for each assembly.
 
@@ -221,7 +221,7 @@ class Assembly(BaseModel):
         queryable=SupportLevel.OPTIONAL,
     )
 
-    group_probabilities: List[float] = OptimadeField(
+    group_probabilities: list[float] = OptimadeField(
         ...,
         description="""Statistical probability of each group. It MUST have the same length as `sites_in_groups`.
 It SHOULD sum to one.
@@ -263,7 +263,7 @@ CORRELATED_STRUCTURE_FIELDS = (
 class StructureResourceAttributes(EntryResourceAttributes):
     """This class contains the Field for the attributes used to represent a structure, e.g. unit cell, atoms, positions."""
 
-    elements: Optional[List[str]] = OptimadeField(
+    elements: Optional[list[str]] = OptimadeField(
         ...,
         description="""The chemical symbols of the different elements present in the structure.
 
@@ -311,7 +311,7 @@ class StructureResourceAttributes(EntryResourceAttributes):
         queryable=SupportLevel.MUST,
     )
 
-    elements_ratios: Optional[List[float]] = OptimadeField(
+    elements_ratios: Optional[list[float]] = OptimadeField(
         ...,
         description="""Relative proportions of different elements in the structure.
 
@@ -523,7 +523,7 @@ Note: the elements in this list each refer to the direction of the corresponding
         queryable=SupportLevel.OPTIONAL,
     )
 
-    cartesian_site_positions: Optional[List[Vector3D]] = OptimadeField(  # type: ignore[valid-type]
+    cartesian_site_positions: Optional[list[Vector3D]] = OptimadeField(  # type: ignore[valid-type]
         ...,
         description="""Cartesian positions of each site in the structure.
 A site is usually used to describe positions of atoms; what atoms can be encountered at a given site is conveyed by the `species_at_sites` property, and the species themselves are described in the `species` property.
@@ -564,7 +564,7 @@ A site is usually used to describe positions of atoms; what atoms can be encount
         support=SupportLevel.SHOULD,
     )
 
-    species: Optional[List[Species]] = OptimadeField(
+    species: Optional[list[Species]] = OptimadeField(
         ...,
         description="""A list describing the species of the sites of this structure.
 Species can represent pure chemical elements, virtual-crystal atoms representing a statistical occupation of a given site by multiple chemical elements, and/or a location to which there are attached atoms, i.e., atoms whose precise location are unknown beyond that they are attached to that position (frequently used to indicate hydrogen atoms attached to another element, e.g., a carbon with three attached hydrogens might represent a methyl group, -CH3).
@@ -633,7 +633,7 @@ Species can represent pure chemical elements, virtual-crystal atoms representing
         queryable=SupportLevel.OPTIONAL,
     )
 
-    species_at_sites: Optional[List[str]] = OptimadeField(
+    species_at_sites: Optional[list[str]] = OptimadeField(
         ...,
         description="""Name of the species at each site (where values for sites are specified with the same order of the property `cartesian_site_positions`).
 The properties of the species are found in the property `species`.
@@ -657,7 +657,7 @@ The properties of the species are found in the property `species`.
         queryable=SupportLevel.OPTIONAL,
     )
 
-    assemblies: Optional[List[Assembly]] = OptimadeField(
+    assemblies: Optional[list[Assembly]] = OptimadeField(
         None,
         description="""A description of groups of sites that are statistically correlated.
 
@@ -765,7 +765,7 @@ The properties of the species are found in the property `species`.
         queryable=SupportLevel.OPTIONAL,
     )
 
-    structure_features: List[StructureFeatures] = OptimadeField(
+    structure_features: list[StructureFeatures] = OptimadeField(
         ...,
         title="Structure Features",
         description="""A list of strings that flag which special features are used by the structure.
@@ -961,7 +961,7 @@ The properties of the species are found in the property `species`.
             return v
 
         for vector in v:
-            if None in vector and any((isinstance(_, float) for _ in vector)):
+            if None in vector and any(isinstance(_, float) for _ in vector):
                 raise ValueError(
                     f"A lattice vector MUST be either all `null` or all numbers (vector: {vector}, all vectors: {v})"
                 )
@@ -1020,7 +1020,7 @@ The properties of the species are found in the property `species`.
 
     @validator("structure_features", always=True)
     def validate_structure_features(cls, v, values):
-        if [StructureFeatures(value) for value in sorted((_.value for _ in v))] != v:
+        if [StructureFeatures(value) for value in sorted(_.value for _ in v)] != v:
             raise ValueError(
                 f"structure_features MUST be sorted alphabetically, given value: {v}"
             )

--- a/optimade/models/utils.py
+++ b/optimade/models/utils.py
@@ -5,7 +5,7 @@ import re
 import warnings
 from enum import Enum
 from functools import reduce
-from typing import TYPE_CHECKING, List, Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 from pydantic import Field
 from pydantic.fields import FieldInfo
@@ -237,7 +237,7 @@ def _reduce_or_anonymize_formula(
     import re
     import sys
 
-    numbers: List[int] = [
+    numbers: list[int] = [
         int(n.strip() or 1) for n in re.split(r"[A-Z][a-z]*", formula)[1:]
     ]
     # Need to remove leading 1 from split and convert to ints

--- a/optimade/server/config.py
+++ b/optimade/server/config.py
@@ -2,7 +2,7 @@
 import warnings
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, List, Literal, Optional, Tuple, Union
+from typing import Any, Literal, Optional, Union
 
 from pydantic import (  # pylint: disable=no-name-in-module
     AnyHttpUrl,
@@ -67,7 +67,7 @@ class SupportedBackend(Enum):
     MONGOMOCK = "mongomock"
 
 
-def config_file_settings(settings: BaseSettings) -> Dict[str, Any]:
+def config_file_settings(settings: BaseSettings) -> dict[str, Any]:
     """Configuration file settings source.
 
     Based on the example in the
@@ -153,7 +153,7 @@ class ServerConfig(BaseSettings):
         description="Which database backend to use out of the supported backends.",
     )
 
-    elastic_hosts: Optional[Union[str, List[str], Dict, List[Dict]]] = Field(
+    elastic_hosts: Optional[Union[str, list[str], dict, list[dict]]] = Field(
         None, description="Host settings to pass through to the `Elasticsearch` class."
     )
 
@@ -224,9 +224,9 @@ This operation can require a full COLLSCAN for empty queries which can be prohib
         ),
         description="General information about the provider of this OPTIMADE implementation",
     )
-    provider_fields: Dict[
+    provider_fields: dict[
         Literal["links", "references", "structures"],
-        List[Union[str, Dict[Literal["name", "type", "unit", "description"], str]]],
+        list[Union[str, dict[Literal["name", "type", "unit", "description"], str]]],
     ] = Field(
         {},
         description=(
@@ -234,15 +234,15 @@ This operation can require a full COLLSCAN for empty queries which can be prohib
             "broken down by endpoint."
         ),
     )
-    aliases: Dict[Literal["links", "references", "structures"], Dict[str, str]] = Field(
+    aliases: dict[Literal["links", "references", "structures"], dict[str, str]] = Field(
         {},
         description=(
             "A mapping between field names in the database with their corresponding OPTIMADE field"
             " names, broken down by endpoint."
         ),
     )
-    length_aliases: Dict[
-        Literal["links", "references", "structures"], Dict[str, str]
+    length_aliases: dict[
+        Literal["links", "references", "structures"], dict[str, str]
     ] = Field(
         {},
         description=(
@@ -354,7 +354,7 @@ This operation can require a full COLLSCAN for empty queries which can be prohib
             init_settings: SettingsSourceCallable,
             env_settings: SettingsSourceCallable,
             file_secret_settings: SettingsSourceCallable,
-        ) -> Tuple[SettingsSourceCallable, ...]:
+        ) -> tuple[SettingsSourceCallable, ...]:
             """
             **Priority of config settings sources**:
 

--- a/optimade/server/entry_collections/elasticsearch.py
+++ b/optimade/server/entry_collections/elasticsearch.py
@@ -124,7 +124,7 @@ class ElasticCollection(EntryCollection):
 
         def get_id(item):
             if self.name == "links":
-                id_ = "{}-{}".format(item["id"], item["type"])
+                id_ = f"{item['id']}-{item['type']}"
             elif "id" in item:
                 id_ = item["id"]
             elif "_id" in item:

--- a/optimade/server/entry_collections/elasticsearch.py
+++ b/optimade/server/entry_collections/elasticsearch.py
@@ -1,6 +1,7 @@
 import json
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Tuple, Type
+from typing import Any, Optional
 
 from optimade.filtertransformers.elasticsearch import ElasticTransformer
 from optimade.models import EntryResource
@@ -24,8 +25,8 @@ class ElasticCollection(EntryCollection):
     def __init__(
         self,
         name: str,
-        resource_cls: Type[EntryResource],
-        resource_mapper: Type[BaseResourceMapper],
+        resource_cls: type[EntryResource],
+        resource_mapper: type[BaseResourceMapper],
         client: Optional["Elasticsearch"] = None,
     ):
         """Initialize the ElasticCollection for the given parameters.
@@ -78,7 +79,7 @@ class ElasticCollection(EntryCollection):
         LOGGER.debug(f"Created Elastic index for {self.name!r} with parameters {body}")
 
     @property
-    def predefined_index(self) -> Dict[str, Any]:
+    def predefined_index(self) -> dict[str, Any]:
         """Loads and returns the default pre-defined index."""
         with open(Path(__file__).parent.joinpath("elastic_indexes.json")) as f:
             index = json.load(f)
@@ -86,8 +87,8 @@ class ElasticCollection(EntryCollection):
 
     @staticmethod
     def create_elastic_index_from_mapper(
-        resource_mapper: Type[BaseResourceMapper], fields: Iterable[str]
-    ) -> Dict[str, Any]:
+        resource_mapper: type[BaseResourceMapper], fields: Iterable[str]
+    ) -> dict[str, Any]:
         """Create a fallback elastic index based on a resource mapper.
 
         Arguments:
@@ -110,7 +111,7 @@ class ElasticCollection(EntryCollection):
         """Returns the total number of entries in the collection."""
         return Search(using=self.client, index=self.name).execute().hits.total.value
 
-    def insert(self, data: List[EntryResource]) -> None:
+    def insert(self, data: list[EntryResource]) -> None:
         """Add the given entries to the underlying database.
 
         Warning:
@@ -123,7 +124,7 @@ class ElasticCollection(EntryCollection):
 
         def get_id(item):
             if self.name == "links":
-                id_ = "%s-%s" % (item["id"], item["type"])
+                id_ = "{}-{}".format(item["id"], item["type"])
             elif "id" in item:
                 id_ = item["id"]
             elif "_id" in item:
@@ -148,8 +149,8 @@ class ElasticCollection(EntryCollection):
         )
 
     def _run_db_query(
-        self, criteria: Dict[str, Any], single_entry=False
-    ) -> Tuple[List[Dict[str, Any]], int, bool]:
+        self, criteria: dict[str, Any], single_entry=False
+    ) -> tuple[list[dict[str, Any]], int, bool]:
         """Run the query on the backend and collect the results.
 
         Arguments:

--- a/optimade/server/entry_collections/entry_collections.py
+++ b/optimade/server/entry_collections/entry_collections.py
@@ -2,7 +2,8 @@ import enum
 import re
 import warnings
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Type, Union
+from collections.abc import Iterable
+from typing import Any, Optional, Union
 
 from lark import Transformer
 
@@ -21,8 +22,8 @@ from optimade.warnings import (
 
 def create_collection(
     name: str,
-    resource_cls: Type[EntryResource],
-    resource_mapper: Type[BaseResourceMapper],
+    resource_cls: type[EntryResource],
+    resource_mapper: type[BaseResourceMapper],
 ) -> "EntryCollection":
     """Create an `EntryCollection` of the configured type, depending on the value of
     `CONFIG.database_backend`.
@@ -83,8 +84,8 @@ class EntryCollection(ABC):
 
     def __init__(
         self,
-        resource_cls: Type[EntryResource],
-        resource_mapper: Type[BaseResourceMapper],
+        resource_cls: type[EntryResource],
+        resource_mapper: type[BaseResourceMapper],
         transformer: Transformer,
     ):
         """Initialize the collection for the given parameters.
@@ -110,14 +111,14 @@ class EntryCollection(ABC):
             for field in CONFIG.provider_fields.get(resource_mapper.ENDPOINT, [])
         ]
 
-        self._all_fields: Set[str] = set()
+        self._all_fields: set[str] = set()
 
     @abstractmethod
     def __len__(self) -> int:
         """Returns the total number of entries in the collection."""
 
     @abstractmethod
-    def insert(self, data: List[EntryResource]) -> None:
+    def insert(self, data: list[EntryResource]) -> None:
         """Add the given entries to the underlying database.
 
         Arguments:
@@ -137,7 +138,7 @@ class EntryCollection(ABC):
 
     def find(
         self, params: Union[EntryListingQueryParams, SingleEntryQueryParams]
-    ) -> Tuple[Union[None, Dict, List[Dict]], Optional[int], bool, Set[str], Set[str],]:
+    ) -> tuple[Union[None, dict, list[dict]], Optional[int], bool, set[str], set[str],]:
         """
         Fetches results and indicates if more data is available.
 
@@ -195,7 +196,7 @@ class EntryCollection(ABC):
                 detail=f"Unrecognised OPTIMADE field(s) in requested `response_fields`: {bad_optimade_fields}."
             )
 
-        results: Union[None, List[Dict], Dict] = None
+        results: Union[None, list[dict], dict] = None
 
         if raw_results:
             results = [self.resource_mapper.map_back(doc) for doc in raw_results]
@@ -224,8 +225,8 @@ class EntryCollection(ABC):
 
     @abstractmethod
     def _run_db_query(
-        self, criteria: Dict[str, Any], single_entry: bool = False
-    ) -> Tuple[List[Dict[str, Any]], Optional[int], bool]:
+        self, criteria: dict[str, Any], single_entry: bool = False
+    ) -> tuple[list[dict[str, Any]], Optional[int], bool]:
         """Run the query on the backend and collect the results.
 
         Arguments:
@@ -239,7 +240,7 @@ class EntryCollection(ABC):
         """
 
     @property
-    def all_fields(self) -> Set[str]:
+    def all_fields(self) -> set[str]:
         """Get the set of all fields handled in this collection,
         from attribute fields in the schema, provider fields and top-level OPTIMADE fields.
 
@@ -266,7 +267,7 @@ class EntryCollection(ABC):
 
         return self._all_fields
 
-    def get_attribute_fields(self) -> Set[str]:
+    def get_attribute_fields(self) -> set[str]:
         """Get the set of attribute fields
 
         Return only the _first-level_ attribute fields from the schema of the resource class,
@@ -298,7 +299,7 @@ class EntryCollection(ABC):
 
     def handle_query_params(
         self, params: Union[EntryListingQueryParams, SingleEntryQueryParams]
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Parse and interpret the backend-agnostic query parameter models into a dictionary
         that can be used by the specific backend.
 
@@ -404,7 +405,7 @@ class EntryCollection(ABC):
 
         return cursor_kwargs
 
-    def parse_sort_params(self, sort_params: str) -> Iterable[Tuple[str, int]]:
+    def parse_sort_params(self, sort_params: str) -> Iterable[tuple[str, int]]:
         """Handles any sort parameters passed to the collection,
         resolving aliases and dealing with any invalid fields.
 
@@ -416,7 +417,7 @@ class EntryCollection(ABC):
             sort direction encoded as 1 (ascending) or -1 (descending).
 
         """
-        sort_spec: List[Tuple[str, int]] = []
+        sort_spec: list[tuple[str, int]] = []
         for field in sort_params.split(","):
             sort_dir = 1
             if field.startswith("-"):
@@ -464,8 +465,8 @@ class EntryCollection(ABC):
     def get_next_query_params(
         self,
         params: EntryListingQueryParams,
-        results: Union[None, Dict, List[Dict]],
-    ) -> Dict[str, List[str]]:
+        results: Union[None, dict, list[dict]],
+    ) -> dict[str, list[str]]:
         """Provides url query pagination parameters that will be used in the next
         link.
 
@@ -477,7 +478,7 @@ class EntryCollection(ABC):
             A dictionary with the necessary query parameters.
 
         """
-        query: Dict[str, List[str]] = dict()
+        query: dict[str, list[str]] = dict()
         if isinstance(results, list) and results:
             # If a user passed a particular pagination mechanism, keep using it
             # Otherwise, use the default pagination mechanism of the collection

--- a/optimade/server/entry_collections/mongo.py
+++ b/optimade/server/entry_collections/mongo.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Tuple, Type, Union
+from typing import Any, Optional, Union
 
 from optimade.filtertransformers.mongo import MongoTransformer
 from optimade.models import EntryResource
@@ -38,8 +38,8 @@ class MongoCollection(EntryCollection):
     def __init__(
         self,
         name: str,
-        resource_cls: Type[EntryResource],
-        resource_mapper: Type[BaseResourceMapper],
+        resource_cls: type[EntryResource],
+        resource_mapper: type[BaseResourceMapper],
         database: str = CONFIG.mongo_database,
     ):
         """Initialize the MongoCollection for the given parameters.
@@ -91,7 +91,7 @@ class MongoCollection(EntryCollection):
             except ExecutionTimeout:
                 return None
 
-    def insert(self, data: List[EntryResource]) -> None:
+    def insert(self, data: list[EntryResource]) -> None:
         """Add the given entries to the underlying database.
 
         Warning:
@@ -105,7 +105,7 @@ class MongoCollection(EntryCollection):
 
     def handle_query_params(
         self, params: Union[EntryListingQueryParams, SingleEntryQueryParams]
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Parse and interpret the backend-agnostic query parameter models into a dictionary
         that can be used by MongoDB.
 
@@ -142,8 +142,8 @@ class MongoCollection(EntryCollection):
         return criteria
 
     def _run_db_query(
-        self, criteria: Dict[str, Any], single_entry: bool = False
-    ) -> Tuple[List[Dict[str, Any]], Optional[int], bool]:
+        self, criteria: dict[str, Any], single_entry: bool = False
+    ) -> tuple[list[dict[str, Any]], Optional[int], bool]:
         """Run the query on the backend and collect the results.
 
         Arguments:

--- a/optimade/server/exception_handlers.py
+++ b/optimade/server/exception_handlers.py
@@ -1,5 +1,6 @@
 import traceback
-from typing import Callable, Iterable, List, Optional, Tuple, Type, Union
+from collections.abc import Iterable
+from typing import Callable, Optional, Union
 
 from fastapi import Request
 from fastapi.encoders import jsonable_encoder
@@ -18,7 +19,7 @@ def general_exception(
     request: Request,
     exc: Exception,
     status_code: int = 500,  # A status_code in `exc` will take precedence
-    errors: Optional[List[OptimadeError]] = None,
+    errors: Optional[list[OptimadeError]] = None,
 ) -> JSONAPIResponse:
     """Handle an exception
 
@@ -221,8 +222,8 @@ def general_exception_handler(request: Request, exc: Exception) -> JSONAPIRespon
 
 
 OPTIMADE_EXCEPTIONS: Iterable[
-    Tuple[
-        Type[Exception],
+    tuple[
+        type[Exception],
         Callable[[Request, Exception], JSONAPIResponse],
     ]
 ] = [

--- a/optimade/server/mappers/entries.py
+++ b/optimade/server/mappers/entries.py
@@ -1,6 +1,7 @@
 import warnings
+from collections.abc import Iterable
 from functools import lru_cache
-from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Type, Union
+from typing import Any, Optional, Union
 
 from optimade.models.entries import EntryResource
 
@@ -65,19 +66,19 @@ class BaseResourceMapper:
     except (ImportError, ModuleNotFoundError):
         PROVIDERS = {}
 
-    KNOWN_PROVIDER_PREFIXES: Set[str] = set(
+    KNOWN_PROVIDER_PREFIXES: set[str] = {
         prov["id"] for prov in PROVIDERS.get("data", [])
-    )
-    ALIASES: Tuple[Tuple[str, str], ...] = ()
-    LENGTH_ALIASES: Tuple[Tuple[str, str], ...] = ()
-    PROVIDER_FIELDS: Tuple[str, ...] = ()
-    ENTRY_RESOURCE_CLASS: Type[EntryResource] = EntryResource
-    RELATIONSHIP_ENTRY_TYPES: Set[str] = {"references", "structures"}
-    TOP_LEVEL_NON_ATTRIBUTES_FIELDS: Set[str] = {"id", "type", "relationships", "links"}
+    }
+    ALIASES: tuple[tuple[str, str], ...] = ()
+    LENGTH_ALIASES: tuple[tuple[str, str], ...] = ()
+    PROVIDER_FIELDS: tuple[str, ...] = ()
+    ENTRY_RESOURCE_CLASS: type[EntryResource] = EntryResource
+    RELATIONSHIP_ENTRY_TYPES: set[str] = {"references", "structures"}
+    TOP_LEVEL_NON_ATTRIBUTES_FIELDS: set[str] = {"id", "type", "relationships", "links"}
 
     @classmethod
     @lru_cache(maxsize=NUM_ENTRY_TYPES)
-    def all_aliases(cls) -> Iterable[Tuple[str, str]]:
+    def all_aliases(cls) -> Iterable[tuple[str, str]]:
         """Returns all of the associated aliases for this entry type,
         including those defined by the server config. The first member
         of each tuple is the OPTIMADE-compliant field name, the second
@@ -116,7 +117,7 @@ class BaseResourceMapper:
 
     @classproperty
     @lru_cache(maxsize=1)
-    def SUPPORTED_PREFIXES(cls) -> Set[str]:
+    def SUPPORTED_PREFIXES(cls) -> set[str]:
         """A set of prefixes handled by this entry type.
 
         !!! note
@@ -131,7 +132,7 @@ class BaseResourceMapper:
         return {CONFIG.provider.prefix}
 
     @classproperty
-    def ALL_ATTRIBUTES(cls) -> Set[str]:
+    def ALL_ATTRIBUTES(cls) -> set[str]:
         """Returns all attributes served by this entry."""
         from optimade.server.config import CONFIG
 
@@ -147,11 +148,11 @@ class BaseResourceMapper:
                 for field in CONFIG.provider_fields.get(cls.ENDPOINT, ())
                 if isinstance(field, dict)
             )
-            .union(set(cls.get_optimade_field(field) for field in cls.PROVIDER_FIELDS))
+            .union({cls.get_optimade_field(field) for field in cls.PROVIDER_FIELDS})
         )
 
     @classproperty
-    def ENTRY_RESOURCE_ATTRIBUTES(cls) -> Dict[str, Any]:
+    def ENTRY_RESOURCE_ATTRIBUTES(cls) -> dict[str, Any]:
         """Returns the dictionary of attributes defined by the underlying entry resource class."""
         from optimade.server.schemas import retrieve_queryable_properties
 
@@ -173,7 +174,7 @@ class BaseResourceMapper:
 
     @classmethod
     @lru_cache(maxsize=NUM_ENTRY_TYPES)
-    def all_length_aliases(cls) -> Tuple[Tuple[str, str], ...]:
+    def all_length_aliases(cls) -> tuple[tuple[str, str], ...]:
         """Returns all of the associated length aliases for this class,
         including those defined by the server config.
 
@@ -368,7 +369,7 @@ class BaseResourceMapper:
     @classmethod
     def deserialize(
         cls, results: Union[dict, Iterable[dict]]
-    ) -> Union[List[EntryResource], EntryResource]:
+    ) -> Union[list[EntryResource], EntryResource]:
         """Converts the raw database entries for this class into serialized models,
         mapping the data along the way.
 

--- a/optimade/server/middleware.py
+++ b/optimade/server/middleware.py
@@ -9,7 +9,8 @@ import json
 import re
 import urllib.parse
 import warnings
-from typing import Generator, Iterable, List, Optional, TextIO, Type, Union
+from collections.abc import Generator, Iterable
+from typing import Optional, TextIO, Union
 
 from starlette.datastructures import URL as StarletteURL
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -111,7 +112,7 @@ class HandleApiHint(BaseHTTPMiddleware):
     """Handle `api_hint` query parameter."""
 
     @staticmethod
-    def handle_api_hint(api_hint: List[str]) -> Union[None, str]:
+    def handle_api_hint(api_hint: list[str]) -> Union[None, str]:
         """Handle `api_hint` parameter value.
 
         There are several scenarios that can play out, when handling the `api_hint`
@@ -308,12 +309,12 @@ class AddWarnings(BaseHTTPMiddleware):
 
     """
 
-    _warnings: List[Warnings]
+    _warnings: list[Warnings]
 
     def showwarning(
         self,
         message: Union[Warning, str],
-        category: Type[Warning],
+        category: type[Warning],
         filename: str,
         lineno: int,
         file: Optional[TextIO] = None,

--- a/optimade/server/query_params.py
+++ b/optimade/server/query_params.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from typing import Iterable, List
+from collections.abc import Iterable
 from warnings import warn
 
 from fastapi import Query
@@ -21,7 +21,7 @@ class BaseQueryParams(ABC):
 
     """
 
-    unsupported_params: List[str] = []
+    unsupported_params: list[str] = []
 
     def check_params(self, query_params: Iterable[str]) -> None:
         """This method checks whether all the query parameters that are specified
@@ -173,7 +173,7 @@ class EntryListingQueryParams(BaseQueryParams):
     """
 
     # The reference server implementation only supports offset/number-based pagination
-    unsupported_params: List[str] = [
+    unsupported_params: list[str] = [
         "page_cursor",
         "page_below",
     ]

--- a/optimade/server/routers/landing.py
+++ b/optimade/server/routers/landing.py
@@ -13,7 +13,7 @@ from optimade.server.routers import ENTRY_COLLECTIONS
 from optimade.server.routers.utils import get_base_url, meta_values
 
 
-@lru_cache()
+@lru_cache
 def render_landing_page(url: str) -> HTMLResponse:
     """Render and cache the landing page.
 

--- a/optimade/server/routers/links.py
+++ b/optimade/server/routers/links.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 from fastapi import APIRouter, Depends, Request
 
@@ -21,7 +21,7 @@ links_coll = create_collection(
 
 @router.get(
     "/links",
-    response_model=LinksResponse if CONFIG.validate_api_response else Dict,
+    response_model=LinksResponse if CONFIG.validate_api_response else dict,
     response_model_exclude_unset=True,
     tags=["Links"],
     responses=ERROR_RESPONSES,

--- a/optimade/server/routers/references.py
+++ b/optimade/server/routers/references.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 from fastapi import APIRouter, Depends, Request
 
@@ -25,7 +25,7 @@ references_coll = create_collection(
 
 @router.get(
     "/references",
-    response_model=ReferenceResponseMany if CONFIG.validate_api_response else Dict,
+    response_model=ReferenceResponseMany if CONFIG.validate_api_response else dict,
     response_model_exclude_unset=True,
     tags=["References"],
     responses=ERROR_RESPONSES,
@@ -43,7 +43,7 @@ def get_references(
 
 @router.get(
     "/references/{entry_id:path}",
-    response_model=ReferenceResponseOne if CONFIG.validate_api_response else Dict,
+    response_model=ReferenceResponseOne if CONFIG.validate_api_response else dict,
     response_model_exclude_unset=True,
     tags=["References"],
     responses=ERROR_RESPONSES,

--- a/optimade/server/routers/structures.py
+++ b/optimade/server/routers/structures.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 from fastapi import APIRouter, Depends, Request
 
@@ -25,7 +25,7 @@ structures_coll = create_collection(
 
 @router.get(
     "/structures",
-    response_model=StructureResponseMany if CONFIG.validate_api_response else Dict,
+    response_model=StructureResponseMany if CONFIG.validate_api_response else dict,
     response_model_exclude_unset=True,
     tags=["Structures"],
     responses=ERROR_RESPONSES,
@@ -43,7 +43,7 @@ def get_structures(
 
 @router.get(
     "/structures/{entry_id:path}",
-    response_model=StructureResponseOne if CONFIG.validate_api_response else Dict,
+    response_model=StructureResponseOne if CONFIG.validate_api_response else dict,
     response_model_exclude_unset=True,
     tags=["Structures"],
     responses=ERROR_RESPONSES,

--- a/optimade/server/routers/utils.py
+++ b/optimade/server/routers/utils.py
@@ -2,7 +2,7 @@
 import re
 import urllib.parse
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Set, Type, Union
+from typing import Any, Optional, Union
 
 from fastapi import Request
 from fastapi.responses import JSONResponse
@@ -91,10 +91,10 @@ def meta_values(
 
 
 def handle_response_fields(
-    results: Union[List[EntryResource], EntryResource, List[Dict], Dict],
-    exclude_fields: Set[str],
-    include_fields: Set[str],
-) -> List[Dict[str, Any]]:
+    results: Union[list[EntryResource], EntryResource, list[dict], dict],
+    exclude_fields: set[str],
+    include_fields: set[str],
+) -> list[dict[str, Any]]:
     """Handle query parameter `response_fields`.
 
     It is assumed that all fields are under `attributes`.
@@ -137,10 +137,10 @@ def handle_response_fields(
 
 
 def get_included_relationships(
-    results: Union[EntryResource, List[EntryResource], Dict, List[Dict]],
-    ENTRY_COLLECTIONS: Dict[str, EntryCollection],
-    include_param: List[str],
-) -> List[Union[EntryResource, Dict]]:
+    results: Union[EntryResource, list[EntryResource], dict, list[dict]],
+    ENTRY_COLLECTIONS: dict[str, EntryCollection],
+    include_param: list[str],
+) -> list[Union[EntryResource, dict]]:
     """Filters the included relationships and makes the appropriate compound request
     to include them in the response.
 
@@ -168,7 +168,7 @@ def get_included_relationships(
                 f"Known relationship types: {sorted(ENTRY_COLLECTIONS.keys())}"
             )
 
-    endpoint_includes: Dict[Any, Dict] = defaultdict(dict)
+    endpoint_includes: dict[Any, dict] = defaultdict(dict)
     for doc in results:
         # convert list of references into dict by ID to only included unique IDs
         if doc is None:
@@ -197,12 +197,12 @@ def get_included_relationships(
                     if ref["id"] not in endpoint_includes[entry_type]:
                         endpoint_includes[entry_type][ref["id"]] = ref
 
-    included: Dict[
-        str, Union[List[EntryResource], EntryResource, List[Dict], Dict]
+    included: dict[
+        str, Union[list[EntryResource], EntryResource, list[dict], dict]
     ] = {}
     for entry_type in endpoint_includes:
         compound_filter = " OR ".join(
-            ['id="{}"'.format(ref_id) for ref_id in endpoint_includes[entry_type]]
+            [f'id="{ref_id}"' for ref_id in endpoint_includes[entry_type]]
         )
         params = EntryListingQueryParams(
             filter=compound_filter,
@@ -246,10 +246,10 @@ def get_base_url(
 
 def get_entries(
     collection: EntryCollection,
-    response: Type[EntryResponseMany],  # noqa
+    response: type[EntryResponseMany],  # noqa
     request: Request,
     params: EntryListingQueryParams,
-) -> Dict:
+) -> dict:
     """Generalized /{entry} endpoint getter"""
     from optimade.server.routers import ENTRY_COLLECTIONS
 
@@ -304,10 +304,10 @@ def get_entries(
 def get_single_entry(
     collection: EntryCollection,
     entry_id: str,
-    response: Type[EntryResponseOne],
+    response: type[EntryResponseOne],
     request: Request,
     params: SingleEntryQueryParams,
-) -> Dict:
+) -> dict:
     from optimade.server.routers import ENTRY_COLLECTIONS
 
     params.check_params(request.query_params)

--- a/optimade/server/schemas.py
+++ b/optimade/server/schemas.py
@@ -1,4 +1,5 @@
-from typing import Callable, Dict, Iterable, Optional
+from collections.abc import Iterable
+from typing import Callable, Optional
 
 from optimade.models import (
     DataType,
@@ -9,7 +10,7 @@ from optimade.models import (
 
 __all__ = ("ENTRY_INFO_SCHEMAS", "ERROR_RESPONSES", "retrieve_queryable_properties")
 
-ENTRY_INFO_SCHEMAS: Dict[str, Callable[[], Dict]] = {
+ENTRY_INFO_SCHEMAS: dict[str, Callable[[], dict]] = {
     "structures": StructureResource.schema,
     "references": ReferenceResource.schema,
 }
@@ -24,7 +25,7 @@ try:
     """
     from optimade.exceptions import POSSIBLE_ERRORS
 
-    ERROR_RESPONSES: Optional[Dict[int, Dict]] = {
+    ERROR_RESPONSES: Optional[dict[int, dict]] = {
         err.status_code: {"model": ErrorResponse, "description": err.title}
         for err in POSSIBLE_ERRORS
     }

--- a/optimade/utils.py
+++ b/optimade/utils.py
@@ -4,7 +4,8 @@ with OPTIMADE providers that can be used in server or client code.
 """
 
 import json
-from typing import Container, Iterable, List, Optional
+from collections.abc import Container, Iterable
+from typing import Optional
 
 from pydantic import ValidationError
 
@@ -102,7 +103,7 @@ def get_providers(add_mongo_id: bool = False) -> list:
 
 def get_child_database_links(
     provider: LinksResource, obey_aggregate: bool = True
-) -> List[LinksResource]:
+) -> list[LinksResource]:
     """For a provider, return a list of available child databases.
 
     Arguments:

--- a/optimade/validator/config.py
+++ b/optimade/validator/config.py
@@ -7,7 +7,8 @@ the hardcoded values.
 
 """
 
-from typing import Any, Container, Dict, List, Set
+from collections.abc import Container
+from typing import Any
 
 from pydantic import BaseSettings, Field
 
@@ -122,26 +123,26 @@ class ValidatorConfig(BaseSettings):
 
     """
 
-    response_classes: Dict[str, Any] = Field(
+    response_classes: dict[str, Any] = Field(
         _RESPONSE_CLASSES,
         description="Dictionary containing the mapping between endpoints and response classes for the main database",
     )
 
-    response_classes_index: Dict[str, Any] = Field(
+    response_classes_index: dict[str, Any] = Field(
         _RESPONSE_CLASSES_INDEX,
         description="Dictionary containing the mapping between endpoints and response classes for the index meta-database",
     )
 
-    entry_schemas: Dict[str, Any] = Field(
+    entry_schemas: dict[str, Any] = Field(
         _ENTRY_SCHEMAS, description="The entry listing endpoint schemas"
     )
 
-    entry_endpoints: Set[str] = Field(
+    entry_endpoints: set[str] = Field(
         _ENTRY_ENDPOINTS,
         description="The entry endpoints to validate, if present in the API's `/info` response `entry_types_by_format['json']`",
     )
 
-    unique_properties: Set[str] = Field(
+    unique_properties: set[str] = Field(
         _UNIQUE_PROPERTIES,
         description=(
             "Fields that should be treated as unique indexes for all endpoints, "
@@ -149,7 +150,7 @@ class ValidatorConfig(BaseSettings):
         ),
     )
 
-    inclusive_operators: Dict[DataType, Set[str]] = Field(
+    inclusive_operators: dict[DataType, set[str]] = Field(
         _INCLUSIVE_OPERATORS,
         description=(
             "Dictionary mapping OPTIMADE `DataType`s to a list of operators that are 'inclusive', "
@@ -157,7 +158,7 @@ class ValidatorConfig(BaseSettings):
         ),
     )
 
-    exclusive_operators: Dict[DataType, Set[str]] = Field(
+    exclusive_operators: dict[DataType, set[str]] = Field(
         _EXCLUSIVE_OPERATORS,
         description=(
             "Dictionary mapping OPTIMADE `DataType`s to a list of operators that are 'exclusive', "
@@ -165,7 +166,7 @@ class ValidatorConfig(BaseSettings):
         ),
     )
 
-    field_specific_overrides: Dict[str, Dict[SupportLevel, Container[str]]] = Field(
+    field_specific_overrides: dict[str, dict[SupportLevel, Container[str]]] = Field(
         _FIELD_SPECIFIC_OVERRIDES,
         description=(
             "Some fields do not require all type comparison operators to be supported. "
@@ -181,16 +182,16 @@ class ValidatorConfig(BaseSettings):
     )
 
     info_endpoint: str = Field("info", description="The name of the info endpoint")
-    non_entry_endpoints: Set[str] = Field(
+    non_entry_endpoints: set[str] = Field(
         _NON_ENTRY_ENDPOINTS,
         description="The list specification-mandated endpoint names that do not contain entries",
     )
-    top_level_non_attribute_fields: Set[str] = Field(
+    top_level_non_attribute_fields: set[str] = Field(
         BaseResourceMapper.TOP_LEVEL_NON_ATTRIBUTES_FIELDS,
         description="Field names to treat as top-level",
     )
 
-    enum_fallback_values: Dict[str, Dict[str, List[str]]] = Field(
+    enum_fallback_values: dict[str, dict[str, list[str]]] = Field(
         _ENUM_DUMMY_VALUES,
         description="Provide fallback values for enum fields to use when validating filters.",
     )

--- a/optimade/validator/utils.py
+++ b/optimade/validator/utils.py
@@ -18,7 +18,7 @@ import sys
 import time
 import traceback as tb
 import urllib.parse
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Optional
 
 import requests
 from pydantic import Field, ValidationError
@@ -80,11 +80,11 @@ class ValidatorResults:
     internal_failure_count: int = 0
     optional_success_count: int = 0
     optional_failure_count: int = 0
-    failure_messages: List[Tuple[str, str]] = dataclasses.field(default_factory=list)
-    internal_failure_messages: List[Tuple[str, str]] = dataclasses.field(
+    failure_messages: list[tuple[str, str]] = dataclasses.field(default_factory=list)
+    internal_failure_messages: list[tuple[str, str]] = dataclasses.field(
         default_factory=list
     )
-    optional_failure_messages: List[Tuple[str, str]] = dataclasses.field(
+    optional_failure_messages: list[tuple[str, str]] = dataclasses.field(
         default_factory=list
     )
     verbosity: int = 0
@@ -146,7 +146,7 @@ class ValidatorResults:
             self.optional_failure_count += 1
             self.optional_failure_messages.append((summary, message))
 
-        pprint_types: Dict[str, Tuple[Callable, Callable]] = {
+        pprint_types: dict[str, tuple[Callable, Callable]] = {
             "internal": (print_notify, print_warning),
             "optional": (print, print),
         }
@@ -168,7 +168,7 @@ class Client:  # pragma: no cover
         self,
         base_url: str,
         max_retries: int = 5,
-        headers: Optional[Dict[str, str]] = None,
+        headers: Optional[dict[str, str]] = None,
         timeout: Optional[float] = DEFAULT_CONN_TIMEOUT,
         read_timeout: Optional[float] = DEFAULT_READ_TIMEOUT,
     ) -> None:
@@ -267,7 +267,7 @@ class Client:  # pragma: no cover
             raise ResponseError(message)
 
 
-def test_case(test_fn: Callable[..., Tuple[Any, str]]):
+def test_case(test_fn: Callable[..., tuple[Any, str]]):
     """Wrapper for test case functions, which pretty-prints any errors
     depending on verbosity level, collates the number and severity of
     test failures, returns the response and summary string to the caller.
@@ -404,19 +404,19 @@ def test_case(test_fn: Callable[..., Tuple[Any, str]]):
 
 class ValidatorLinksResponse(Success):
     meta: ResponseMeta = Field(...)
-    data: List[LinksResource] = Field(...)
+    data: list[LinksResource] = Field(...)
 
 
 class ValidatorEntryResponseOne(Success):
     meta: ResponseMeta = Field(...)
     data: EntryResource = Field(...)
-    included: Optional[List[Dict[str, Any]]] = Field(None)  # type: ignore[assignment]
+    included: Optional[list[dict[str, Any]]] = Field(None)  # type: ignore[assignment]
 
 
 class ValidatorEntryResponseMany(Success):
     meta: ResponseMeta = Field(...)
-    data: List[EntryResource] = Field(...)
-    included: Optional[List[Dict[str, Any]]] = Field(None)  # type: ignore[assignment]
+    data: list[EntryResource] = Field(...)
+    included: Optional[list[dict[str, Any]]] = Field(None)  # type: ignore[assignment]
 
 
 class ValidatorReferenceResponseOne(ValidatorEntryResponseOne):
@@ -424,7 +424,7 @@ class ValidatorReferenceResponseOne(ValidatorEntryResponseOne):
 
 
 class ValidatorReferenceResponseMany(ValidatorEntryResponseMany):
-    data: List[ReferenceResource] = Field(...)
+    data: list[ReferenceResource] = Field(...)
 
 
 class ValidatorStructureResponseOne(ValidatorEntryResponseOne):
@@ -432,4 +432,4 @@ class ValidatorStructureResponseOne(ValidatorEntryResponseOne):
 
 
 class ValidatorStructureResponseMany(ValidatorEntryResponseMany):
-    data: List[StructureResource] = Field(...)
+    data: list[StructureResource] = Field(...)

--- a/optimade/validator/validator.py
+++ b/optimade/validator/validator.py
@@ -13,7 +13,7 @@ import random
 import re
 import sys
 import urllib.parse
-from typing import Any, Dict, List, Optional, Set, Tuple, Union
+from typing import Any, Optional, Union
 
 import requests
 
@@ -72,7 +72,7 @@ class ImplementationValidator:
         as_type: Optional[str] = None,
         index: bool = False,
         minimal: bool = False,
-        http_headers: Optional[Dict[str, str]] = None,
+        http_headers: Optional[dict[str, str]] = None,
         timeout: float = DEFAULT_CONN_TIMEOUT,
         read_timeout: float = DEFAULT_READ_TIMEOUT,
     ):
@@ -176,8 +176,8 @@ class ImplementationValidator:
 
         self.valid = None
 
-        self._test_id_by_type: Dict[str, Any] = {}
-        self._entry_info_by_type: Dict[str, Any] = {}
+        self._test_id_by_type: dict[str, Any] = {}
+        self._entry_info_by_type: dict[str, Any] = {}
 
         self.results = ValidatorResults(verbosity=self.verbosity)
 
@@ -353,7 +353,7 @@ class ImplementationValidator:
         self.print_summary()
 
     @test_case
-    def _recurse_through_endpoint(self, endp: str) -> Tuple[Optional[bool], str]:
+    def _recurse_through_endpoint(self, endp: str) -> tuple[Optional[bool], str]:
         """For a given endpoint (`endp`), get the entry type
         and supported fields, testing that all mandatory fields
         are supported, then test queries on every property according
@@ -450,8 +450,8 @@ class ImplementationValidator:
         )
 
     def _check_entry_info(
-        self, entry_info: Dict[str, Any], endp: str
-    ) -> Dict[str, Dict[str, Any]]:
+        self, entry_info: dict[str, Any], endp: str
+    ) -> dict[str, dict[str, Any]]:
         """Checks that `entry_info` contains all the required properties,
         and returns the property list for the endpoint.
 
@@ -473,8 +473,8 @@ class ImplementationValidator:
 
     @test_case
     def _test_must_properties(
-        self, properties: List[str], endp: str
-    ) -> Tuple[bool, str]:
+        self, properties: list[str], endp: str
+    ) -> tuple[bool, str]:
         """Check that the entry info lists all properties with the "MUST"
         support level for this endpoint.
 
@@ -486,13 +486,13 @@ class ImplementationValidator:
             `True` if the properties were found, and a string summary.
 
         """
-        must_props = set(
+        must_props = {
             prop
             for prop in CONF.entry_schemas.get(endp, {})
             if CONF.entry_schemas[endp].get(prop, {}).get("support")
             == SupportLevel.MUST
-        )
-        must_props_supported = set(prop for prop in properties if prop in must_props)
+        }
+        must_props_supported = {prop for prop in properties if prop in must_props}
         missing = must_props - must_props_supported
         if len(missing) != 0:
             raise ResponseError(
@@ -503,8 +503,8 @@ class ImplementationValidator:
 
     @test_case
     def _get_archetypal_entry(
-        self, endp: str, properties: List[str]
-    ) -> Tuple[Optional[Dict[str, Any]], str]:
+        self, endp: str, properties: list[str]
+    ) -> tuple[Optional[dict[str, Any]], str]:
         """Get a random entry from the first page of results for this
         endpoint.
 
@@ -544,8 +544,8 @@ class ImplementationValidator:
 
     @test_case
     def _check_response_fields(
-        self, endp: str, fields: List[str]
-    ) -> Tuple[Optional[bool], str]:
+        self, endp: str, fields: list[str]
+    ) -> tuple[Optional[bool], str]:
         """Check that the response field query parameter is obeyed.
 
         Parameters:
@@ -593,8 +593,8 @@ class ImplementationValidator:
         prop_type: DataType,
         sortable: bool,
         endp: str,
-        chosen_entry: Dict[str, Any],
-    ) -> Tuple[Optional[bool], str]:
+        chosen_entry: dict[str, Any],
+    ) -> tuple[Optional[bool], str]:
         """For the given property, property type and chose entry, this method
         runs a series of queries for each field in the entry, testing that the
         initial document is returned where expected.
@@ -704,9 +704,9 @@ class ImplementationValidator:
         prop_type: DataType,
         sortable: bool,
         endp: str,
-        chosen_entry: Dict[str, Any],
+        chosen_entry: dict[str, Any],
         query_optional: bool,
-    ) -> Tuple[Optional[bool], str]:
+    ) -> tuple[Optional[bool], str]:
         """This method constructs appropriate queries using all operators
         for a certain field and applies some tests:
 
@@ -847,7 +847,7 @@ class ImplementationValidator:
             # if we have all results on this page, check that the blessed ID is in the response
             if excluded and (
                 chosen_entry.get("id", "")
-                in set(entry.get("id") for entry in response["data"])
+                in {entry.get("id") for entry in response["data"]}
             ):
                 raise ResponseError(
                     f"Entry {chosen_entry['id']} with value {prop!r}: {test_value} was not excluded by {query!r}"
@@ -1060,7 +1060,7 @@ class ImplementationValidator:
     @test_case
     def _test_data_available_matches_data_returned(
         self, deserialized: Any
-    ) -> Tuple[Optional[bool], str]:
+    ) -> tuple[Optional[bool], str]:
         """In the case where no query is requested, `data_available`
         must equal `data_returned` in the meta response, which is tested
         here.
@@ -1126,7 +1126,7 @@ class ImplementationValidator:
     @test_case
     def _test_versions_endpoint_content(
         self, response: requests.Response
-    ) -> Tuple[requests.Response, str]:
+    ) -> tuple[requests.Response, str]:
         """Checks that the response from the versions endpoint complies
         with the specification and that its 'Content-Type' header complies with
         [RFC 4180](https://tools.ietf.org/html/rfc4180.html).
@@ -1186,9 +1186,9 @@ class ImplementationValidator:
     @test_case
     def _test_versions_headers(
         self,
-        content_type: Dict[str, Any],
-        expected_parameter: Union[str, List[str]],
-    ) -> Tuple[Dict[str, Any], str]:
+        content_type: dict[str, Any],
+        expected_parameter: Union[str, list[str]],
+    ) -> tuple[dict[str, Any], str]:
         """Tests that the `Content-Type` field of the `/versions` header contains
         the passed parameter.
 
@@ -1270,8 +1270,8 @@ class ImplementationValidator:
         self,
         response: requests.models.Response,
         check_next_link: int = 5,
-        previous_links: Optional[Set[str]] = None,
-    ) -> Tuple[Optional[bool], str]:
+        previous_links: Optional[set[str]] = None,
+    ) -> tuple[Optional[bool], str]:
         """Test that a multi-entry endpoint obeys the page limit by
         following pagination links up to a depth of `check_next_link`.
 
@@ -1387,7 +1387,7 @@ class ImplementationValidator:
         response: requests.models.Response,
         response_cls: Any,
         request: Optional[str] = None,
-    ) -> Tuple[Any, str]:
+    ) -> tuple[Any, str]:
         """Try to create the appropriate pydantic model from the response.
 
         Parameters:
@@ -1416,13 +1416,13 @@ class ImplementationValidator:
 
         return (
             response_cls(**json_response),
-            "deserialized correctly as object of type {}".format(response_cls),
+            f"deserialized correctly as object of type {response_cls}",
         )
 
     @test_case
     def _get_available_endpoints(
-        self, base_info: Union[Any, Dict[str, Any]]
-    ) -> Tuple[Optional[List[str]], str]:
+        self, base_info: Union[Any, dict[str, Any]]
+    ) -> tuple[Optional[list[str]], str]:
         """Tries to get `entry_types_by_format` from base info response
         even if it could not be deserialized.
 
@@ -1478,8 +1478,8 @@ class ImplementationValidator:
 
     @test_case
     def _get_endpoint(
-        self, request_str: str, expected_status_code: Union[List[int], int] = 200
-    ) -> Tuple[Optional[requests.Response], str]:
+        self, request_str: str, expected_status_code: Union[list[int], int] = 200
+    ) -> tuple[Optional[requests.Response], str]:
         """Gets the response from the endpoint specified by `request_str`.
         function is wrapped by the `test_case` decorator
 

--- a/tasks.py
+++ b/tasks.py
@@ -3,7 +3,7 @@ import os
 import re
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional, Tuple
+from typing import TYPE_CHECKING, Optional
 
 from invoke import task
 from jsondiff import diff
@@ -15,9 +15,9 @@ if TYPE_CHECKING:
 TOP_DIR = Path(__file__).parent.resolve()
 
 
-def update_file(filename: str, sub_line: Tuple[str, str], strip: Optional[str] = None):
+def update_file(filename: str, sub_line: tuple[str, str], strip: Optional[str] = None):
     """Utility function for tasks to read, update, and write files"""
-    with open(filename, "r") as handle:
+    with open(filename) as handle:
         lines = [
             re.sub(sub_line[0], sub_line[1], line.rstrip(strip)) for line in handle
         ]
@@ -119,7 +119,7 @@ def setver(_, ver=""):
         (r'"version": ".*",', f'"version": "{ver}",'),
     )
 
-    print("Bumped version to {}".format(ver))
+    print(f"Bumped version to {ver}")
 
 
 @task(help={"ver": "OPTIMADE API version to set"}, post=[update_openapijson])
@@ -191,7 +191,7 @@ def create_api_reference_docs(context, pre_clean=False, pre_commit=False):
     def write_file(full_path: Path, content: str):
         """Write file with `content` to `full_path`"""
         if full_path.exists():
-            with open(full_path, "r") as handle:
+            with open(full_path) as handle:
                 cached_content = handle.read()
             if content == cached_content:
                 del cached_content
@@ -306,7 +306,7 @@ def swagger_validator(_, fname):
             print(f"\033[31m{line}\033[0m")
 
     swagger_url = "https://validator.swagger.io/validator/debug"
-    with open(fname, "r") as f:
+    with open(fname) as f:
         schema = json.load(f)
     response = requests.post(swagger_url, json=schema)
 

--- a/tests/adapters/references/conftest.py
+++ b/tests/adapters/references/conftest.py
@@ -10,9 +10,7 @@ from optimade.adapters.references import Reference
 @pytest.fixture
 def RAW_REFERENCES():
     """Read and return raw_references.json"""
-    with open(
-        Path(__file__).parent.joinpath("raw_test_references.json"), "r"
-    ) as raw_data:
+    with open(Path(__file__).parent.joinpath("raw_test_references.json")) as raw_data:
         return json.load(raw_data)
 
 

--- a/tests/adapters/structures/conftest.py
+++ b/tests/adapters/structures/conftest.py
@@ -1,7 +1,6 @@
 import json
 from pathlib import Path
 from random import choice
-from typing import List
 
 import pytest
 
@@ -9,18 +8,16 @@ from optimade.adapters.structures import Structure
 
 
 @pytest.fixture
-def RAW_STRUCTURES() -> List[dict]:
+def RAW_STRUCTURES() -> list[dict]:
     """Read and return raw_structures.json"""
-    with open(
-        Path(__file__).parent.joinpath("raw_test_structures.json"), "r"
-    ) as raw_data:
+    with open(Path(__file__).parent.joinpath("raw_test_structures.json")) as raw_data:
         return json.load(raw_data)
 
 
 @pytest.fixture
-def SPECIAL_SPECIES_STRUCTURES() -> List[dict]:
+def SPECIAL_SPECIES_STRUCTURES() -> list[dict]:
     """Read and return special_species.json"""
-    with open(Path(__file__).parent.joinpath("special_species.json"), "r") as raw_data:
+    with open(Path(__file__).parent.joinpath("special_species.json")) as raw_data:
         return json.load(raw_data)
 
 
@@ -37,7 +34,7 @@ def structure(raw_structure) -> Structure:
 
 
 @pytest.fixture
-def structures(RAW_STRUCTURES) -> List[Structure]:
+def structures(RAW_STRUCTURES) -> list[Structure]:
     """Create and return list of adapters.Structure"""
     return [Structure(_) for _ in RAW_STRUCTURES]
 

--- a/tests/adapters/structures/utils.py
+++ b/tests/adapters/structures/utils.py
@@ -5,7 +5,7 @@ from pathlib import Path
 def get_min_ver(dependency: str) -> str:
     """Retrieve version of `dependency` from setup.py, raise if not found."""
     pyproject_toml = Path(__file__).parent.joinpath("../../../pyproject.toml")
-    with open(pyproject_toml, "r") as setup_file:
+    with open(pyproject_toml) as setup_file:
         for line in setup_file.readlines():
             min_ver = re.findall(rf'"{dependency}((=|!|<|>|~)=|>|<)(.+)"', line)
             if min_ver:

--- a/tests/filterparser/test_filterparser.py
+++ b/tests/filterparser/test_filterparser.py
@@ -1,5 +1,4 @@
 import abc
-from typing import Tuple
 
 import pytest
 from lark import Tree
@@ -11,7 +10,7 @@ from optimade.filterparser import LarkParser
 class BaseTestFilterParser(abc.ABC):
     """Base class for parsing different versions of the grammar using `LarkParser`."""
 
-    version: Tuple[int, int, int]
+    version: tuple[int, int, int]
     variant: str = "default"
 
     @pytest.fixture(autouse=True)

--- a/tests/models/conftest.py
+++ b/tests/models/conftest.py
@@ -12,7 +12,7 @@ def load_test_data(filename: str) -> list:
     if not json_file_path.exists():
         raise RuntimeError(f"Could not find {filename!r} in 'tests.models.test_data'")
 
-    with open(json_file_path, "r") as handle:
+    with open(json_file_path) as handle:
         data = json.load(handle)
 
     return data

--- a/tests/models/test_jsonapi.py
+++ b/tests/models/test_jsonapi.py
@@ -8,7 +8,7 @@ def test_hashability():
     from optimade.models.jsonapi import Error
 
     error = Error(id="test")
-    assert set([error])
+    assert {error}
 
 
 def test_toplevel_links():

--- a/tests/models/test_optimade_json.py
+++ b/tests/models/test_optimade_json.py
@@ -31,7 +31,7 @@ def test_convert_python_types():
 
     test_none = None
     python_types_as_objects = [
-        str("Test"),
+        "Test",
         42,
         42.42,
         ["Test", 42],

--- a/tests/models/test_structures.py
+++ b/tests/models/test_structures.py
@@ -194,7 +194,7 @@ def test_structure_fatal_deformities(good_structure, deformity):
 
 
 minor_deformities = (
-    {f: None} for f in set(f for _ in CORRELATED_STRUCTURE_FIELDS for f in _)
+    {f: None} for f in {f for _ in CORRELATED_STRUCTURE_FIELDS for f in _}
 )
 
 

--- a/tests/models/test_utils.py
+++ b/tests/models/test_utils.py
@@ -1,4 +1,4 @@
-from typing import Callable, List
+from typing import Callable
 
 import pytest
 from pydantic import BaseModel, Field, ValidationError
@@ -46,7 +46,7 @@ def test_compatible_strict_optimade_field() -> None:
 
     class CorrectModelWithStrictField(BaseModel):
         # check that unit and uniqueItems are passed through
-        good_field: List[str] = StrictField(
+        good_field: list[str] = StrictField(
             ...,
             support=SupportLevel.MUST,
             queryable=SupportLevel.OPTIONAL,
@@ -58,7 +58,7 @@ def test_compatible_strict_optimade_field() -> None:
         )
 
     class CorrectModelWithOptimadeField(BaseModel):
-        good_field: List[str] = OptimadeField(
+        good_field: list[str] = OptimadeField(
             ...,
             # Only difference here is that OptimadeField allows case-insensitive
             # strings to be passed instead of support levels directly

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, Union
+from typing import Optional, Union
 
 import pytest
 
@@ -124,7 +124,6 @@ def check_response(get_good_response):
         server: The type of server to test, or the actual test client class.
 
     """
-    from typing import List
 
     from optimade.server.config import CONFIG
 
@@ -132,11 +131,11 @@ def check_response(get_good_response):
 
     def inner(
         request: str,
-        expected_ids: Union[str, List[str]],
+        expected_ids: Union[str, list[str]],
         page_limit: int = CONFIG.page_limit,
         expected_return: Optional[int] = None,
         expected_as_is: bool = False,
-        expected_warnings: Optional[List[Dict[str, str]]] = None,
+        expected_warnings: Optional[list[dict[str, str]]] = None,
         server: Union[str, OptimadeTestClient] = "regular",
     ):
         if expected_warnings:

--- a/tests/server/query_params/conftest.py
+++ b/tests/server/query_params/conftest.py
@@ -12,13 +12,13 @@ def structures():
 @pytest.fixture
 def check_include_response(get_good_response):
     """Fixture to check "good" `include` response"""
-    from typing import List, Optional, Set, Union
+    from typing import Optional, Union
 
     def inner(
         request: str,
-        expected_included_types: Union[List, Set],
-        expected_included_resources: Union[List, Set],
-        expected_relationship_types: Optional[Union[List, Set]] = None,
+        expected_included_types: Union[list, set],
+        expected_included_resources: Union[list, set],
+        expected_relationship_types: Optional[Union[list, set]] = None,
         server: str = "regular",
     ):
         response = get_good_response(request, server)

--- a/tests/server/routers/test_utils.py
+++ b/tests/server/routers/test_utils.py
@@ -1,5 +1,6 @@
 """Tests specifically for optimade.servers.routers.utils."""
-from typing import Mapping, Optional, Tuple, Union
+from collections.abc import Mapping
+from typing import Optional, Union
 from unittest import mock
 
 import pytest
@@ -8,7 +9,7 @@ from requests.exceptions import ConnectionError
 
 def mocked_providers_list_response(
     url: Union[str, bytes] = "",
-    param: Optional[Union[Mapping[str, str], Tuple[str, str]]] = None,
+    param: Optional[Union[Mapping[str, str], tuple[str, str]]] = None,
     **kwargs,
 ):
     """This function will be used to mock requests.get

--- a/tests/server/test_client.py
+++ b/tests/server/test_client.py
@@ -5,7 +5,7 @@ import json
 import warnings
 from functools import partial
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Optional
 
 import httpx
 import pytest
@@ -337,7 +337,7 @@ def test_command_line_client_write_to_file(
     assert 'Performing query structures/?filter=elements HAS "Ag"' in captured.err
     assert not captured.out
     assert Path(test_filename).is_file()
-    with open(test_filename, "r") as f:
+    with open(test_filename) as f:
         results = json.load(f)
     for url in TEST_URLS:
         assert len(results["structures"]['elements HAS "Ag"'][url]["data"]) == 11
@@ -360,9 +360,9 @@ def test_strict_async(async_http_client, http_client, use_async):
 
 @pytest.mark.parametrize("use_async", [True, False])
 def test_client_global_data_callback(async_http_client, http_client, use_async):
-    container: Dict[str, str] = {}
+    container: dict[str, str] = {}
 
-    def global_database_callback(_: str, results: Dict):
+    def global_database_callback(_: str, results: dict):
         """A test callback that creates a flat dictionary of results via global state"""
 
         for structure in results["data"]:
@@ -386,7 +386,7 @@ def test_client_global_data_callback(async_http_client, http_client, use_async):
 
 @pytest.mark.parametrize("use_async", [True, False])
 def test_client_page_skip_callback(async_http_client, http_client, use_async):
-    def page_skip_callback(_: str, results: Dict) -> Optional[Dict]:
+    def page_skip_callback(_: str, results: dict) -> Optional[dict]:
         """A test callback that skips to the final page of results."""
         if len(results["data"]) > 16:
             return {"next": f"{TEST_URL}/structures?page_offset=16"}
@@ -407,10 +407,10 @@ def test_client_page_skip_callback(async_http_client, http_client, use_async):
 
 @pytest.mark.parametrize("use_async", [True, False])
 def test_client_mutable_data_callback(async_http_client, http_client, use_async):
-    container: Dict[str, str] = {}
+    container: dict[str, str] = {}
 
     def mutable_database_callback(
-        _: str, results: Dict, db: Optional[Dict[str, str]] = None
+        _: str, results: dict, db: Optional[dict[str, str]] = None
     ) -> None:
         """A test callback that creates a flat dictionary of results via mutable args."""
 
@@ -436,7 +436,7 @@ def test_client_mutable_data_callback(async_http_client, http_client, use_async)
 def test_client_asynchronous_write_callback(
     async_http_client, http_client, use_async, tmp_path
 ):
-    def write_to_file(_: str, results: Dict):
+    def write_to_file(_: str, results: dict):
         """A test callback that creates a flat dictionary of results via global state"""
 
         with open(tmp_path / "formulae.csv", "a") as f:
@@ -458,7 +458,7 @@ def test_client_asynchronous_write_callback(
 
     cli.get(response_fields=["chemical_formula_reduced"])
 
-    with open(tmp_path / "formulae.csv", "r") as f:
+    with open(tmp_path / "formulae.csv") as f:
         lines = f.readlines()
 
     assert len(lines) == 17 * len(TEST_URLS) + 1

--- a/tests/server/test_config.py
+++ b/tests/server/test_config.py
@@ -33,7 +33,7 @@ def test_default_config_path(top_dir):
 
     org_env_var = os.getenv("OPTIMADE_CONFIG_FILE")
 
-    with open(top_dir.joinpath("tests/test_config.json"), "r") as config_file:
+    with open(top_dir.joinpath("tests/test_config.json")) as config_file:
         config = json.load(config_file)
 
     different_base_url = "http://something_you_will_never_think_of.com"

--- a/tests/server/utils.py
+++ b/tests/server/utils.py
@@ -1,7 +1,8 @@
 import json
 import re
 import warnings
-from typing import Iterable, Optional, Type, Union
+from collections.abc import Iterable
+from typing import Optional, Union
 from urllib.parse import urlparse
 
 import httpx
@@ -31,7 +32,7 @@ class OptimadeTestClient(TestClient):
         root_path: str = "",
         version: str = "",
     ) -> None:
-        super(OptimadeTestClient, self).__init__(
+        super().__init__(
             app=app,
             base_url=base_url,
             raise_server_exceptions=raise_server_exceptions,
@@ -64,7 +65,7 @@ class OptimadeTestClient(TestClient):
             while url.startswith("/"):
                 url = url[1:]
             url = f"{self.version}/{url}"
-        return super(OptimadeTestClient, self).request(
+        return super().request(
             method=method,
             url=url,
             **kwargs,
@@ -75,7 +76,7 @@ class BaseEndpointTests:
     """Base class for common tests of endpoints"""
 
     request_str: Optional[str] = None
-    response_cls: Optional[Type[jsonapi.Response]] = None
+    response_cls: Optional[type[jsonapi.Response]] = None
 
     response: Optional[httpx.Response] = None
     json_response: Optional[dict] = None
@@ -223,7 +224,7 @@ class NoJsonEndpointTests:
     """A simplified mixin class for tests on non-JSON endpoints."""
 
     request_str: Optional[str] = None
-    response_cls: Optional[Type] = None
+    response_cls: Optional[type] = None
 
     response: Optional[httpx.Response] = None
 


### PR DESCRIPTION
This PR is complementary to #1745. I will first investigate how easy it is to merge the two...

- [x] Add `pyupgrade --py39-plus` as a pre-commit hook and run it
- [x] Use 3.9 as base version of CI/pre-commit to avoid any compatibility issues between tools