### PR TITLE
Drastically reduce the default Mongo count timeout

### DIFF
--- a/optimade/server/config.py
+++ b/optimade/server/config.py
@@ -219,7 +219,7 @@ class ServerConfig(BaseSettings):
     ] = None
 
     mongo_count_timeout: Annotated[
-        int,
+        float,
         Field(
             description=(
                 "Number of seconds to allow MongoDB to perform a full database count "
@@ -229,7 +229,7 @@ class ServerConfig(BaseSettings):
                 "response times."
             ),
         ),
-    ] = 5
+    ] = 0.5
 
     mongo_database: Annotated[
         str,

--- a/optimade/server/entry_collections/mongo.py
+++ b/optimade/server/entry_collections/mongo.py
@@ -85,7 +85,7 @@ class MongoCollection(EntryCollection):
             return self.collection.estimated_document_count()
         else:
             if "maxTimeMS" not in kwargs:
-                kwargs["maxTimeMS"] = 1000 * CONFIG.mongo_count_timeout
+                kwargs["maxTimeMS"] = int(1000 * CONFIG.mongo_count_timeout)
             try:
                 return self.collection.count_documents(**kwargs)
             except ExecutionTimeout:


### PR DESCRIPTION
I've noticed a few o-p-t APIs that are running with big data on small boxes. As such, I'd like to reduce the count timeout to just half a second to avoid big queries taking 5 seconds per page to fall over.