### PR TITLE
Add config option `exit_after_insert` to exit API after inserting data 

### DIFF
--- a/optimade/server/config.py
+++ b/optimade/server/config.py
@@ -440,7 +440,7 @@ class ServerConfig(BaseSettings):
     @classmethod
     def check_jsonl_path(cls, value: Any) -> Path | None:
         """Check that the path to the JSONL file is valid."""
-        if value in ("null", ""):
+        if value in ("null", "", None, "None"):
             return None
 
         return value

--- a/optimade/server/config.py
+++ b/optimade/server/config.py
@@ -179,6 +179,10 @@ class ServerConfig(BaseSettings):
         ),
     ] = None
 
+    exit_after_insert: Annotated[
+        bool, Field(description="Exit the API after inserting data")
+    ] = False
+
     create_default_index: Annotated[
         bool,
         Field(

--- a/optimade/server/main.py
+++ b/optimade/server/main.py
@@ -131,6 +131,12 @@ if CONFIG.insert_test_data or CONFIG.insert_from_jsonl:
     elif CONFIG.insert_test_data:
         _insert_test_data()
 
+    if CONFIG.exit_after_insert:
+        LOGGER.info("Exiting after inserting test data.")
+        import sys
+
+        sys.exit(0)
+
 # Add CORS middleware first
 app.add_middleware(CORSMiddleware, allow_origins=["*"])
 


### PR DESCRIPTION
This allows for the standardized ingestion procedure to occur in parallel to a running API, with zero downtime.