### PR TITLE
Add `skip_ssl` flag/option to client

### DIFF
--- a/optimade/client/cli.py
+++ b/optimade/client/cli.py
@@ -106,6 +106,7 @@ __all__ = ("_get",)
     nargs=-1,
 )
 @click.option("-v", "--verbosity", count=True, help="Increase verbosity of output.")
+@click.option("--skip-ssl", is_flag=True, help="Ignore SSL errors in HTTPS requests.")
 @click.option(
     "--http-timeout",
     type=float,
@@ -129,6 +130,7 @@ def get(
     exclude_providers,
     exclude_databases,
     verbosity,
+    skip_ssl,
     http_timeout,
 ):
     return _get(
@@ -149,6 +151,7 @@ def get(
         exclude_providers,
         exclude_databases,
         verbosity,
+        skip_ssl,
         http_timeout,
     )
 
@@ -171,6 +174,7 @@ def _get(
     exclude_providers,
     exclude_databases,
     verbosity,
+    skip_ssl,
     http_timeout,
     **kwargs,
 ):
@@ -197,6 +201,7 @@ def _get(
         if exclude_databases
         else None,
         "silent": silent,
+        "skip_ssl": skip_ssl,
     }
 
     # Only set http timeout if its not null to avoid overwriting or duplicating the

--- a/optimade/client/client.py
+++ b/optimade/client/client.py
@@ -115,6 +115,9 @@ class OptimadeClient:
     silent: bool
     """Whether to disable progress bar printing."""
 
+    skip_ssl: bool = False
+    """Whether to skip SSL verification."""
+
     _excluded_providers: Optional[set[str]] = None
     """A set of providers IDs excluded from future queries."""
 
@@ -160,6 +163,7 @@ class OptimadeClient:
         ] = None,
         verbosity: int = 0,
         callbacks: Optional[list[Callable[[str, dict], Union[None, dict]]]] = None,
+        skip_ssl: bool = False,
     ):
         """Create the OPTIMADE client object.
 
@@ -195,6 +199,7 @@ class OptimadeClient:
         self.max_attempts = max_attempts
         self.silent = silent
         self.verbosity = verbosity
+        self.skip_ssl = skip_ssl
 
         if headers:
             self.headers.update(headers)
@@ -209,6 +214,7 @@ class OptimadeClient:
                     include_providers=self._included_providers,
                     exclude_databases=self._excluded_databases,
                     progress=progress,
+                    skip_ssl=self.skip_ssl,
                 )
             )
         else:

--- a/tests/server/test_client.py
+++ b/tests/server/test_client.py
@@ -242,6 +242,7 @@ def test_command_line_client(async_http_client, http_client, use_async, capsys):
         http_client=async_http_client if use_async else http_client,
         http_timeout=httpx.Timeout(2.0),
         verbosity=0,
+        skip_ssl=False,
     )
 
     # Test multi-provider query
@@ -279,6 +280,7 @@ def test_command_line_client_silent(async_http_client, http_client, use_async, c
         http_client=async_http_client if use_async else http_client,
         http_timeout=httpx.Timeout(2.0),
         verbosity=0,
+        skip_ssl=False,
     )
 
     # Test silent mode
@@ -319,6 +321,7 @@ def test_command_line_client_multi_provider(
         http_client=async_http_client if use_async else http_client,
         http_timeout=httpx.Timeout(2.0),
         verbosity=0,
+        skip_ssl=False,
     )
     _get(**args)
     captured = capsys.readouterr()
@@ -354,6 +357,7 @@ def test_command_line_client_write_to_file(
         http_client=async_http_client if use_async else http_client,
         http_timeout=httpx.Timeout(2.0),
         verbosity=0,
+        skip_ssl=False,
     )
     test_filename = "test-optimade-client.json"
     if Path(test_filename).is_file():


### PR DESCRIPTION
This is a workaround for the current SSL issues with the providers list, but may be useful again in the future.

The `--skip_ssl` CLI flag or `skip_ssl` argument can now be provided to `OptimadeClient` to try any failed SSL challenges with SSL verification turned off.