### PR TITLE
Allow Mongo DBs that share 12 first ID characters

### DIFF
--- a/optimade/utils.py
+++ b/optimade/utils.py
@@ -120,16 +120,17 @@ def insert_from_jsonl(jsonl_path: Path, create_default_index: bool = False) -> N
 
 
 def mongo_id_for_database(database_id: str, database_type: str) -> str:
-    """Produce a MongoDB ObjectId for a database"""
+    """Produce a deterministic MongoDB ObjectId for a database"""
+    import hashlib
+
     from bson.objectid import ObjectId
 
-    oid = f"{database_id}{database_type}"
-    if len(oid) > 12:
-        oid = oid[:12]
-    elif len(oid) < 12:
-        oid = f"{oid}{'0' * (12 - len(oid))}"
+    combined = f"{database_id}{database_type}"
 
-    return str(ObjectId(oid.encode("UTF-8")))
+    hash_obj = hashlib.md5(combined.encode("utf-8"))
+    hash_bytes = hash_obj.digest()[:12]  # ObjectId requires 12 bytes
+
+    return str(ObjectId(hash_bytes))
 
 
 def get_providers(add_mongo_id: bool = False) -> list:


### PR DESCRIPTION
The `mongo_id_for_database` generates a deterministic Mongo ID based on the database id and type.

In the current implementation it just uses the first 12 characters for this, but this means that i get a conflict if database ids share the first 12 characters, e.g.

- mc3d-pbesol-v1
- mc3d-pbesol-v2

This PR just hashes the id+type and takes the first 12 bytes from there.