### PR TITLE
Fix an inappropriate test expression to remove a logical short circuit

### DIFF
--- a/optimade/validator/validator.py
+++ b/optimade/validator/validator.py
@@ -561,7 +561,7 @@ class ImplementationValidator:
         test_query = f"{endp}?response_fields={','.join(subset_fields)}&page_limit=1"
         response, _ = self._get_endpoint(test_query, multistage=True)
 
-        if response and len(response.json()["data"]) >= 0:
+        if response and len(response.json()["data"]) > 0:
             doc = response.json()["data"][0]
             expected_fields = set(subset_fields)
             expected_fields -= CONF.top_level_non_attribute_fields


### PR DESCRIPTION
In file: validator.py, the comparison of Collection length creates a logical short circuit. I suggested that the Collection length comparison should be done without creating a logical short circuit. 

Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.