### PR TITLE
Remove tabulate related pins for pymatgen & aiida-core inconsistencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,8 +16,6 @@ updates:
   ignore:
   - dependency-name: "elasticsearch*"
     versions: [ ">=8" ]
-  - dependency-name: "pymatgen"
-    versions: [ "==2024.6.10", "==2024.6.4" ]
   - dependency-name: "jarvis-tools"
     versions: [ "==2024.4.20", "==2024.4.30" ]
   groups:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ http-client = [
 
 ase = ["ase~=3.22"]
 cif = ["numpy>=1.22,<3.0"]
-pymatgen = ["pymatgen>=2022,!=2024.6.10,!=2024.6.4", "tabulate~=0.8", "pandas~=2.2"]
+pymatgen = ["pymatgen>=2022", "pandas~=2.2"]
 jarvis = ["jarvis-tools>=2023.1.8,!=2024.4.20,!=2024.4.30"]
 client = ["optimade[cif]"]
 


### PR DESCRIPTION
Now that aiida-core 2.6.1 is out, we can freely install the latest pymatgen versions (that require tabulate>=0.9).