### PR TITLE
Extend dependabot groups for development and security

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,12 @@ updates:
     python-dependencies:
       applies-to: version-updates
       dependency-type: production
+    python-dependencies-dev:
+      applies-to: version-updates
+      dependency-type: development
+    python-dependencies-security:
+      applies-to: security-updates
+      dependency-type: production
 - package-ecosystem: gitsubmodule
   directory: "/"
   schedule:


### PR DESCRIPTION
Unsure whether this will _actually_ bunch dependencies that are currently in a separate PR into groups (the dependencies include `ruff`, `jsondiff`, `mypy` and probably more).