### PR TITLE
Update push-protected settings in CD

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -78,8 +78,8 @@ jobs:
       with:
         token: ${{ secrets.RELEASE_PAT_BOT }}
         branch: ${{ steps.save_branch.outputs.publish_branch }}
-        unprotect_reviews: true
-        sleep: 15
+        unprotect_reviews: false
+        pre_sleep: 15
         force: true
         tags: true
 


### PR DESCRIPTION
Lots of release failures stemming from the push-protected action; this PR tries to disable some parts of it in favor of relying on the new GitHub rulesets to set the correct bypass.