### PR TITLE
Do not use jarvis on Python 3.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ http-client = [
 ase = ["ase~=3.22"]
 cif = ["numpy>=1.22,<3.0"]
 pymatgen = ["pymatgen>=2022; python_version < '3.13'", "pandas~=2.2"]
-jarvis = ["jarvis-tools>=2023.1.8,!=2024.4.20,!=2024.4.30"]
+jarvis = ["jarvis-tools>=2023.1.8,!=2024.4.20,!=2024.4.30; python_version < '3.13'"]
 client = ["optimade[cif]"]
 
 # General

--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -1,5 +1,5 @@
 aiida-core==2.6.2
 ase==3.23.0
-jarvis-tools==2024.10.10
+jarvis-tools==2024.10.10; python_version < '3.13'
 numpy>=1.20
 pymatgen==2024.10.27; python_version < '3.13'


### PR DESCRIPTION
Failing in CI recently for some reason, not worth the effort to support 3.13 and at some point should be removed.