### PR TITLE
Add support for `space_group_symmetry_operations_xyz`

### DIFF
--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -4340,6 +4340,24 @@
             "x-optimade-support": "should",
             "x-optimade-unit": "\u00c5"
           },
+          "space_group_symmetry_operations_xyz": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string",
+                  "pattern": "^([-+]?[xyz]([-+][xyz])?([-+](1/2|[12]/3|[1-3]/4|[1-5]/6))?|[-+]?(1/2|[12]/3|[1-3]/4|[1-5]/6)([-+][xyz]([-+][xyz])?)?),([-+]?[xyz]([-+][xyz])?([-+](1/2|[12]/3|[1-3]/4|[1-5]/6))?|[-+]?(1/2|[12]/3|[1-3]/4|[1-5]/6)([-+][xyz]([-+][xyz])?)?),([-+]?[xyz]([-+][xyz])?([-+](1/2|[12]/3|[1-3]/4|[1-5]/6))?|[-+]?(1/2|[12]/3|[1-3]/4|[1-5]/6)([-+][xyz]([-+][xyz])?)?)$"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Space Group Symmetry Operations Xyz",
+            "description": "A list of symmetry operations given as general position x, y and z coordinates in algebraic form.\n\n- **Type**: list of strings\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n      - The property is RECOMMENDED if coordinates are returned in a form to which these operations can or must be applied (e.g. fractional atom coordinates of an asymmetric unit).\n      - The property is REQUIRED if symmetry operations are necessary to reconstruct the full model of the material and no other symmetry information (e.g., the Hall symbol) is provided that would allow the user to derive symmetry operations unambiguously.\n    - **Query***: Support for queries on this property is not required and in fact is NOT RECOMMENDED.\n    - MUST be `null` if `nperiodic_dimensions` is equal to 0.\n    - Each symmetry operation is described by a string that gives that symmetry operation in Jones' faithful representation (Bradley & Cracknell, 1972: pp. 35-37), adapted for computer string notation.\n    - The letters `x`, `y` and `z` that are typesetted with overbars in printed text represent coordinate values multiplied by -1 and are encoded as `-x`, `-y` and `-z`, respectively.\n    - The syntax of the strings representing symmetry operations MUST conform to regular expressions given in appendix The Symmetry Operation String Regular Expressions.\n    - The interpretation of the strings MUST follow the conventions of the IUCr CIF core dictionary (IUCr, 2023). In particular, this property MUST explicitly provide all symmetry operations needed to generate all the atoms in the unit cell from the atoms in the asymmetric unit, for the setting used.\n    - This symmetry operation set MUST always include the `x,y,z` identity operation.\n    - The symmetry operations are to be applied to fractional atom coordinates. In case only Cartesian coordinates are available, these Cartesian coordinates must be converted to fractional coordinates before the application of the provided symmetry operations.\n    - If the symmetry operation list is present, it MUST be compatible with other space group specifications (e.g. the ITC space group number, the Hall symbol, the Hermann-Mauguin symbol) if these are present.\n\n- **Examples**:\n    - Space group operations for the space group with ITC number 3 (H-M symbol `P 2`, extended H-M symbol `P 1 2 1`, Hall symbol `P 2y`): `[\"x,y,z\", \"-x,y,-z\"]`\n    - Space group operations for the space group with ITC number 5 (H-M symbol `C 2`, extended H-M symbol `C 1 2 1`, Hall symbol `C 2y`): `[\"x,y,z\", \"-x,y,-z\", \"x+1/2,y+1/2,z\", \"-x+1/2,y+1/2,-z\"]`\n\n- **Notes**: The list of space group symmetry operations applies to the whole periodic array of atoms and together with the lattice translations given in the `lattice_vectors` property provides the necessary information to reconstruct all atom site positions of the periodic material.\n  Thus, the symmetry operations described in this property are only applicable to material models with at least one periodic dimension.\n  This property is not meant to represent arbitrary symmetries of molecules, non-periodic (finite) collections of atoms or non-crystallographic symmetry.\n\n- **Bibliographic References**:\n  - Bradley, C. J. and Cracknell, A. P. (1972) The Mathematical Theory of Symmetry in Solids. Oxford, Clarendon Press (paperback edition 2010) 745 p. ISBN 978-0-19-958258-7.\n  - IUCr (2023) Core dictionary (coreCIF) version 2.4.5; data name `_space_group_symop_operation_xyz`. Available from: https://www.iucr.org/__data/iucr/cifdic_html/1/cif_core.dic/Ispace_group_symop_operation_xyz.html [Accessed 2023-06-18T16:46+03:00].",
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
+          },
           "cartesian_site_positions": {
             "anyOf": [
               {

--- a/optimade/models/types.py
+++ b/optimade/models/types.py
@@ -7,11 +7,14 @@ from optimade.models.utils import (
     ELEMENT_SYMBOLS_PATTERN,
     EXTENDED_CHEMICAL_SYMBOLS_PATTERN,
     SEMVER_PATTERN,
+    SYMMETRY_OPERATION_REGEXP,
 )
 
 __all__ = ("ChemicalSymbol", "SemanticVersion")
 
 ChemicalSymbol = Annotated[str, Field(pattern=EXTENDED_CHEMICAL_SYMBOLS_PATTERN)]
+
+SymmetryOperation = Annotated[str, Field(pattern=SYMMETRY_OPERATION_REGEXP)]
 
 ElementSymbol = Annotated[str, Field(pattern=ELEMENT_SYMBOLS_PATTERN)]
 

--- a/optimade/models/utils.py
+++ b/optimade/models/utils.py
@@ -233,6 +233,7 @@ ANONYMOUS_ELEMENTS = tuple(itertools.islice(anonymous_element_generator(), 150))
 """ Returns the first 150 values of the anonymous element generator. """
 
 CHEMICAL_FORMULA_REGEXP = r"(^$)|^([A-Z][a-z]?([2-9]|[1-9]\d+)?)+$"
+SYMMETRY_OPERATION_REGEXP = r"^([-+]?[xyz]([-+][xyz])?([-+](1/2|[12]/3|[1-3]/4|[1-5]/6))?|[-+]?(1/2|[12]/3|[1-3]/4|[1-5]/6)([-+][xyz]([-+][xyz])?)?),([-+]?[xyz]([-+][xyz])?([-+](1/2|[12]/3|[1-3]/4|[1-5]/6))?|[-+]?(1/2|[12]/3|[1-3]/4|[1-5]/6)([-+][xyz]([-+][xyz])?)?),([-+]?[xyz]([-+][xyz])?([-+](1/2|[12]/3|[1-3]/4|[1-5]/6))?|[-+]?(1/2|[12]/3|[1-3]/4|[1-5]/6)([-+][xyz]([-+][xyz])?)?)$"
 
 EXTRA_SYMBOLS = ["X", "vacancy"]
 

--- a/tests/adapters/structures/test_structures.py
+++ b/tests/adapters/structures/test_structures.py
@@ -191,6 +191,7 @@ def compare_lossy_conversion(
         "immutable_id",
         "species",
         "fractional_site_positions",
+        "space_group_symmetry_operations_xyz",
     )
     array_keys = ("cartesian_site_positions", "lattice_vectors")
 

--- a/tests/models/test_data/test_bad_structures.json
+++ b/tests/models/test_data/test_bad_structures.json
@@ -2331,5 +2331,71 @@
       {"name": "P", "chemical_symbols": ["P"], "concentration": [1.0] }
     ],
     "structure_features": ["site_attachments"]
+  },
+  {
+    "task_id": "db/1234567",
+    "type": "structure",
+    "last_modified": {
+      "$date": "inf"
+    },
+    "band_gap": 1.23456,
+    "chemsys": "C-H-Cl-N-Na-O-Os-P",
+    "elements": ["C", "Cl", "H", "N", "Na", "O", "Os", "P"],
+    "nelements": 8,
+    "nsites": 7,
+    "elements_ratios": [0.09090909091, 0.36363636363, 0.09090909091, 0.09090909091, 0.09090909091, 0.09090909091, 0.09090909091, 0.09090909091],
+    "chemical_formula_reduced": "CClH4NNaOOsP",
+    "chemical_formula_hill": "H4CClNNaOOsP",
+    "chemical_formula_descriptive": "Methyl-ClNNaOOsP",
+    "formula_anonymous": "A4BCDEFGH",
+    "dimension_types": [1, 1, 1],
+    "nperiodic_dimensions": 3,
+    "lattice_vectors": [[4.0,0.0,0.0],[0.0, 4.0, 0.0],[0.0,1.0,4.0]],
+    "cartesian_site_positions": [ [0,0,0], [0,0,0], [0,0,0], [0,0,0], [0,0,0], [0,0,0], [0,0,0] ],
+    "species_at_sites": ["Cl", "O", "N", "met", "Os", "Na", "P"],
+    "species": [
+      {"name": "Cl", "chemical_symbols": ["Cl"], "concentration": [1.0] },
+      {"name": "O", "chemical_symbols": ["O"], "concentration": [1.0], "mass": [12.0, 14.0] },
+      {"name": "N", "chemical_symbols": ["N"], "concentration": [1.0] },
+      {"name": "met", "chemical_symbols": ["C"], "concentration": [1.0], "attached": ["H"], "nattached": [4] },
+      {"name": "Os", "chemical_symbols": ["Os"], "concentration": [1.0] },
+      {"name": "Na", "chemical_symbols": ["Na"], "concentration": [1.0] },
+      {"name": "P", "chemical_symbols": ["P"], "concentration": [1.0] }
+    ],
+    "structure_features": ["site_attachments"],
+    "space_group_symmetry_operations_xyz": ["-x,-y,-z"]
+  },
+  {
+    "task_id": "db/1234567",
+    "type": "structure",
+    "last_modified": {
+      "$date": "inf"
+    },
+    "band_gap": 1.23456,
+    "chemsys": "C-H-Cl-N-Na-O-Os-P",
+    "elements": ["C", "Cl", "H", "N", "Na", "O", "Os", "P"],
+    "nelements": 8,
+    "nsites": 7,
+    "elements_ratios": [0.09090909091, 0.36363636363, 0.09090909091, 0.09090909091, 0.09090909091, 0.09090909091, 0.09090909091, 0.09090909091],
+    "chemical_formula_reduced": "CClH4NNaOOsP",
+    "chemical_formula_hill": "H4CClNNaOOsP",
+    "chemical_formula_descriptive": "Methyl-ClNNaOOsP",
+    "formula_anonymous": "A4BCDEFGH",
+    "dimension_types": [1, 1, 1],
+    "nperiodic_dimensions": 0,
+    "lattice_vectors": [[4.0,0.0,0.0],[0.0, 4.0, 0.0],[0.0,1.0,4.0]],
+    "cartesian_site_positions": [ [0,0,0], [0,0,0], [0,0,0], [0,0,0], [0,0,0], [0,0,0], [0,0,0] ],
+    "species_at_sites": ["Cl", "O", "N", "met", "Os", "Na", "P"],
+    "species": [
+      {"name": "Cl", "chemical_symbols": ["Cl"], "concentration": [1.0] },
+      {"name": "O", "chemical_symbols": ["O"], "concentration": [1.0], "mass": [12.0, 14.0] },
+      {"name": "N", "chemical_symbols": ["N"], "concentration": [1.0] },
+      {"name": "met", "chemical_symbols": ["C"], "concentration": [1.0], "attached": ["H"], "nattached": [4] },
+      {"name": "Os", "chemical_symbols": ["Os"], "concentration": [1.0] },
+      {"name": "Na", "chemical_symbols": ["Na"], "concentration": [1.0] },
+      {"name": "P", "chemical_symbols": ["P"], "concentration": [1.0] }
+    ],
+    "structure_features": ["site_attachments"],
+    "space_group_symmetry_operations_xyz": ["x,y,z", "-x,-y,-z"]
   }
 ]

--- a/tests/models/test_data/test_good_structures.json
+++ b/tests/models/test_data/test_good_structures.json
@@ -125,7 +125,8 @@
         "group_probabilities": [0.3, 0.5, 0.2]
       }
     ],
-    "structure_features": ["assemblies", "implicit_atoms"]
+    "structure_features": ["assemblies", "implicit_atoms"],
+    "space_group_symmetry_operations_xyz": ["x,y,z", "-x,y,-z"]
   },
   {
     "task_id": "db/1234567",
@@ -189,7 +190,8 @@
       {"name": "Na", "chemical_symbols": ["Na"], "concentration": [1.0] },
       {"name": "P", "chemical_symbols": ["P"], "concentration": [1.0] }
     ],
-    "structure_features": ["site_attachments"]
+    "structure_features": ["site_attachments"],
+    "space_group_symmetry_operations_xyz": ["x,y,z", "-x,y,-z", "x+1/2,y+1/2,z", "-x+1/2,y+1/2,-z"]
   },
   {
     "task_id": "db/1234567",
@@ -221,6 +223,7 @@
       {"name": "Na", "chemical_symbols": ["Na"], "concentration": [1.0] },
       {"name": "P", "chemical_symbols": ["P"], "concentration": [1.0] }
     ],
-    "structure_features": ["disorder", "site_attachments"]
+    "structure_features": ["disorder", "site_attachments"],
+    "space_group_symmetry_operations_xyz": ["x,y,z"]
   }
 ]

--- a/tests/models/test_structures.py
+++ b/tests/models/test_structures.py
@@ -203,6 +203,14 @@ deformities = (
         {"chemical_formula_anonymous": "A44B15C9D4E3F2GHI0J0K0L0"},
         "String should match pattern",
     ),
+    (
+        {"space_group_symmetry_operations_xyz": ["-x,-y,-z"]},
+        "The identity operation 'x,y,z' MUST be included in the space group symmetry operations, if provided.",
+    ),
+    (
+        {"space_group_symmetry_operations_xyz": ["xy,z"]},
+        "String should match pattern",
+    ),
 )
 
 

--- a/tests/server/test_client.py
+++ b/tests/server/test_client.py
@@ -509,7 +509,7 @@ def test_list_properties(
 
     results = cli.list_properties("structures")
     for database in results:
-        assert len(results[database]) == 22, str(results[database])
+        assert len(results[database]) == 23, str(results[database])
 
     results = cli.search_property("structures", "site")
     for database in results:


### PR DESCRIPTION
As above. Adds the OPTIMADE 1.2 field `space_group_symmetry_operations_xyz`, superseding #1422.