### PR TITLE
Switch entirely to ruff and remove all other linters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,12 +2,6 @@ default_language_version:
   python: python3.9
 
 repos:
-  - repo: https://github.com/ambv/black
-    rev: 23.11.0
-    hooks:
-    - id: black
-      name: Blacken
-
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:
@@ -30,10 +24,11 @@ repos:
       args: ["--py39-plus"]
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: 'v0.1.6'
+    rev: 'v0.1.8'
     hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]
+    - id: ruff-format
 
   - repo: local
     hooks:

--- a/optimade/adapters/__init__.py
+++ b/optimade/adapters/__init__.py
@@ -1,4 +1,3 @@
-# pylint: disable=undefined-variable
 from .exceptions import *  # noqa: F403
 from .references import *  # noqa: F403
 from .structures import *  # noqa: F403

--- a/optimade/adapters/structures/cif.py
+++ b/optimade/adapters/structures/cif.py
@@ -38,7 +38,7 @@ except ImportError:
 __all__ = ("get_cif",)
 
 
-def get_cif(  # pylint: disable=too-many-locals,too-many-branches
+def get_cif(
     optimade_structure: OptimadeStructure,
 ) -> str:
     """Get CIF file as string from OPTIMADE structure.

--- a/optimade/adapters/structures/cif.py
+++ b/optimade/adapters/structures/cif.py
@@ -122,7 +122,8 @@ def get_cif(  # pylint: disable=too-many-locals,too-many-branches
         sites = attributes.cartesian_site_positions
 
     species: dict[str, OptimadeStructureSpecies] = {
-        species.name: species for species in attributes.species  # type: ignore[union-attr]
+        species.name: species
+        for species in attributes.species  # type: ignore[union-attr]
     }
 
     symbol_occurences: dict[str, int] = {}

--- a/optimade/adapters/structures/proteindatabank.py
+++ b/optimade/adapters/structures/proteindatabank.py
@@ -163,7 +163,8 @@ def get_pdbx_mmcif(  # pylint: disable=too-many-locals
         sites = attributes.cartesian_site_positions
 
     species: dict[str, OptimadeStructureSpecies] = {
-        species.name: species for species in attributes.species  # type: ignore[union-attr]
+        species.name: species
+        for species in attributes.species  # type: ignore[union-attr]
     }
 
     for site_number in range(attributes.nsites):  # type: ignore[arg-type]

--- a/optimade/adapters/structures/proteindatabank.py
+++ b/optimade/adapters/structures/proteindatabank.py
@@ -44,7 +44,7 @@ from optimade.models import StructureResource as OptimadeStructure
 __all__ = ("get_pdb", "get_pdbx_mmcif")
 
 
-def get_pdbx_mmcif(  # pylint: disable=too-many-locals
+def get_pdbx_mmcif(
     optimade_structure: OptimadeStructure,
 ) -> str:
     """Write Protein Data Bank (PDB) structure in the PDBx/mmCIF format from OPTIMADE structure.
@@ -196,7 +196,7 @@ def get_pdbx_mmcif(  # pylint: disable=too-many-locals
     return cif
 
 
-def get_pdb(  # pylint: disable=too-many-locals
+def get_pdb(
     optimade_structure: OptimadeStructure,
 ) -> str:
     """Write Protein Data Bank (PDB) structure in the old PDB format from OPTIMADE structure.

--- a/optimade/adapters/structures/utils.py
+++ b/optimade/adapters/structures/utils.py
@@ -32,7 +32,7 @@ def valid_lattice_vector(lattice_vec: tuple[Vector3D, Vector3D, Vector3D]):
 
 
 def scaled_cell(
-    cell: tuple[Vector3D, Vector3D, Vector3D]
+    cell: tuple[Vector3D, Vector3D, Vector3D],
 ) -> tuple[Vector3D, Vector3D, Vector3D]:
     """Return a scaled 3x3 cell from cartesian 3x3 cell (`lattice_vectors`).
     This 3x3 matrix can be used to calculate the fractional coordinates from the cartesian_site_positions.

--- a/optimade/filtertransformers/base_transformer.py
+++ b/optimade/filtertransformers/base_transformer.py
@@ -106,7 +106,7 @@ class BaseTransformer(Transformer, abc.ABC):
     _quantity_type: type[Quantity] = Quantity
     _quantities = None
 
-    def __init__(self, mapper: Optional[type[BaseResourceMapper]] = None):  # pylint: disable=super-init-not-called
+    def __init__(self, mapper: Optional[type[BaseResourceMapper]] = None):
         """Initialise the transformer object, optionally loading in a
         resource mapper for use when post-processing.
 

--- a/optimade/filtertransformers/base_transformer.py
+++ b/optimade/filtertransformers/base_transformer.py
@@ -106,9 +106,7 @@ class BaseTransformer(Transformer, abc.ABC):
     _quantity_type: type[Quantity] = Quantity
     _quantities = None
 
-    def __init__(
-        self, mapper: Optional[type[BaseResourceMapper]] = None
-    ):  # pylint: disable=super-init-not-called
+    def __init__(self, mapper: Optional[type[BaseResourceMapper]] = None):  # pylint: disable=super-init-not-called
         """Initialise the transformer object, optionally loading in a
         resource mapper for use when post-processing.
 
@@ -121,7 +119,8 @@ class BaseTransformer(Transformer, abc.ABC):
         [`Quantity`][optimade.filtertransformers.base_transformer.Quantity] object.
         """
         return {
-            quantity.backend_field: quantity for _, quantity in self.quantities.items()  # type: ignore[misc]
+            quantity.backend_field: quantity  # type: ignore[misc]
+            for _, quantity in self.quantities.items()
         }
 
     @property

--- a/optimade/filtertransformers/elasticsearch.py
+++ b/optimade/filtertransformers/elasticsearch.py
@@ -188,7 +188,7 @@ class ElasticTransformer(BaseTransformer):
             # != queries must also include an existence check
             # Note that for MongoDB, `$exists` will include null-valued fields,
             # where as in ES `exists` excludes them.
-            # pylint: disable=invalid-unary-operand-type
+
             return ~Q(query_type, **{field: value}) & Q("exists", field=field)
 
     def _has_query_op(self, quantities, op, predicate_zip_list):
@@ -372,7 +372,7 @@ class ElasticTransformer(BaseTransformer):
             if value == "KNOWN":
                 return query
             elif value == "UNKNOWN":
-                return ~query  # pylint: disable=invalid-unary-operand-type
+                return ~query
             raise NotImplementedError
 
         return query

--- a/optimade/models/__init__.py
+++ b/optimade/models/__init__.py
@@ -1,4 +1,3 @@
-# pylint: disable=undefined-variable
 from .baseinfo import *  # noqa: F403
 from .entries import *  # noqa: F403
 from .index_metadb import *  # noqa: F403

--- a/optimade/models/baseinfo.py
+++ b/optimade/models/baseinfo.py
@@ -1,4 +1,3 @@
-# pylint: disable=no-self-argument,no-name-in-module
 import re
 from typing import Annotated, Literal, Optional
 

--- a/optimade/models/responses.py
+++ b/optimade/models/responses.py
@@ -1,4 +1,3 @@
-# pylint: disable=no-self-argument
 from typing import Annotated, Any, Optional, Union
 
 from pydantic import model_validator

--- a/optimade/server/mappers/__init__.py
+++ b/optimade/server/mappers/__init__.py
@@ -1,4 +1,3 @@
-# pylint: disable=undefined-variable
 from .entries import *  # noqa: F403
 from .links import *  # noqa: F403
 from .references import *  # noqa: F403

--- a/optimade/server/query_params.py
+++ b/optimade/server/query_params.py
@@ -184,7 +184,7 @@ class EntryListingQueryParams(BaseQueryParams):
         *,
         filter: Annotated[
             str,
-            Query(  # pylint: disable=redefined-builtin
+            Query(
                 description="A filter string, in the format described in section API Filtering Format Specification of the specification.",
             ),
         ] = "",

--- a/optimade/server/routers/utils.py
+++ b/optimade/server/routers/utils.py
@@ -221,7 +221,7 @@ def get_included_relationships(
 def get_base_url(
     parsed_url_request: Union[
         urllib.parse.ParseResult, urllib.parse.SplitResult, StarletteURL, str
-    ]
+    ],
 ) -> str:
     """Get base URL for current server
 

--- a/optimade/server/routers/utils.py
+++ b/optimade/server/routers/utils.py
@@ -1,4 +1,3 @@
-# pylint: disable=import-outside-toplevel,too-many-locals
 import re
 import urllib.parse
 from datetime import datetime

--- a/optimade/utils.py
+++ b/optimade/utils.py
@@ -80,9 +80,7 @@ def get_providers(add_mongo_id: bool = False) -> list:
 
 {}
     The list of providers will not be included in the `/links`-endpoint.
-""".format(
-                    "".join([f"    * {_}\n" for _ in PROVIDER_LIST_URLS])
-                )
+""".format("".join([f"    * {_}\n" for _ in PROVIDER_LIST_URLS]))
             )
             return []
 

--- a/optimade/validator/__init__.py
+++ b/optimade/validator/__init__.py
@@ -1,5 +1,5 @@
 """ This module contains the ImplementationValidator class and corresponding command line tools. """
-# pylint: disable=import-outside-toplevel
+
 import warnings
 
 from optimade import __api_version__, __version__

--- a/optimade/validator/validator.py
+++ b/optimade/validator/validator.py
@@ -4,7 +4,7 @@ class that can be pointed at an OPTIMADE implementation and validated
 against the specification via the pydantic models implemented in this package.
 
 """
-# pylint: disable=import-outside-toplevel
+
 
 import dataclasses
 import json
@@ -59,7 +59,7 @@ class ImplementationValidator:
 
     valid: Optional[bool]
 
-    def __init__(  # pylint: disable=too-many-arguments
+    def __init__(
         self,
         client: Optional[Any] = None,
         base_url: Optional[str] = None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,13 +104,11 @@ testing = [
 ]
 
 dev = [
-   "black~=23.1",
-   "isort~=5.12",
    "mypy~=1.0",
    "pre-commit~=3.0",
    "invoke~=2.0",
    "types-all==1.0.0",
-   "ruff~=0.0",
+   "ruff~=0.1",
    "optimade[docs,testing,client,http-client]"
 ]
 
@@ -162,7 +160,3 @@ filterwarnings = [
 ]
 testpaths = "tests"
 addopts = "-rs"
-
-[tool.isort]
-known_first_party = "optimade"
-profile = "black"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,13 +1,9 @@
-black==23.11.0
 build==1.0.3
-flake8==6.1.0
 invoke==2.2.0
-isort==5.12.0
 jsondiff==2.0.0
 mypy==1.7.1
-pre-commit==3.5.0
-pylint==3.0.2
+pre-commit==3.6.0
 pytest==7.4.3
 pytest-cov==4.1.0
-ruff==0.1.6
+ruff==0.1.8
 types-all==1.0.0

--- a/tests/adapters/structures/test_aiida.py
+++ b/tests/adapters/structures/test_aiida.py
@@ -1,5 +1,3 @@
-# pylint: disable=import-error
-
 import pytest
 
 from .utils import get_min_ver

--- a/tests/adapters/structures/test_ase.py
+++ b/tests/adapters/structures/test_ase.py
@@ -1,4 +1,3 @@
-# pylint: disable=import-error
 import pytest
 
 from .utils import get_min_ver

--- a/tests/adapters/structures/test_cif.py
+++ b/tests/adapters/structures/test_cif.py
@@ -1,5 +1,3 @@
-# pylint: disable=import-error
-
 import pytest
 
 from .utils import get_min_ver

--- a/tests/adapters/structures/test_jarvis.py
+++ b/tests/adapters/structures/test_jarvis.py
@@ -1,4 +1,3 @@
-# pylint: disable=import-error
 import pytest
 
 from .utils import get_min_ver

--- a/tests/adapters/structures/test_pdb.py
+++ b/tests/adapters/structures/test_pdb.py
@@ -1,4 +1,3 @@
-# pylint: disable=import-error
 import pytest
 
 from .utils import get_min_ver

--- a/tests/adapters/structures/test_pdbx_mmcif.py
+++ b/tests/adapters/structures/test_pdbx_mmcif.py
@@ -1,4 +1,3 @@
-# pylint: disable=import-error
 import pytest
 
 from .utils import get_min_ver

--- a/tests/adapters/structures/test_pymatgen.py
+++ b/tests/adapters/structures/test_pymatgen.py
@@ -1,4 +1,3 @@
-# pylint: disable=import-error
 import pytest
 
 from .utils import get_min_ver

--- a/tests/models/test_links.py
+++ b/tests/models/test_links.py
@@ -1,4 +1,3 @@
-# pylint: disable=no-member
 import pytest
 
 from optimade.models import LinksResponse

--- a/tests/models/test_references.py
+++ b/tests/models/test_references.py
@@ -1,4 +1,3 @@
-# pylint: disable=no-member
 import pytest
 from pydantic import ValidationError
 

--- a/tests/models/test_structures.py
+++ b/tests/models/test_structures.py
@@ -1,4 +1,3 @@
-# pylint: disable=no-member
 import itertools
 from typing import TYPE_CHECKING
 

--- a/tests/server/middleware/test_cors.py
+++ b/tests/server/middleware/test_cors.py
@@ -3,8 +3,8 @@
 
 def test_regular_CORS_request(both_clients):
     response = both_clients.get("/info", headers={"Origin": "http://example.org"})
-    assert ("access-control-allow-origin", "*") in tuple(
-        response.headers.items()
+    assert (
+        ("access-control-allow-origin", "*") in tuple(response.headers.items())
     ), f"Access-Control-Allow-Origin header not found in response headers: {response.headers}"
 
 

--- a/tests/server/routers/test_utils.py
+++ b/tests/server/routers/test_utils.py
@@ -106,9 +106,7 @@ def test_get_providers_warning(caplog, top_dir):
 
 {}
     The list of providers will not be included in the `/links`-endpoint.
-""".format(
-                "".join([f"    * {_}\n" for _ in PROVIDER_LIST_URLS])
-            )
+""".format("".join([f"    * {_}\n" for _ in PROVIDER_LIST_URLS]))
             assert warning_message in caplog.messages
 
     finally:

--- a/tests/server/routers/test_utils.py
+++ b/tests/server/routers/test_utils.py
@@ -97,7 +97,7 @@ def test_get_providers_warning(caplog, top_dir):
 
         caplog.clear()
         with mock.patch("requests.get", side_effect=ConnectionError):
-            del data.providers  # pylint: disable=no-member
+            del data.providers
             assert get_providers() == []
 
             warning_message = """Could not retrieve a list of providers!

--- a/tests/server/test_config.py
+++ b/tests/server/test_config.py
@@ -1,4 +1,3 @@
-# pylint: disable=protected-access,pointless-statement,relative-beyond-top-level
 import json
 import os
 from pathlib import Path

--- a/tests/server/utils.py
+++ b/tests/server/utils.py
@@ -66,7 +66,7 @@ class OptimadeTestClient(TestClient):
                 version = f"/v{__api_version__.split('.')[0]}"
         self.version = version
 
-    def request(  # pylint: disable=too-many-locals
+    def request(
         self,
         method: str,
         url: httpx._types.URLTypes,
@@ -138,7 +138,7 @@ class BaseEndpointTests:
 
     def test_serialize_response(self):
         assert self.response_cls is not None, "Response class unset for this endpoint"
-        self.response_cls(**self.json_response)  # pylint: disable=not-callable
+        self.response_cls(**self.json_response)
 
 
 class EndpointTests(BaseEndpointTests):
@@ -262,7 +262,7 @@ class HttpxTestClient(httpx.Client):
 
     client = client_factory()(server="regular")
 
-    def request(  # pylint: disable=too-many-locals
+    def request(
         self,
         method: str,
         url: httpx._types.URLTypes,
@@ -276,7 +276,7 @@ class RequestsTestClient(requests.Session):
 
     client = client_factory()(server="regular")
 
-    def request(  # pylint: disable=too-many-locals
+    def request(
         self,
         method,
         url,
@@ -291,7 +291,7 @@ class AsyncHttpxTestClient(httpx.AsyncClient):
 
     client = client_factory()(server="regular")
 
-    async def request(  # pylint: disable=too-many-locals
+    async def request(
         self,
         method: str,
         url: httpx._types.URLTypes,


### PR DESCRIPTION
Rather than dealing with pylint and isort conflicts (#1901), now is the time to switch entirely to ruff and ruff-format. This will lead to some additional linting cruft (re-expanding lines that black previously squished etc.) but should be worth it.