### PR TITLE
Update docs build to accomodate mkdocs-autoref>=1.2

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,7 +102,8 @@ plugins:
               replace_admonitions: true
             show_if_no_docstring: false
   - awesome-pages
-  - autorefs
+  - autorefs:
+      resolve_closest: true
 
 watch:
   - optimade

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,11 +90,11 @@ client = ["optimade[cif]"]
 # General
 docs = [
     "mike~=2.0",
-    "mkdocs~=1.4",
-    "mkdocs-autorefs>=1,<2",
+    "mkdocs~=1.6",
+    "mkdocs-autorefs~=1.2",
     "mkdocs-awesome-pages-plugin~=2.8",
     "mkdocs-material~=9.0",
-    "mkdocstrings[python]~=0.20",
+    "mkdocstrings[python]~=0.26",
 ]
 
 testing = [

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,6 +1,6 @@
 mike==2.1.3
 mkdocs==1.6.1
-mkdocs-autorefs==1.0.1
+mkdocs-autorefs==1.2.0
 mkdocs-awesome-pages-plugin==2.9.3
 mkdocs-material==9.5.34
-mkdocstrings[python]==0.25.2
+mkdocstrings[python]==0.26.0


### PR DESCRIPTION
Building from https://github.com/Materials-Consortia/optimade-python-tools/pull/2137, use the new setting in mkdocs-autorefs to accommodate new warnings for multiply defined refs (https://github.com/mkdocstrings/autorefs/issues/520)