### PR TITLE
Catch error for invalid URI.

### DIFF
--- a/optimade/server/config.py
+++ b/optimade/server/config.py
@@ -497,12 +497,17 @@ class ServerConfig(BaseSettings):
                     "mongodb://"
                 ) or self.mongo_uri.startswith("mongodb+srv://"):
                     self.mongo_uri = f"mongodb://{self.mongo_uri}"
+                try:
+                    uri: dict[str, Any] = pymongo.uri_parser.parse_uri(
+                        self.mongo_uri, warn=True
+                    )
+                    if uri.get("database"):
+                        self.mongo_database = uri["database"]
+                except InvalidURI as error_msg:
+                    warnings.warn(
+                        f"The uri {self.mongo_uri} may be invalid.\n{error_msg}"
+                    )
 
-                uri: dict[str, Any] = pymongo.uri_parser.parse_uri(
-                    self.mongo_uri, warn=True
-                )
-                if uri.get("database"):
-                    self.mongo_database = uri["database"]
 
         return self
 

--- a/optimade/server/config.py
+++ b/optimade/server/config.py
@@ -503,7 +503,7 @@ class ServerConfig(BaseSettings):
                     )
                     if uri.get("database"):
                         self.mongo_database = uri["database"]
-                except InvalidURI as error_msg:
+                except pymongo.errors.InvalidURI as error_msg:
                     warnings.warn(
                         f"The uri {self.mongo_uri} may be invalid.\n{error_msg}"
                     )

--- a/optimade/server/config.py
+++ b/optimade/server/config.py
@@ -508,7 +508,6 @@ class ServerConfig(BaseSettings):
                         f"The uri {self.mongo_uri} may be invalid.\n{error_msg}"
                     )
 
-
         return self
 
     @classmethod


### PR DESCRIPTION
This is a second attempt to resolve issue #2197 and should enable connecting to a MongoDB Atlas Cluster via its connection string.