### PR TITLE
feat: support python 3.14 where return in finally is a syntax error

### DIFF
--- a/optimade/validator/utils.py
+++ b/optimade/validator/utils.py
@@ -374,9 +374,7 @@ def test_case(test_fn: Callable[..., tuple[Any, str]]):
                 summary = f"{display_request} - {test_fn.__name__} - failed with internal error"
                 failure_type = "internal"
             else:
-                summary = (
-                    f"{display_request} - {test_fn.__name__} - failed with error"
-                )
+                summary = f"{display_request} - {test_fn.__name__} - failed with error"
                 failure_type = "optional" if optional else None
 
             validator.results.add_failure(

--- a/optimade/validator/utils.py
+++ b/optimade/validator/utils.py
@@ -332,71 +332,70 @@ def test_case(test_fn: Callable[..., tuple[Any, str]]):
             result = exc
             traceback = tb.format_exc()
 
-        finally:
-            # This catches the case of the Client throwing a SystemExit if the server
-            # did not respond, the case of the validator "fail-fast"'ing and throwing
-            # a SystemExit below, and the case of the user interrupting the process manually
-            if isinstance(result, (SystemExit, KeyboardInterrupt)):
-                raise result
+        # This catches the case of the Client throwing a SystemExit if the server
+        # did not respond, the case of the validator "fail-fast"'ing and throwing
+        # a SystemExit below, and the case of the user interrupting the process manually
+        if isinstance(result, (SystemExit, KeyboardInterrupt)):
+            raise result
 
-            display_request = None
-            try:
-                display_request = validator.client.last_request
-            except AttributeError:
-                pass
-            if display_request is None:
-                display_request = validator.base_url
-                if request is not None:
-                    display_request += "/" + request
+        display_request = None
+        try:
+            display_request = validator.client.last_request
+        except AttributeError:
+            pass
+        if display_request is None:
+            display_request = validator.base_url
+            if request is not None:
+                display_request += "/" + request
 
-            request = display_request
+        request = display_request
 
-            # If the result was None, return it here and ignore statuses
-            if result is None:
-                return result, msg
-            display_request = requests.utils.requote_uri(request.replace("\n", ""))  # type: ignore[union-attr]
-
-            if not isinstance(result, Exception):
-                if not multistage:
-                    success_type = "optional" if optional else None
-                    validator.results.add_success(
-                        f"{display_request} - {msg}", success_type
-                    )
-            else:
-                message = msg.split("\n")
-                if validator.verbosity > 1:
-                    # ValidationErrors from pydantic already include very detailed errors
-                    # that get duplicated in the traceback
-                    if not isinstance(result, ValidationError):
-                        message += traceback.split("\n")
-
-                failure_type: str | None = None
-                if isinstance(result, InternalError):
-                    summary = f"{display_request} - {test_fn.__name__} - failed with internal error"
-                    failure_type = "internal"
-                else:
-                    summary = (
-                        f"{display_request} - {test_fn.__name__} - failed with error"
-                    )
-                    failure_type = "optional" if optional else None
-
-                validator.results.add_failure(
-                    summary, "\n".join(message), failure_type=failure_type
-                )
-
-                # set failure result to None as this is expected by other functions
-                result = None
-
-                if validator.fail_fast and not optional:
-                    validator.print_summary()
-                    raise SystemExit
-
-            # Reset the client request so that it can be properly
-            # displayed if the next request fails
-            if not multistage:
-                validator.client.last_request = None
-
+        # If the result was None, return it here and ignore statuses
+        if result is None:
             return result, msg
+        display_request = requests.utils.requote_uri(request.replace("\n", ""))  # type: ignore[union-attr]
+
+        if not isinstance(result, Exception):
+            if not multistage:
+                success_type = "optional" if optional else None
+                validator.results.add_success(
+                    f"{display_request} - {msg}", success_type
+                )
+        else:
+            message = msg.split("\n")
+            if validator.verbosity > 1:
+                # ValidationErrors from pydantic already include very detailed errors
+                # that get duplicated in the traceback
+                if not isinstance(result, ValidationError):
+                    message += traceback.split("\n")
+
+            failure_type: str | None = None
+            if isinstance(result, InternalError):
+                summary = f"{display_request} - {test_fn.__name__} - failed with internal error"
+                failure_type = "internal"
+            else:
+                summary = (
+                    f"{display_request} - {test_fn.__name__} - failed with error"
+                )
+                failure_type = "optional" if optional else None
+
+            validator.results.add_failure(
+                summary, "\n".join(message), failure_type=failure_type
+            )
+
+            # set failure result to None as this is expected by other functions
+            result = None
+
+            if validator.fail_fast and not optional:
+                validator.print_summary()
+                raise SystemExit
+
+        # Reset the client request so that it can be properly
+        # displayed if the next request fails
+        if not multistage:
+            validator.client.last_request = None
+
+        return result, msg
 
     return wrapper
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,13 +83,11 @@ http-client = [
 ase = ["ase~=3.22"]
 cif = ["numpy>=1.22,<3.0"]
 pymatgen = [
-    "pymatgen>=2022; python_version < '3.13'",
-    "pymatgen>=2026; python_version >= '3.13'",
+    "pymatgen>=2022",
     "pandas~=2.2",
 ]
 jarvis = [
-    "jarvis-tools>=2023.1.8,!=2024.4.20,!=2024.4.30; python_version < '3.13'",
-    "jarvis-tools>=2026.6.12; python_version >= '3.13'",
+    "jarvis-tools>=2023.1.8",
 ]
 client = ["optimade[cif]"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,8 +82,15 @@ http-client = [
 
 ase = ["ase~=3.22"]
 cif = ["numpy>=1.22,<3.0"]
-pymatgen = ["pymatgen>=2022; python_version < '3.13'", "pandas~=2.2"]
-jarvis = ["jarvis-tools>=2023.1.8,!=2024.4.20,!=2024.4.30; python_version < '3.13'"]
+pymatgen = [
+    "pymatgen>=2022; python_version < '3.13'",
+    "pymatgen>=2026; python_version >= '3.13'",
+    "pandas~=2.2",
+]
+jarvis = [
+    "jarvis-tools>=2023.1.8,!=2024.4.20,!=2024.4.30; python_version < '3.13'",
+    "jarvis-tools>=2026.6.12; python_version >= '3.13'",
+]
 client = ["optimade[cif]"]
 
 # General

--- a/uv.lock
+++ b/uv.lock
@@ -2435,6 +2435,10 @@ name = "monty"
 version = "2026.5.18"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
+    "python_full_version >= '3.15' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and sys_platform != 'win32'",
+    "python_full_version >= '3.13' and python_full_version < '3.15' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and python_full_version < '3.15' and sys_platform != 'win32'",
     "python_full_version == '3.12.*' and sys_platform == 'win32'",
     "python_full_version == '3.12.*' and sys_platform != 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'win32'",
@@ -2700,6 +2704,10 @@ name = "networkx"
 version = "3.6.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
+    "python_full_version >= '3.15' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and sys_platform != 'win32'",
+    "python_full_version >= '3.13' and python_full_version < '3.15' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and python_full_version < '3.15' and sys_platform != 'win32'",
     "python_full_version == '3.12.*' and sys_platform == 'win32'",
     "python_full_version == '3.12.*' and sys_platform != 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'win32'",
@@ -2897,13 +2905,13 @@ all = [
     { name = "elasticsearch-dsl" },
     { name = "fastapi" },
     { name = "httpx2" },
-    { name = "jarvis-tools", marker = "python_full_version < '3.13'" },
+    { name = "jarvis-tools" },
     { name = "mongomock" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pandas" },
     { name = "pymatgen", version = "2025.10.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "pymatgen", version = "2026.5.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "pymatgen", version = "2026.5.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pymongo" },
     { name = "rich" },
     { name = "uvicorn", extra = ["standard"] },
@@ -2938,7 +2946,7 @@ http-client = [
     { name = "rich" },
 ]
 jarvis = [
-    { name = "jarvis-tools", marker = "python_full_version < '3.13'" },
+    { name = "jarvis-tools" },
 ]
 mongo = [
     { name = "mongomock" },
@@ -2947,7 +2955,7 @@ mongo = [
 pymatgen = [
     { name = "pandas" },
     { name = "pymatgen", version = "2025.10.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "pymatgen", version = "2026.5.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "pymatgen", version = "2026.5.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 server = [
     { name = "fastapi" },
@@ -2989,7 +2997,7 @@ requires-dist = [
     { name = "fastapi", marker = "extra == 'server'", specifier = ">=0.135.0" },
     { name = "griffe", marker = "extra == 'docs'", specifier = ">=1.13,<3.0" },
     { name = "httpx2", marker = "extra == 'http-client'", specifier = "~=2.4" },
-    { name = "jarvis-tools", marker = "python_full_version < '3.13' and extra == 'jarvis'", specifier = ">=2023.1.8,!=2024.4.20,!=2024.4.30" },
+    { name = "jarvis-tools", marker = "extra == 'jarvis'", specifier = ">=2023.1.8" },
     { name = "jsondiff", marker = "extra == 'testing'", specifier = "~=2.0" },
     { name = "lark", specifier = "~=1.1" },
     { name = "mike", marker = "extra == 'docs'", specifier = "~=2.0" },
@@ -3007,7 +3015,7 @@ requires-dist = [
     { name = "pandas", marker = "extra == 'pymatgen'", specifier = "~=2.2" },
     { name = "pydantic", extras = ["email"], specifier = "~=2.2" },
     { name = "pydantic-settings", specifier = "~=2.0" },
-    { name = "pymatgen", marker = "python_full_version < '3.13' and extra == 'pymatgen'", specifier = ">=2022" },
+    { name = "pymatgen", marker = "extra == 'pymatgen'", specifier = ">=2022" },
     { name = "pymongo", marker = "extra == 'mongo'", specifier = "~=4.0" },
     { name = "pytest", marker = "extra == 'testing'", specifier = ">=8.3,<10.0" },
     { name = "pytest-asyncio", marker = "extra == 'testing'", specifier = ">=0.25,<2.0" },
@@ -3258,7 +3266,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "python_full_version >= '3.11' or sys_platform != 'win32'" },
+    { name = "ptyprocess", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -3933,6 +3941,10 @@ name = "pymatgen"
 version = "2026.5.4"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
+    "python_full_version >= '3.15' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and sys_platform != 'win32'",
+    "python_full_version >= '3.13' and python_full_version < '3.15' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and python_full_version < '3.15' and sys_platform != 'win32'",
     "python_full_version == '3.12.*' and sys_platform == 'win32'",
     "python_full_version == '3.12.*' and sys_platform != 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'win32'",
@@ -4497,6 +4509,10 @@ name = "scikit-learn"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
+    "python_full_version >= '3.15' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and sys_platform != 'win32'",
+    "python_full_version >= '3.13' and python_full_version < '3.15' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and python_full_version < '3.15' and sys_platform != 'win32'",
     "python_full_version == '3.12.*' and sys_platform == 'win32'",
     "python_full_version == '3.12.*' and sys_platform != 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'win32'",


### PR DESCRIPTION
I made sure the full test suite passes in a fresh python 3.14 environment.
This implied specifying a version for pymatgen and jarvis in pyproject.toml and removing a finally block that was redundant, because it was causing a SyntaxWarning that wass promoted to an exception by pytest.

Relevent links for the handling of control flow inside the finally:
https://docs.python.org/3/tutorial/errors.html#defining-clean-up-actions
https://peps.python.org/pep-0765/

Fortunately, the finally was redundant as no exception can reach it as per the catchall except just before.