### PR TITLE
Add `.from_url` method to base adapter for easily loading a single entry

### DIFF
--- a/optimade/adapters/base.py
+++ b/optimade/adapters/base.py
@@ -146,6 +146,34 @@ class EntryAdapter:
             }
         )
 
+    @classmethod
+    def from_url(cls, url: str) -> Any:
+        """Convert OPTIMADE URL into the target entry type.
+
+        Parameters:
+            url (str): The OPTIMADE URL to convert.
+
+        Returns:
+            The converted URL.
+
+        """
+        import requests
+
+        try:
+            response = requests.get(url, timeout=100)
+            json_response = response.json()
+
+            data: dict = json_response.get("data", {})
+            if isinstance(data, list):
+                raise RuntimeError(f"returned a list of {len(data)} entries.")
+
+            return cls(data)
+
+        except Exception as exc:
+            raise RuntimeError(
+                f"Could not retrieve single OPTIMADE entry from URL {url}"
+            ) from exc
+
     @staticmethod
     def _get_model_attributes(
         starting_instances: Union[tuple[BaseModel, ...], list[BaseModel]], name: str

--- a/tests/adapters/conftest.py
+++ b/tests/adapters/conftest.py
@@ -1,3 +1,4 @@
+from json import JSONDecodeError
 from unittest.mock import Mock
 
 import pytest
@@ -10,7 +11,17 @@ def mock_requests_get(monkeypatch):
 
     def _mock_requests_get(json_data, status_code=200):
         mock_response = Mock()
-        mock_response.json.return_value = json_data
+        if not isinstance(json_data, dict):
+
+            def mock_raise():
+                raise JSONDecodeError(
+                    msg="Unable to interpret response as JSON", doc="", pos=0
+                )
+
+            mock_response.json = mock_raise
+        else:
+            mock_response.json.return_value = json_data
+
         mock_response.status_code = status_code
 
         def mock_get(*args, **kwargs):

--- a/tests/adapters/conftest.py
+++ b/tests/adapters/conftest.py
@@ -1,0 +1,21 @@
+from unittest.mock import Mock
+
+import pytest
+import requests
+
+
+@pytest.fixture
+def mock_requests_get(monkeypatch):
+    """Patch requests.get to return the desired mock response."""
+
+    def _mock_requests_get(json_data, status_code=200):
+        mock_response = Mock()
+        mock_response.json.return_value = json_data
+        mock_response.status_code = status_code
+
+        def mock_get(*args, **kwargs):
+            return mock_response
+
+        monkeypatch.setattr(requests, "get", mock_get)
+
+    return _mock_requests_get

--- a/tests/adapters/structures/test_structures.py
+++ b/tests/adapters/structures/test_structures.py
@@ -289,6 +289,10 @@ def test_load_bad_structure_from_url(raw_structure, mock_requests_get):
     with pytest.raises(RuntimeError):
         Structure.from_url("https://example.com/v1/structures/1")
 
+    mock_requests_get(["bad_json_data"])
+    with pytest.raises(RuntimeError):
+        Structure.from_url("https://example.com/v1/structures/1")
+
     mock_requests_get({"data": [raw_structure, raw_structure]})
     with pytest.raises(RuntimeError):
         Structure.from_url("https://example.com/v1/structures/1")


### PR DESCRIPTION
This PR adds a method `.from_url` to the base adapter class, which allows for convenient usage like

```python
from optimade.adapters.structure import Structure
structure = Structure.from_url("https://example.org/v1/structures/1")
```

The result will be validated and will error out if the response does not validate against the entry class.