### PR TITLE
Add upper pin to numpy in preparation for v2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ http-client = [
 ]
 
 ase = ["ase~=3.22"]
-cif = ["numpy>=1.20"]
+cif = ["numpy~=1.22"]
 pymatgen = ["pymatgen>=2022"]
 jarvis = ["jarvis-tools>=2023.1.8"]
 client = ["optimade[cif]"]


### PR DESCRIPTION
In preparation for https://numpy.org/devdocs/numpy_2_0_migration_guide.html.

We barely use numpy ourselves but some of our optional deps definitely do, so this will probably end up blocking until the whole cascade of deps updates has finished. Also should be backported to the v0.25.x branch and releases.