### PR TITLE
mkdocs fix global setting of `members: true`

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,7 +88,6 @@ plugins:
 
             # Members options
             inherited_members: true
-            members: true
             filters:
               - "!^_[^_]"
               - "!__json_encoder__$"


### PR DESCRIPTION
Closes #1934, supersedes #1935 