### PR TITLE
Give warning instead of error for wrong mongo URI

### DIFF
--- a/optimade/server/config.py
+++ b/optimade/server/config.py
@@ -498,7 +498,9 @@ class ServerConfig(BaseSettings):
                 ) or self.mongo_uri.startswith("mongodb+srv://"):
                     self.mongo_uri = f"mongodb://{self.mongo_uri}"
 
-                uri: dict[str, Any] = pymongo.uri_parser.parse_uri(self.mongo_uri, warn=True)
+                uri: dict[str, Any] = pymongo.uri_parser.parse_uri(
+                    self.mongo_uri, warn=True
+                )
                 if uri.get("database"):
                     self.mongo_database = uri["database"]
 

--- a/optimade/server/config.py
+++ b/optimade/server/config.py
@@ -490,7 +490,7 @@ class ServerConfig(BaseSettings):
 
         """
         if self.database_backend == SupportedBackend.MONGODB:
-            if self.mongo_uri and self.mongo_database:
+            if self.mongo_uri:
                 import pymongo.uri_parser
 
                 if not self.mongo_uri.startswith(

--- a/optimade/server/config.py
+++ b/optimade/server/config.py
@@ -498,7 +498,7 @@ class ServerConfig(BaseSettings):
                 ) or self.mongo_uri.startswith("mongodb+srv://"):
                     self.mongo_uri = f"mongodb://{self.mongo_uri}"
 
-                uri: dict[str, Any] = pymongo.uri_parser.parse_uri(self.mongo_uri)
+                uri: dict[str, Any] = pymongo.uri_parser.parse_uri(self.mongo_uri, warn=True)
                 if uri.get("database"):
                     self.mongo_database = uri["database"]
 


### PR DESCRIPTION
Quick fix for issue #2197 By raising a warning instead of an error optimade should still work even when env vars are used,
and always taking the mongo_database  value from the Uri.

I leave it up to @ml-evs to make a more permanent solution.