### PR TITLE
Use PEP 639 SPDX license in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "optimade"
 description = "Tools for implementing and consuming OPTIMADE APIs."
 readme = "README.md"
 keywords = ["optimade", "jsonapi", "materials"]
-license = { text = "MIT" }
+license = "MIT"
 authors = [{ name = "OPTIMADE development team", email = "dev@optimade.org" }]
 dynamic = ["version"]
 classifiers = [


### PR DESCRIPTION
[PEP 639 – Improving License Clarity with Better Package Metadata](https://peps.python.org/pep-0639/)