### PR TITLE
Add upper pin for pandas and ignore pandas3/pyarrow deprecation warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ http-client = [
 
 ase = ["ase~=3.22"]
 cif = ["numpy~=1.22"]
-pymatgen = ["pymatgen>=2022"]
+pymatgen = ["pymatgen>=2022", "pandas~=2.2"]
 jarvis = ["jarvis-tools>=2023.1.8"]
 client = ["optimade[cif]"]
 
@@ -138,6 +138,8 @@ ignore_missing_imports = true
 follow_imports = "skip"
 
 [tool.pytest.ini_options]
+testpaths = "tests"
+addopts = "-rs"
 filterwarnings = [
     "error",
     "ignore:.*flaky.*:UserWarning",
@@ -157,6 +159,5 @@ filterwarnings = [
     "ignore:.*ast.Num is deprecated and will be removed in Python 3.14*:DeprecationWarning", # Raised indirectly by aiida for Python 3.12
     "ignore:.*ast.Str is deprecated and will be removed in Python 3.14*:DeprecationWarning", # Raised indirectly by aiida for Python 3.12
     "ignore:.*ast.* is deprecated and will be removed in Python 3.14*:DeprecationWarning", # Raised indirectly by aiida for Python 3.12
+    "ignore:\\nPyarrow will become a required dependency of pandas.*:DeprecationWarning" # Raised indirectly by pymatgen for Python 3.12
 ]
-testpaths = "tests"
-addopts = "-rs"


### PR DESCRIPTION
This PR ignores a new deprecation warning for pandas (sub-dep of pymatgen) and adds an upper pin for the case the message reflects (missing pyarrow). pandas v3 will therefore break pymatgen first so we shouldn't have to worry too much here.

Annoying gotcha: the emitted deprecation warning starts with a newline (took a while to notice this...) and `filterwarnings` only matches from the start of strings, so various obvious regex attempts fail and the newline needs to be explicitly added to the filter.