### PR TITLE
Fix issue with mongodb+srv:// URIs

### DIFF
--- a/optimade/server/config.py
+++ b/optimade/server/config.py
@@ -498,16 +498,11 @@ class ServerConfig(BaseSettings):
                     or self.mongo_uri.startswith("mongodb+srv://")
                 ):
                     self.mongo_uri = f"mongodb://{self.mongo_uri}"
-                try:
-                    uri: dict[str, Any] = pymongo.uri_parser.parse_uri(
-                        self.mongo_uri, warn=True
-                    )
-                    if uri.get("database"):
-                        self.mongo_database = uri["database"]
-                except pymongo.errors.InvalidURI as error_msg:
-                    warnings.warn(
-                        f"The uri {self.mongo_uri} may be invalid.\n{error_msg}"
-                    )
+                uri: dict[str, Any] = pymongo.uri_parser.parse_uri(
+                    self.mongo_uri, warn=True
+                )
+                if uri.get("database"):
+                    self.mongo_database = uri["database"]
 
         return self
 

--- a/optimade/server/config.py
+++ b/optimade/server/config.py
@@ -493,9 +493,10 @@ class ServerConfig(BaseSettings):
             if self.mongo_uri:
                 import pymongo.uri_parser
 
-                if not self.mongo_uri.startswith(
-                    "mongodb://"
-                ) or self.mongo_uri.startswith("mongodb+srv://"):
+                if not (
+                    self.mongo_uri.startswith("mongodb://")
+                    or self.mongo_uri.startswith("mongodb+srv://")
+                ):
                     self.mongo_uri = f"mongodb://{self.mongo_uri}"
                 try:
                     uri: dict[str, Any] = pymongo.uri_parser.parse_uri(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,4 +167,5 @@ filterwarnings = [
     "ignore:.*The 'app' shortcut is now deprecated.*:DeprecationWarning", # Raised by httpx for test client code; would rather not force upgrade of httpx to deal with it for now
     "ignore::pytest.PytestUnraisableExceptionWarning",  # Started raising with pytest 8.2.1, seemingly related to anyio warnings
     "ignore:.*Unclosed.*:ResourceWarning", # Also started raising with pytest 8.2.1, seemingly related to anyio warnings
+    "ignore:.*This function should have been removed on 2025-01-01*:DeprecationWarning", # Raised by monty, who knows when it will actually be removed
 ]

--- a/tests/adapters/conftest.py
+++ b/tests/adapters/conftest.py
@@ -5,6 +5,13 @@ import pytest
 import requests
 
 
+@pytest.fixture(autouse=True)
+def set_ci_env(monkeypatch):
+    """Super unpleasant workaround to deal with monty's deprecation behaviour."""
+    monkeypatch.setenv("CI", "false")
+    yield
+
+
 @pytest.fixture
 def mock_requests_get(monkeypatch):
     """Patch requests.get to return the desired mock response."""


### PR DESCRIPTION
Closes #2197 by fixing a misleading issue when parsing `mongodb+srv://` style URIs.