### PR TITLE
Retain `next_url` value in responses from `OptimadeClient`

### DIFF
--- a/optimade/client/client.py
+++ b/optimade/client/client.py
@@ -1233,7 +1233,7 @@ class OptimadeClient:
 
         next_url = callback_response.get("next") or results["links"].get("next", None)
         if isinstance(next_url, dict):
-            next_url = next_url.pop("href")
+            next_url = next_url["href"]
 
         return results, next_url
 


### PR DESCRIPTION
When responses are evaluated and `next_url` is extracted in function `_handle_response` of file `optimade-python-tools/optimade/client/client.py`, using pop will actually mutate the page response's `next_url` field.

This only affects when the response has a links object, if the response is a string, the issue is not present.

This issue affects consumers of the library which establish a deeper connection with it, e.g., when `get_one_async` is called. It might affect consumers which do a more conventional consumption too, but I haven't verified this.

Example with COD:

Before the patch, we see this under .links of the response:

```
{
    "base_url": "https://www.crystallography.net/cod/optimade/v1.1.0/",
    "first": {
        "href": "https://www.crystallography.net/cod/optimade/v1.1.0/structures?page_limit=100&filter=elements%20HAS%20%22Ag%22"
    },
    "next": {},
    "prev": None
}
```

after the patch we see the following response:

```
{
    "base_url": "https://www.crystallography.net/cod/optimade/v1.1.0/",
    "first": {
        "href": "https://www.crystallography.net/cod/optimade/v1.1.0/structures?page_limit=100&filter=elements%20HAS%20%22Ag%22"
    },
    "next": {
        "href": "https://www.crystallography.net/cod/optimade/v1.1.0/structures?page_offset=100&page_limit=100&filter=elements%20HAS%20%22Ag%22"
    },
    "prev": None
}
```

