### PR TITLE
Allow backported releases in CI

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -6,7 +6,6 @@ on:
     - published
 
 env:
-  PUBLISH_UPDATE_BRANCH: master
   GIT_USER_NAME: OPTIMADE Developers
   GIT_USER_EMAIL: "dev@optimade.org"
 
@@ -36,21 +35,26 @@ jobs:
         pip install -r requirements.txt -r requirements-dev.txt -r requirements-client.txt -r requirements-http-client.txt -r requirements-docs.txt
         pip install -e .[all]
 
+    - name: Get base branch name for tag
+      id: branch_finder
+      run:
+        echo "branch=$(git branch --show-current)" >> "$GITHUB_OUTPUT"
+
     - name: Update changelog
       uses: CharMixer/auto-changelog-action@v1
       with:
         token: ${{ secrets.RELEASE_PAT_BOT }}
-        release_branch: ${{ env.PUBLISH_UPDATE_BRANCH }}
+        release_branch: ${{ steps.branch_finder.outputs.branch }}
         exclude_labels: "duplicate,question,invalid,wontfix,dependency_updates,skip_changelog"
 
     - name: Update API Reference docs and version - Commit changes and update tag
       run: .github/utils/update_docs.sh
 
-    - name: Update '${{ env.PUBLISH_UPDATE_BRANCH }}'
+    - name: Update triggering branch
       uses: CasperWA/push-protected@v2
       with:
         token: ${{ secrets.RELEASE_PAT_BOT }}
-        branch: ${{ env.PUBLISH_UPDATE_BRANCH }}
+        release_branch: ${{ steps.branch_finder.outputs.branch }}
         unprotect_reviews: true
         sleep: 15
         force: true
@@ -63,7 +67,7 @@ jobs:
       uses: CharMixer/auto-changelog-action@v1
       with:
         token: ${{ secrets.RELEASE_PAT_BOT }}
-        release_branch: ${{ env.PUBLISH_UPDATE_BRANCH }}
+        release_branch: ${{ steps.branch_finder.outputs.branch }}
         since_tag: "${{ env.PREVIOUS_VERSION }}"
         output: "release_changelog.md"
         exclude_labels: "duplicate,question,invalid,wontfix,dependency_updates,skip_changelog"
@@ -96,7 +100,7 @@ jobs:
       with:
         submodules: true
         fetch-depth: 0
-        ref: ${{ env.PUBLISH_UPDATE_BRANCH }}
+        ref: ${{ needs.publish.branch_finder.outputs.branch }}
 
     - name: Set up Python 3.10
       uses: actions/setup-python@v5
@@ -126,7 +130,7 @@ jobs:
     uses: ./.github/workflows/cd_container_image.yml
     with:
       release: true
-      checkout_ref: master
+      checkout_ref: ${{ needs.publish.branch_finder.outputs.branch }}
     secrets: inherit
     permissions:
       packages: write

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -39,7 +39,7 @@ jobs:
       with:
         submodules: true
         fetch-depth: 0
-        branch: ${{ publish_branch }}
+        branch: ${{ steps.save_branch.outputs.publish_branch }}
 
     - name: Set up Python 3.10
       uses: actions/setup-python@v5

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -8,6 +8,7 @@ on:
 env:
   GIT_USER_NAME: OPTIMADE Developers
   GIT_USER_EMAIL: "dev@optimade.org"
+  DEFAULT_RELEASE_BRANCH: "master"
 
 jobs:
 
@@ -137,10 +138,15 @@ jobs:
         git config --global user.name "${{ env.GIT_USER_NAME }}"
         git config --global user.email "${{ env.GIT_USER_EMAIL }}"
 
-    - name: Deploy documentation
+    - name: Deploy versioned documentation
+      run: |
+        mike deploy --push --remote origin --branch gh-pages --config-file mkdocs.yml ${GITHUB_REF#refs/tags/v}
+
+    - name: Deploy stable/latest documentation
+      if: ${{ needs.publish.outputs.publish_branch }} == ${{ DEFAULT_RELEASE_BRANCH }}
       run: |
         mike deploy --push --remote origin --branch gh-pages --update-aliases --config-file mkdocs.yml ${GITHUB_REF#refs/tags/v} stable
-        mike deploy --push --remote origin --branch gh-pages --update-aliases --config-file mkdocs.yml latest master
+        mike deploy --push --remote origin --branch gh-pages --update-aliases --config-file mkdocs.yml latest ${{ DEFAULT_RELEASE_BRANCH }}
 
   publish_container_image:
     name: Publish container image

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -15,13 +15,31 @@ jobs:
     name: Publish OPTIMADE Python tools
     runs-on: ubuntu-latest
     if: github.repository == 'Materials-Consortia/optimade-python-tools' && startsWith(github.ref, 'refs/tags/v')
+    outputs:
+      publish_branch: ${{ steps.save_branch.outputs.publish_branch }}
 
     steps:
-    - name: Checkout repository
+    - name: Get triggering branch
+      uses: octokit/request-action@v2.x
+      id: get_release_branch
+      with:
+        route: GET /repos/{owner}/{repo}/releases/tags/${{ github.ref_name }}
+        owner: octokit
+        repo: request-action
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Save branch name
+      id: save_branch
+      run: |
+        echo 'publish_branch=${{ fromJson(steps.get_release_branch.outputs.data).target_commitish }}' >> $GITHUB_OUTPUT
+
+    - name: Checkout publish branch
       uses: actions/checkout@v4
       with:
         submodules: true
         fetch-depth: 0
+        branch: ${{ publish_branch }}
 
     - name: Set up Python 3.10
       uses: actions/setup-python@v5
@@ -44,7 +62,7 @@ jobs:
       uses: CharMixer/auto-changelog-action@v1
       with:
         token: ${{ secrets.RELEASE_PAT_BOT }}
-        release_branch: ${{ steps.branch_finder.outputs.branch }}
+        release_branch: ${{ steps.save_branch.outputs.publish_branch }}
         exclude_labels: "duplicate,question,invalid,wontfix,dependency_updates,skip_changelog"
 
     - name: Update API Reference docs and version - Commit changes and update tag
@@ -54,7 +72,7 @@ jobs:
       uses: CasperWA/push-protected@v2
       with:
         token: ${{ secrets.RELEASE_PAT_BOT }}
-        release_branch: ${{ steps.branch_finder.outputs.branch }}
+        branch: ${{ steps.save_branch.outputs.publish_branch }}
         unprotect_reviews: true
         sleep: 15
         force: true
@@ -67,7 +85,7 @@ jobs:
       uses: CharMixer/auto-changelog-action@v1
       with:
         token: ${{ secrets.RELEASE_PAT_BOT }}
-        release_branch: ${{ steps.branch_finder.outputs.branch }}
+        release_branch: ${{ steps.save_branch.outputs.publish_branch }}
         since_tag: "${{ env.PREVIOUS_VERSION }}"
         output: "release_changelog.md"
         exclude_labels: "duplicate,question,invalid,wontfix,dependency_updates,skip_changelog"
@@ -100,7 +118,7 @@ jobs:
       with:
         submodules: true
         fetch-depth: 0
-        ref: ${{ needs.publish.branch_finder.outputs.branch }}
+        ref: ${{ needs.publish.outputs.publish_branch }}
 
     - name: Set up Python 3.10
       uses: actions/setup-python@v5
@@ -130,7 +148,7 @@ jobs:
     uses: ./.github/workflows/cd_container_image.yml
     with:
       release: true
-      checkout_ref: ${{ needs.publish.branch_finder.outputs.branch }}
+      checkout_ref: ${{ needs.publish.outputs.publish_branch }}
     secrets: inherit
     permissions:
       packages: write

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -24,8 +24,8 @@ jobs:
       id: get_release_branch
       with:
         route: GET /repos/{owner}/{repo}/releases/tags/${{ github.ref_name }}
-        owner: octokit
-        repo: request-action
+        owner: Materials-Consortia
+        repo: optimade-python-tools
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Closes #1930 by picking various commits from #1931 / #1932, and also makes sure that the version aliases in the docs are deployed correctly.