### PR TITLE
Handle TooManyRedirects exception for provider connections

### DIFF
--- a/optimade/utils.py
+++ b/optimade/utils.py
@@ -249,7 +249,9 @@ def get_child_database_links(
     except (requests.ConnectionError, requests.Timeout) as exc:
         raise RuntimeError(f"Unable to connect to provider {provider['id']}") from exc
     except requests.TooManyRedirects as exc:
-        raise RuntimeError(f"Too many redirects from provider {provider['id']}") from exc
+        raise RuntimeError(
+            f"Too many redirects from provider {provider['id']}"
+        ) from exc
 
     if links.status_code != 200:
         raise RuntimeError(

--- a/optimade/utils.py
+++ b/optimade/utils.py
@@ -248,6 +248,8 @@ def get_child_database_links(
             ) from exc
     except (requests.ConnectionError, requests.Timeout) as exc:
         raise RuntimeError(f"Unable to connect to provider {provider['id']}") from exc
+    except requests.TooManyRedirects as exc:
+        raise RuntimeError(f"Too many redirects from provider {provider['id']}") from exc
 
     if links.status_code != 200:
         raise RuntimeError(


### PR DESCRIPTION
The OPTIMADE client wasn't handling the `requests.TooManyRedirects` exception when connecting to providers. I was seeing this from the `psdi` provider.