### PR TITLE
Stop pagination when last response contains no data

### DIFF
--- a/optimade/client/client.py
+++ b/optimade/client/client.py
@@ -989,7 +989,7 @@ class OptimadeClient:
                     if not paginate:
                         break
 
-                    if (len(results.data) == 0):
+                    if len(results.data) == 0:
                         if next_url and not self.silent:
                             self._progress.print(
                                 f"{base_url} unexpectedly stopped returning results. Stopping download."

--- a/optimade/client/client.py
+++ b/optimade/client/client.py
@@ -989,6 +989,13 @@ class OptimadeClient:
                     if not paginate:
                         break
 
+                    if (len(results.data) == 0):
+                        if next_url and not self.silent:
+                            self._progress.print(
+                                f"{base_url} unexpectedly stopped returning results. Stopping download."
+                            )
+                        break
+
                     if (
                         self.max_results_per_provider
                         and len(results.data) >= self.max_results_per_provider

--- a/optimade/client/client.py
+++ b/optimade/client/client.py
@@ -990,10 +990,11 @@ class OptimadeClient:
                         break
 
                     if len(results.data) == 0:
-                        if next_url and not self.silent:
-                            self._progress.print(
-                                f"{base_url} unexpectedly stopped returning results. Stopping download."
-                            )
+                        if next_url:
+                            message = f"{base_url} unexpectedly stopped returning results. Stopping download."
+                            results.errors.append(message)
+                            if not self.silent:
+                                self._progress.print(message)
                         break
 
                     if (
@@ -1073,6 +1074,14 @@ class OptimadeClient:
                         continue
 
                     results.update(page_results)
+
+                    if len(results.data) == 0:
+                        if next_url:
+                            message = f"{base_url} unexpectedly stopped returning results. Stopping download."
+                            results.errors.append(message)
+                            if not self.silent:
+                                self._progress.print(message)
+                        break
 
                     if (
                         self.max_results_per_provider


### PR DESCRIPTION
Issue:

The issue was discovered with AFLOW database particularly. It seems that when a server is misbehaving with its responses and infinite loop of requests could be triggered. The condition arises when a server:

- Sends back 0 results AND
- Sends back a "next_url"

This is clearly a faulty response since when there are no results, you can't possibly have a next page.

What happens with the library is, since the number of results are 0, the counter used to stop downloading is never increased. But since the server also returns a "next_url", library assumes that it needs to continue to the next page and makes another request. Since the counter is never increased, this goes on forever.

This PR ensures that no new requests are created when the last response has 0 results. It will also display an appropriate message if there was a "next_url" with 0 results.