### PR TITLE
Client: add ability to count the number of results using binary search over pagination

### DIFF
--- a/optimade/client/cli.py
+++ b/optimade/client/cli.py
@@ -105,6 +105,7 @@ __all__ = ("_get",)
     default=None,
     nargs=-1,
 )
+@click.option("-v", "--verbosity", count=True, help="Increase verbosity of output.")
 @click.option(
     "--http-timeout",
     type=float,
@@ -127,6 +128,7 @@ def get(
     include_providers,
     exclude_providers,
     exclude_databases,
+    verbosity,
     http_timeout,
 ):
     return _get(
@@ -146,6 +148,7 @@ def get(
         include_providers,
         exclude_providers,
         exclude_databases,
+        verbosity,
         http_timeout,
     )
 
@@ -167,6 +170,7 @@ def _get(
     include_providers,
     exclude_providers,
     exclude_databases,
+    verbosity,
     http_timeout,
     **kwargs,
 ):
@@ -199,6 +203,8 @@ def _get(
     # default value set on the OptimadeClient class
     if http_timeout:
         args["http_timeout"] = http_timeout
+
+    args["verbosity"] = verbosity
 
     client = OptimadeClient(
         **args,

--- a/tests/server/test_client.py
+++ b/tests/server/test_client.py
@@ -76,9 +76,28 @@ def test_client_endpoints(async_http_client, http_client, use_async):
         count_results = cli.references.count()
         assert count_results["references"][filter][TEST_URL] > 0
 
+        if use_async:
+            cli.__force_binary_search = True
+            count_results_binary = cli.references.count()
+            assert (
+                count_results_binary["references"][filter][TEST_URL]
+                == count_results["references"][filter][TEST_URL]
+            )
+            cli.__force_binary_search = False
+
         filter = 'elements HAS "Ag"'
         count_results = cli.count(filter)
         assert count_results["structures"][filter][TEST_URL] > 0
+
+        if use_async:
+            cli.__force_binary_search = True
+            filter = 'elements HAS "Ag"'
+            count_results_binary = cli.count(filter)
+            assert (
+                count_results_binary["structures"][filter][TEST_URL]
+                == count_results["structures"][filter][TEST_URL]
+            )
+            cli.__force_binary_search = False
 
         count_results = cli.info.get()
         assert count_results["info"][""][TEST_URL]["data"]["type"] == "info"

--- a/tests/server/test_client.py
+++ b/tests/server/test_client.py
@@ -216,6 +216,7 @@ def test_command_line_client(async_http_client, http_client, use_async, capsys):
         exclude_databases=None,
         http_client=async_http_client if use_async else http_client,
         http_timeout=httpx.Timeout(2.0),
+        verbosity=0,
     )
 
     # Test multi-provider query
@@ -252,6 +253,7 @@ def test_command_line_client_silent(async_http_client, http_client, use_async, c
         exclude_databases=None,
         http_client=async_http_client if use_async else http_client,
         http_timeout=httpx.Timeout(2.0),
+        verbosity=0,
     )
 
     # Test silent mode
@@ -291,6 +293,7 @@ def test_command_line_client_multi_provider(
         exclude_databases=None,
         http_client=async_http_client if use_async else http_client,
         http_timeout=httpx.Timeout(2.0),
+        verbosity=0,
     )
     _get(**args)
     captured = capsys.readouterr()
@@ -325,6 +328,7 @@ def test_command_line_client_write_to_file(
         exclude_databases=None,
         http_client=async_http_client if use_async else http_client,
         http_timeout=httpx.Timeout(2.0),
+        verbosity=0,
     )
     test_filename = "test-optimade-client.json"
     if Path(test_filename).is_file():

--- a/tests/test_config.json
+++ b/tests/test_config.json
@@ -14,6 +14,7 @@
         "prefix": "exmpl",
         "homepage": "https://example.com"
     },
+    "mongo_count_timeout": 0,
     "index_base_url": "http://localhost:5001",
     "provider_fields": {
         "structures": [


### PR DESCRIPTION
Closes #1924.

This PR implements a workaround for the client to count the number of results returned by a filter using binary search over pagination. When a database does not return `meta->data_returned`, for whatever reason, the client will now execute the query with a series of probe `page_offset` values to find the number of matching results, for example, starting with a query for page 1,000,000, and finding no results, the client will then try 1,000. If a result is found on that page, the window has been narrowed to 1,000 to 1,000,000. The window will be reduced logarithmically until each end of the window has the same approximate power of 10, at which point the average value will be taken, e.g., if the query returned 1,001 entries, the trial values would be:

- 10^3 -> 10^6 => int(10^4.5)
- 10^3 -> 10^4.5 => int(10^3.75)
- 10^3 -> 10^3.75 => int(10^3.375)
- 10^3 (1000) -> 10^3.375 (2371) => 3371 // 2 = 1685
- 1000 -> 1685 => 1342
- 1000 -> 1342 => 1171
- etc until reaching 1001.

I think this scheme makes more sense than vanilla binary search or exponential search as OPTIMADE queries of this kind are probably either smallish or largeish, without much middle ground...

Caveats:

- the server must currently implement `page_offset`; `page_number` is possible but not yet implemented
- the code for one API must currently be run asynchronously

PR also adds a verbosity flag `-vvv` that enables some debug printing on the client.